### PR TITLE
[Feat/#59] 홈 더보기 뷰 UI 구현

### DIFF
--- a/app/src/main/java/com/poti/android/domain/model/party/GoodsCategory.kt
+++ b/app/src/main/java/com/poti/android/domain/model/party/GoodsCategory.kt
@@ -1,0 +1,15 @@
+package com.poti.android.domain.model.party
+
+data class GoodsCategory(
+    val nickname: String,
+    val mainArtist: String?,
+    val groupItems: List<GroupItem>,
+)
+
+data class GroupItem(
+    val artist: String,
+    val postImage: String,
+    val postTitle: String,
+    val postCount: Int,
+    val tag: String?,
+)

--- a/app/src/main/java/com/poti/android/presentation/party/PartyNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/PartyNavigation.kt
@@ -28,6 +28,7 @@ fun NavGraphBuilder.partyNavGraph(
         )
         goodsFilterNavGraph(
             paddingValues = paddingValues,
+            navController = navController,
         )
         partyDetailNavGraph(
             paddingValues = paddingValues,

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/DummyGoodsCategory.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/DummyGoodsCategory.kt
@@ -1,0 +1,39 @@
+package com.poti.android.presentation.party.goodsfilter
+
+import com.poti.android.domain.model.party.GoodsCategory
+import com.poti.android.domain.model.party.GroupItem
+
+val dummyGoodsCategory = GoodsCategory(
+    nickname = "포티",
+    mainArtist = "아이브",
+    groupItems = listOf(
+        GroupItem(
+            postTitle = "아이브 공식 응원봉",
+            artist = "IVE",
+            postImage = "",
+            postCount = 3,
+            tag = "인기",
+        ),
+        GroupItem(
+            postTitle = "아이브 콘서트 MD 세트",
+            artist = "IVE",
+            postImage = "",
+            postCount = 5,
+            tag = "NEW",
+        ),
+        GroupItem(
+            postTitle = "아이브 포토카드 랜덤팩",
+            artist = "IVE",
+            postImage = "",
+            postCount = 2,
+            tag = null,
+        ),
+        GroupItem(
+            postTitle = "아이브 시즌그리팅",
+            artist = "IVE",
+            postImage = "",
+            postCount = 7,
+            tag = "마감임박",
+        ),
+    ),
+)

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
@@ -10,23 +10,52 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.poti.android.core.common.extension.onSuccess
+import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.common.util.screenWidthDp
 import com.poti.android.core.designsystem.component.button.PotiFloatingButton
 import com.poti.android.core.designsystem.component.button.PotiSmallButton
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.party.GoodsCategory
+import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiEffect
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
 
 @Composable
 fun GoodsCategoryRoute(
+    onPopBackStack: () -> Unit,
+    onNavigateToPartyCreate: () -> Unit,
+    onNavigateToGoodsFilter: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: GoodsCategoryViewModel = hiltViewModel(),
 ) {
-//    GoodsCategoryScreen(modifier = modifier)
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    HandleSideEffects(viewModel.sideEffect) { effect ->
+        when (effect) {
+            GoodsCategoryUiEffect.NavigateBack -> onPopBackStack()
+            GoodsCategoryUiEffect.NavigateToPartyCreate -> onNavigateToPartyCreate()
+            GoodsCategoryUiEffect.NavigateToGoodsFilter -> onNavigateToGoodsFilter()
+        }
+    }
+
+    uiState.goodsCategoryLoadState.onSuccess { goodsCategory ->
+        GoodsCategoryScreen(
+            goodsCategory = goodsCategory,
+            onBackClick = onPopBackStack,
+            onFloatingClick = onNavigateToPartyCreate,
+            onSortFilterClick = {},
+            onCardClick = onNavigateToGoodsFilter,
+            modifier = modifier,
+        )
+    }
 }
 
 @Composable
@@ -49,7 +78,7 @@ private fun GoodsCategoryScreen(
         },
         floatingActionButton = {
             PotiFloatingButton(
-                onClick = onFloatingClick, // 아티스트 입력 상태로 등록 화면 이동
+                onClick = onFloatingClick, // 아티스트 입력 상태로 등록 화면 이동, 아티스트 아이디?
             )
         },
     ) { innerPadding ->
@@ -76,7 +105,7 @@ private fun GoodsCategoryScreen(
                     title = groupItem.postTitle,
                     partyCount = groupItem.postCount,
                     tag = groupItem.tag,
-                    onClick = onCardClick, // 상세 화면 이동
+                    onClick = onCardClick, // 굿즈별 페이지로 이동 타이틀, 아티스트 아이디?
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = 16.dp),

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
@@ -32,7 +32,7 @@ import com.poti.android.presentation.party.home.component.GoodsLargeCard
 fun GoodsCategoryRoute(
     onPopBackStack: () -> Unit,
     onNavigateToPartyCreate: () -> Unit,
-    onNavigateToGoodsFilter: () -> Unit,
+    onNavigateToGoodsPartyList: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: GoodsCategoryViewModel = hiltViewModel(),
 ) {
@@ -42,7 +42,7 @@ fun GoodsCategoryRoute(
         when (effect) {
             GoodsCategoryUiEffect.NavigateBack -> onPopBackStack()
             GoodsCategoryUiEffect.NavigateToPartyCreate -> onNavigateToPartyCreate()
-            GoodsCategoryUiEffect.NavigateToGoodsFilter -> onNavigateToGoodsFilter()
+            GoodsCategoryUiEffect.NavigateToGoodsFilter -> onNavigateToGoodsPartyList()
         }
     }
 
@@ -52,7 +52,7 @@ fun GoodsCategoryRoute(
             onBackClick = onPopBackStack,
             onFloatingClick = onNavigateToPartyCreate,
             onSortFilterClick = {},
-            onCardClick = onNavigateToGoodsFilter,
+            onCardClick = onNavigateToGoodsPartyList,
             modifier = modifier,
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
@@ -1,16 +1,16 @@
 package com.poti.android.presentation.party.goodsfilter
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -59,16 +59,14 @@ private fun GoodsCategoryScreen(
                 .padding(innerPadding),
             contentPadding = PaddingValues(horizontal = screenWidthDp(16.dp)),
         ) {
-            stickyHeader {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    PotiSmallButton(
-                        text = "인기순", // TODO: 바텀시트 연결
-                        onClick = onSortFilterClick,
-                    )
-                }
+            item {
+                PotiSmallButton(
+                    text = "인기순", // TODO: 바텀시트 연결
+                    onClick = onSortFilterClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .wrapContentWidth(Alignment.End),
+                )
             }
 
             items(goodsCategory.groupItems) { groupItem ->

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
@@ -26,6 +26,7 @@ import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.party.GoodsCategory
 import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiEffect
+import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiIntent
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
 
 @Composable
@@ -49,10 +50,18 @@ fun GoodsCategoryRoute(
     uiState.goodsCategoryLoadState.onSuccess { goodsCategory ->
         GoodsCategoryScreen(
             goodsCategory = goodsCategory,
-            onBackClick = onPopBackStack,
-            onFloatingClick = onNavigateToPartyCreate,
-            onSortFilterClick = {},
-            onCardClick = onNavigateToGoodsPartyList,
+            onBackClick = {
+                viewModel.processIntent(GoodsCategoryUiIntent.OnBackClick)
+            },
+            onFloatingClick = {
+                viewModel.processIntent(GoodsCategoryUiIntent.OnFloatingClick)
+            },
+            onSortFilterClick = {
+                viewModel.processIntent(GoodsCategoryUiIntent.OnSortFilterClick)
+            },
+            onCardClick = {
+                viewModel.processIntent(GoodsCategoryUiIntent.OnCardClick)
+            },
             modifier = modifier,
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryScreen.kt
@@ -1,15 +1,106 @@
 package com.poti.android.presentation.party.goodsfilter
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.core.common.util.screenWidthDp
+import com.poti.android.core.designsystem.component.button.PotiFloatingButton
+import com.poti.android.core.designsystem.component.button.PotiSmallButton
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.domain.model.party.GoodsCategory
+import com.poti.android.presentation.party.home.component.GoodsLargeCard
 
 @Composable
 fun GoodsCategoryRoute(
     modifier: Modifier = Modifier,
 ) {
-    GoodsCategoryScreen(modifier = modifier)
+//    GoodsCategoryScreen(modifier = modifier)
 }
 
 @Composable
-private fun GoodsCategoryScreen(modifier: Modifier = Modifier) {
+private fun GoodsCategoryScreen(
+    goodsCategory: GoodsCategory,
+    onBackClick: () -> Unit,
+    onFloatingClick: () -> Unit,
+    onSortFilterClick: () -> Unit,
+    onCardClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = PotiTheme.colors.white,
+        topBar = {
+            PotiHeaderPage(
+                onNavigationClick = onBackClick,
+                title = goodsCategory.nickname, // TODO: [예림] 홈 스트링 리소스 사용
+            )
+        },
+        floatingActionButton = {
+            PotiFloatingButton(
+                onClick = onFloatingClick, // 아티스트 입력 상태로 등록 화면 이동
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(horizontal = screenWidthDp(16.dp)),
+        ) {
+            stickyHeader {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    PotiSmallButton(
+                        text = "인기순", // TODO: 바텀시트 연결
+                        onClick = onSortFilterClick,
+                    )
+                }
+            }
+
+            items(goodsCategory.groupItems) { groupItem ->
+                GoodsLargeCard(
+                    imageUrl = groupItem.postImage,
+                    artist = groupItem.artist,
+                    title = groupItem.postTitle,
+                    partyCount = groupItem.postCount,
+                    tag = groupItem.tag,
+                    onClick = onCardClick, // 상세 화면 이동
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                )
+            }
+            item {
+                Spacer(Modifier.height(80.dp))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GoodsCategoryScreenPreview() {
+    PotiTheme {
+        GoodsCategoryScreen(
+            goodsCategory = dummyGoodsCategory,
+            onBackClick = {},
+            onFloatingClick = {},
+            onSortFilterClick = {},
+            onCardClick = {},
+        )
+    }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryViewModel.kt
@@ -1,0 +1,17 @@
+package com.poti.android.presentation.party.goodsfilter
+
+import com.poti.android.core.base.BaseViewModel
+import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiEffect
+import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiIntent
+import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class GoodsCategoryViewModel @Inject constructor() :
+    BaseViewModel<GoodsCategoryUiState, GoodsCategoryUiIntent, GoodsCategoryUiEffect>(
+        initialState = GoodsCategoryUiState(),
+    ) {
+        override fun processIntent(intent: GoodsCategoryUiIntent) {
+        }
+    }

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/GoodsCategoryViewModel.kt
@@ -1,6 +1,7 @@
 package com.poti.android.presentation.party.goodsfilter
 
 import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.state.ApiState
 import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiEffect
 import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiIntent
 import com.poti.android.presentation.party.goodsfilter.model.GoodsCategoryUiState
@@ -13,5 +14,25 @@ class GoodsCategoryViewModel @Inject constructor() :
         initialState = GoodsCategoryUiState(),
     ) {
         override fun processIntent(intent: GoodsCategoryUiIntent) {
+            when (intent) {
+                GoodsCategoryUiIntent.OnBackClick -> sendEffect(GoodsCategoryUiEffect.NavigateBack)
+                GoodsCategoryUiIntent.OnFloatingClick -> sendEffect(GoodsCategoryUiEffect.NavigateToPartyCreate)
+                GoodsCategoryUiIntent.OnSortFilterClick -> {}
+                GoodsCategoryUiIntent.OnCardClick -> sendEffect(GoodsCategoryUiEffect.NavigateToGoodsFilter)
+            }
+        }
+
+        init {
+            loadGoodsCategory()
+        }
+
+        private fun loadGoodsCategory() {
+            updateState {
+                copy(
+                    goodsCategoryLoadState = ApiState.Success(
+                        dummyGoodsCategory,
+                    ),
+                )
+            }
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/model/GoodsCategoryUiState.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/model/GoodsCategoryUiState.kt
@@ -11,9 +11,19 @@ data class GoodsCategoryUiState(
 ) : UiState
 
 sealed interface GoodsCategoryUiIntent : UiIntent {
+    data object OnBackClick : GoodsCategoryUiIntent
+
+    data object OnFloatingClick : GoodsCategoryUiIntent
+
+    data object OnSortFilterClick : GoodsCategoryUiIntent
+
     data object OnCardClick : GoodsCategoryUiIntent
 }
 
 sealed interface GoodsCategoryUiEffect : UiEffect {
     data object NavigateBack : GoodsCategoryUiEffect
+
+    data object NavigateToPartyCreate : GoodsCategoryUiEffect
+
+    data object NavigateToGoodsFilter : GoodsCategoryUiEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/model/GoodsCategoryUiState.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/model/GoodsCategoryUiState.kt
@@ -1,0 +1,19 @@
+package com.poti.android.presentation.party.goodsfilter.model
+
+import com.poti.android.core.base.UiEffect
+import com.poti.android.core.base.UiIntent
+import com.poti.android.core.base.UiState
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.model.party.GoodsCategory
+
+data class GoodsCategoryUiState(
+    val potsInfo: ApiState<GoodsCategory> = ApiState.Loading,
+) : UiState
+
+sealed interface GoodsCategoryUiIntent : UiIntent {
+    data object OnCardClick : GoodsCategoryUiIntent
+}
+
+sealed interface GoodsCategoryUiEffect : UiEffect {
+    data object NavigateBack : GoodsCategoryUiEffect
+}

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/model/GoodsCategoryUiState.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/model/GoodsCategoryUiState.kt
@@ -7,7 +7,7 @@ import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.model.party.GoodsCategory
 
 data class GoodsCategoryUiState(
-    val potsInfo: ApiState<GoodsCategory> = ApiState.Loading,
+    val goodsCategoryLoadState: ApiState<GoodsCategory> = ApiState.Loading,
 ) : UiState
 
 sealed interface GoodsCategoryUiIntent : UiIntent {

--- a/app/src/main/java/com/poti/android/presentation/party/goodsfilter/navigation/GoodsNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/goodsfilter/navigation/GoodsNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.party.create.navigation.navigateToPartyCreate
 import com.poti.android.presentation.party.goodsfilter.GoodsCategoryRoute
 import com.poti.android.presentation.party.goodsfilter.GoodsFilteredPartyListRoute
 import kotlinx.serialization.Serializable
@@ -33,9 +34,13 @@ fun NavController.navigateToGoodsCategory() {
 
 fun NavGraphBuilder.goodsFilterNavGraph(
     paddingValues: PaddingValues,
+    navController: NavController,
 ) {
     composable<GoodsRoute.GoodsList> {
         GoodsCategoryRoute(
+            onPopBackStack = navController::popBackStack,
+            onNavigateToPartyCreate = navController::navigateToPartyCreate,
+            onNavigateToGoodsPartyList = navController::navigateToGoodsPartyList,
             modifier = Modifier.padding(paddingValues),
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/party/home/component/GoodsLargeCard.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/component/GoodsLargeCard.kt
@@ -37,9 +37,9 @@ import com.poti.android.core.designsystem.theme.PotiTheme
 fun GoodsLargeCard(
     imageUrl: String,
     artist: String,
-    goodsType: String,
+    title: String,
     partyCount: Int,
-    tag: String,
+    tag: String?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -71,7 +71,7 @@ fun GoodsLargeCard(
                 modifier = Modifier.fillMaxSize(),
             )
 
-            if (tag.isNotBlank()) {
+            if (!tag.isNullOrBlank()) {
                 PotiSecondaryTag(
                     text = tag,
                     sizeType = PotiTagSize.SMALL,
@@ -106,7 +106,7 @@ fun GoodsLargeCard(
                 )
 
                 Text(
-                    text = goodsType,
+                    text = title,
                     modifier = Modifier,
                     color = PotiTheme.colors.black,
                     overflow = TextOverflow.Ellipsis,
@@ -136,7 +136,7 @@ private fun GoodsLargeCardPreview() {
             GoodsLargeCard(
                 imageUrl = "",
                 artist = "아티스트명",
-                goodsType = "상품 종류명",
+                title = "상품 종류명",
                 partyCount = 3,
                 tag = "인기",
                 onClick = {},
@@ -146,7 +146,7 @@ private fun GoodsLargeCardPreview() {
             GoodsLargeCard(
                 imageUrl = "",
                 artist = "아티스트명 ".repeat(10),
-                goodsType = "상품 종류명 ".repeat(10),
+                title = "상품 종류명 ".repeat(10),
                 partyCount = 3,
                 tag = "인기",
                 onClick = {},


### PR DESCRIPTION
## Related issue 🛠️
- closed #59 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 홈 더보기 뷰 UI 구현

## Screenshot 📸

| 스크린샷 1 | 
| --- | 
| <img src="https://github.com/user-attachments/assets/8d08fe97-e77d-4f50-a939-ed5e17306ca5" width="250" /> | 

## Uncompleted Tasks 😅
- [ ] 바텀시트 연결
- [x] 뷰 모델

## To Reviewers 📢
- 뷰 모델 생성만 해놨는데 얼른 할게Yo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 상품 카테고리 필터 화면 추가 — 카드 목록, 정렬/필터 버튼, 플로팅 액션, 항목 상호작용 및 미리보기 제공
  * 화면용 ViewModel과 UI 상태·인텐트·이펙트 구조 도입으로 내비게이션 및 사용자 액션 처리
  * 샘플 상품 카테고리 데이터 추가로 UI 시연 및 테스트 가능

* **Refactor**
  * 상품 카드 컴포넌트 매개변수 개선 — 제목 필드로 변경하고 태그를 nullable로 처리하여 유연성 향상

* **Navigation**
  * 필터 화면 내비게이션 경로에 뒤로가기·생성·목록 이동 콜백 연동

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->