### PR TITLE
[feat/#32] card-history implement

### DIFF
--- a/app/src/main/java/com/poti/android/presentation/history/component/HistoryCardHistory.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/component/HistoryCardHistory.kt
@@ -1,0 +1,174 @@
+package com.poti.android.presentation.history.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.poti.android.R
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.designsystem.theme.PotiTheme.colors
+import com.poti.android.core.designsystem.theme.PotiTheme.typography
+
+enum class CardHistorySize(
+    val imageSize: Dp,
+) {
+    SMALL(imageSize = 81.dp),
+    LARGE(imageSize = 96.dp),
+}
+
+val CardHistorySize.artistStyle: TextStyle
+    @Composable get() = when (this) {
+        CardHistorySize.SMALL -> typography.caption12m
+        CardHistorySize.LARGE -> typography.body14m
+    }
+
+val CardHistorySize.titleStyle: TextStyle
+    @Composable get() = when (this) {
+        CardHistorySize.SMALL -> typography.body14m
+        CardHistorySize.LARGE -> typography.body16m
+    }
+
+@Composable
+fun HistoryCardHistory(
+    sizeType: CardHistorySize,
+    imageUrl: String,
+    artist: String,
+    title: String,
+    participantState: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(if (isPressed) colors.gray100 else colors.white)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .size(sizeType.imageSize)
+                .clip(RoundedCornerShape(8.dp)),
+            contentScale = ContentScale.Crop,
+        )
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = artist,
+                style = sizeType.artistStyle,
+                color = colors.gray800,
+            )
+
+            Text(
+                text = title,
+                style = sizeType.titleStyle,
+                color = colors.black,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // TODO: [천민재] 임시 컴포넌트
+            ParticipantState(state = participantState)
+        }
+
+        Icon(
+            painter = painterResource(id = R.drawable.ic_arrow_right_lg),
+            contentDescription = null,
+            tint = colors.gray700,
+        )
+    }
+}
+
+// TODO: [천민재] 임시 컴포넌트
+@Composable
+fun ParticipantState(
+    modifier: Modifier = Modifier,
+    state: String,
+) {
+    val (text, color) = when (state) {
+        "done" -> "모집 완료" to colors.poti600
+        "wait" -> "입금 대기" to colors.sementicRed
+        else -> "상태" to colors.gray800
+    }
+
+    Text(
+        text = text,
+        modifier = modifier,
+        style = typography.body14sb,
+        color = color,
+    )
+}
+
+@Preview
+@Composable
+private fun HistoryCardHistoryPreview() {
+    var status by remember { mutableStateOf("done") }
+
+    PotiTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            HistoryCardHistory(
+                modifier = Modifier.width(344.dp),
+                sizeType = CardHistorySize.LARGE,
+                imageUrl = "",
+                artist = "ive(아이브)",
+                title = "러브다이브 위드뮤",
+                participantState = status,
+                onClick = { status = if (status == "done") "wait" else "done" },
+            )
+
+            HistoryCardHistory(
+                modifier = Modifier.width(344.dp),
+                sizeType = CardHistorySize.SMALL,
+                imageUrl = "",
+                artist = "ive(아이브)",
+                title = "러브다이브 위드뮤",
+                participantState = status,
+                onClick = { status = if (status == "done") "wait" else "done" },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/history/component/HistoryCardItem.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/component/HistoryCardItem.kt
@@ -1,46 +1,44 @@
 package com.poti.android.presentation.history.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.poti.android.R
+import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.core.designsystem.theme.PotiTheme.colors
 import com.poti.android.core.designsystem.theme.PotiTheme.typography
 
-enum class CardHistorySize(
-    val imageSize: Dp,
-) {
-    SMALL(imageSize = 81.dp),
-    LARGE(imageSize = 96.dp),
+enum class CardHistorySize {
+    SMALL,
+    LARGE,
 }
 
 val CardHistorySize.artistStyle: TextStyle
@@ -56,12 +54,13 @@ val CardHistorySize.titleStyle: TextStyle
     }
 
 @Composable
-fun HistoryCardHistory(
+fun HistoryCardItem(
     sizeType: CardHistorySize,
     imageUrl: String,
     artist: String,
     title: String,
-    participantState: String,
+    participantStageType: ParticipantStateLabelStage,
+    participantStatusType: ParticipantStateLabelStatus,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -73,12 +72,12 @@ fun HistoryCardHistory(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(if (isPressed) colors.gray100 else colors.white)
-            .clickable(
+            .noRippleClickable(
                 interactionSource = interactionSource,
-                indication = null,
                 onClick = onClick,
             )
-            .padding(8.dp),
+            .padding(8.dp)
+            .height(IntrinsicSize.Min),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -86,31 +85,55 @@ fun HistoryCardHistory(
             model = imageUrl,
             contentDescription = null,
             modifier = Modifier
-                .size(sizeType.imageSize)
+                .fillMaxHeight()
+                .aspectRatio(1f)
                 .clip(RoundedCornerShape(8.dp)),
             contentScale = ContentScale.Crop,
         )
 
         Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier
+                .weight(1f)
+                .padding(
+                    vertical =
+                        if (sizeType == CardHistorySize.SMALL) 2.dp else 4.dp,
+                ),
         ) {
             Text(
                 text = artist,
                 style = sizeType.artistStyle,
                 color = colors.gray800,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
+
+            if (sizeType == CardHistorySize.SMALL) {
+                Spacer(modifier = Modifier.height(2.dp))
+            }
 
             Text(
                 text = title,
                 style = sizeType.titleStyle,
                 color = colors.black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(
+                modifier = Modifier.height(
+                    if (sizeType == CardHistorySize.SMALL) {
+                        12.dp
+                    } else {
+                        22.dp
+                    },
+                ),
+            )
 
-            // TODO: [천민재] 임시 컴포넌트
-            ParticipantState(state = participantState)
+            HistoryParticipantStateLabel(
+                sizeType = ParticipantStateLabelSize.SMALL,
+                stageType = participantStageType,
+                statusType = participantStatusType,
+            )
         }
 
         Icon(
@@ -121,53 +144,33 @@ fun HistoryCardHistory(
     }
 }
 
-// TODO: [천민재] 임시 컴포넌트
-@Composable
-fun ParticipantState(
-    modifier: Modifier = Modifier,
-    state: String,
-) {
-    val (text, color) = when (state) {
-        "done" -> "모집 완료" to colors.poti600
-        "wait" -> "입금 대기" to colors.sementicRed
-        else -> "상태" to colors.gray800
-    }
-
-    Text(
-        text = text,
-        modifier = modifier,
-        style = typography.body14sb,
-        color = color,
-    )
-}
-
 @Preview
 @Composable
-private fun HistoryCardHistoryPreview() {
-    var status by remember { mutableStateOf("done") }
-
+private fun HistoryCardItemPreview() {
     PotiTheme {
         Column(
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            HistoryCardHistory(
-                modifier = Modifier.width(344.dp),
-                sizeType = CardHistorySize.LARGE,
-                imageUrl = "",
-                artist = "ive(아이브)",
-                title = "러브다이브 위드뮤",
-                participantState = status,
-                onClick = { status = if (status == "done") "wait" else "done" },
-            )
-
-            HistoryCardHistory(
+            HistoryCardItem(
                 modifier = Modifier.width(344.dp),
                 sizeType = CardHistorySize.SMALL,
                 imageUrl = "",
                 artist = "ive(아이브)",
                 title = "러브다이브 위드뮤",
-                participantState = status,
-                onClick = { status = if (status == "done") "wait" else "done" },
+                participantStageType = ParticipantStateLabelStage.DELIVERY,
+                participantStatusType = ParticipantStateLabelStatus.WAIT,
+                onClick = {},
+            )
+
+            HistoryCardItem(
+                modifier = Modifier.width(344.dp),
+                sizeType = CardHistorySize.LARGE,
+                imageUrl = "",
+                artist = "ive(아이브)",
+                title = "러브다이브 위드뮤",
+                participantStageType = ParticipantStateLabelStage.DEPOSIT,
+                participantStatusType = ParticipantStateLabelStatus.DONE,
+                onClick = {},
             )
         }
     }


### PR DESCRIPTION
## Related issue 🛠️
- closed #32 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- HistoryCardHistory 컴포넌트 구현

## Screenshot 📸

| 스크린샷 |
| --- |
| <img width="423" height="308" alt="스크린샷 2026-01-15 오전 4 29 44" src="https://github.com/user-attachments/assets/62208148-44c9-4bba-a7b5-237db91df3c7" /> |


## Uncompleted Tasks 😅
- [ ]

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 히스토리 엔트리를 표시하는 새로운 카드 컴포넌트 추가
  * 두 가지 크기 변형(소형, 대형) 지원으로 다양한 레이아웃에 대응
  * 아티스트명, 제목, 썸네일 이미지 및 참여자 상태 정보 표시 기능 구현

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->