### PR TITLE
[Feat/#66] 홈 API 연동

### DIFF
--- a/app/src/main/java/com/poti/android/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/RepositoryModule.kt
@@ -2,9 +2,11 @@ package com.poti.android.data.di
 
 import com.poti.android.data.repository.ArtistRepositoryImpl
 import com.poti.android.data.repository.AuthRepositoryImpl
+import com.poti.android.data.repository.HomeRepositoryImpl
 import com.poti.android.data.repository.UserRepositoryImpl
 import com.poti.android.domain.repository.ArtistRepository
 import com.poti.android.domain.repository.AuthRepository
+import com.poti.android.domain.repository.HomeRepository
 import com.poti.android.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
@@ -26,4 +28,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindArtistRepository(artistRepositoryImpl: ArtistRepositoryImpl): ArtistRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindHomeRepository(homeRepositoryImpl: HomeRepositoryImpl): HomeRepository
 }

--- a/app/src/main/java/com/poti/android/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/ServiceModule.kt
@@ -2,6 +2,7 @@ package com.poti.android.data.di
 
 import com.poti.android.data.remote.service.ArtistService
 import com.poti.android.data.remote.service.AuthService
+import com.poti.android.data.remote.service.HomeService
 import com.poti.android.data.remote.service.UserService
 import dagger.Module
 import dagger.Provides
@@ -27,4 +28,9 @@ object ServiceModule {
     @Singleton
     fun provideArtistService(retrofit: Retrofit): ArtistService =
         retrofit.create(ArtistService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideHomeService(retrofit: Retrofit): HomeService =
+        retrofit.create(HomeService::class.java)
 }

--- a/app/src/main/java/com/poti/android/data/mapper/home/HomeMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/home/HomeMapper.kt
@@ -1,0 +1,38 @@
+package com.poti.android.data.mapper.home
+
+import com.poti.android.data.remote.dto.response.home.HomeBannerDto
+import com.poti.android.data.remote.dto.response.home.HomeResponseDto
+import com.poti.android.data.remote.dto.response.home.MyGroupItemDto
+import com.poti.android.data.remote.dto.response.home.OtherGroupItemDto
+import com.poti.android.domain.model.home.Banner
+import com.poti.android.domain.model.home.GroupItem
+import com.poti.android.domain.model.home.HomeContent
+
+fun HomeResponseDto.toDomain(): HomeContent = HomeContent(
+    nickname = nickname,
+    mainArtist = mainArtist.orEmpty(),
+    myGroupItems = myGroupItems.orEmpty().map { it.toDomain() },
+    otherGroupItems = otherGroupItems.map { it.toDomain() },
+    banners = banners.map { it.toDomain() },
+)
+
+fun MyGroupItemDto.toDomain(): GroupItem = GroupItem(
+    postTitle = postTitle.orEmpty(),
+    artist = artist.orEmpty(),
+    postImage = postImage.orEmpty(),
+    postCount = postCount?.toLong() ?: 0L,
+    tag = tag.orEmpty(),
+)
+
+fun OtherGroupItemDto.toDomain(): GroupItem = GroupItem(
+    postTitle = postTitle,
+    artist = artist,
+    postImage = postImage.orEmpty(),
+    postCount = postCount.toLong(),
+    tag = tag,
+)
+
+fun HomeBannerDto.toDomain(): Banner = Banner(
+    postId = postId,
+    imageUrl = imageUrl,
+)

--- a/app/src/main/java/com/poti/android/data/mapper/home/HomeMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/home/HomeMapper.kt
@@ -11,6 +11,7 @@ import com.poti.android.domain.model.home.HomeContent
 fun HomeResponseDto.toDomain(): HomeContent = HomeContent(
     nickname = nickname,
     mainArtist = mainArtist.orEmpty(),
+    mainArtistId = mainArtistId ?: 0L,
     myGroupItems = myGroupItems.orEmpty().map { it.toDomain() },
     otherGroupItems = otherGroupItems.map { it.toDomain() },
     banners = banners.map { it.toDomain() },
@@ -19,16 +20,18 @@ fun HomeResponseDto.toDomain(): HomeContent = HomeContent(
 fun MyGroupItemDto.toDomain(): GroupItem = GroupItem(
     postTitle = postTitle.orEmpty(),
     artist = artist.orEmpty(),
+    artistId = artistId ?: 0L,
     postImage = postImage.orEmpty(),
-    postCount = postCount?.toLong() ?: 0L,
+    postCount = postCount ?: 0,
     tag = tag.orEmpty(),
 )
 
 fun OtherGroupItemDto.toDomain(): GroupItem = GroupItem(
     postTitle = postTitle,
     artist = artist,
+    artistId = artistId ?: 0L,
     postImage = postImage.orEmpty(),
-    postCount = postCount.toLong(),
+    postCount = postCount,
     tag = tag,
 )
 

--- a/app/src/main/java/com/poti/android/data/remote/datasource/HomeRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/HomeRemoteDataSource.kt
@@ -1,0 +1,13 @@
+package com.poti.android.data.remote.datasource
+
+import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.response.home.HomeResponseDto
+import com.poti.android.data.remote.service.HomeService
+import javax.inject.Inject
+
+class HomeRemoteDataSource @Inject constructor(
+    private val homeService: HomeService,
+) {
+    suspend fun getHomeContent(): BaseResponse<HomeResponseDto> =
+        homeService.getHomeContent()
+}

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/home/HomeResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/home/HomeResponseDto.kt
@@ -1,0 +1,54 @@
+package com.poti.android.data.remote.dto.response.home
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HomeResponseDto(
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("mainArtist")
+    val mainArtist: String?,
+    @SerialName("myGroupItems")
+    val myGroupItems: List<MyGroupItemDto>?,
+    @SerialName("otherGroupItems")
+    val otherGroupItems: List<OtherGroupItemDto>,
+    @SerialName("banners")
+    val banners: List<HomeBannerDto>,
+)
+
+@Serializable
+data class MyGroupItemDto(
+    @SerialName("artist")
+    val artist: String?,
+    @SerialName("postImage")
+    val postImage: String?,
+    @SerialName("postTitle")
+    val postTitle: String?,
+    @SerialName("postCount")
+    val postCount: Int?,
+    @SerialName("tag")
+    val tag: String?,
+)
+
+@Serializable
+data class OtherGroupItemDto(
+    @SerialName("artist")
+    val artist: String,
+    @SerialName("postImage")
+    val postImage: String?,
+    @SerialName("postTitle")
+    val postTitle: String,
+    @SerialName("postCount")
+    val postCount: Int,
+    @SerialName("tag")
+    val tag: String,
+)
+
+@Serializable
+data class HomeBannerDto(
+    @SerialName("postId")
+    val postId: Long,
+    @SerialName("imageUrl")
+    val imageUrl: String,
+)

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/home/HomeResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/home/HomeResponseDto.kt
@@ -9,6 +9,8 @@ data class HomeResponseDto(
     val nickname: String,
     @SerialName("mainArtist")
     val mainArtist: String?,
+    @SerialName("mainArtistId")
+    val mainArtistId: Long?,
     @SerialName("myGroupItems")
     val myGroupItems: List<MyGroupItemDto>?,
     @SerialName("otherGroupItems")
@@ -21,6 +23,8 @@ data class HomeResponseDto(
 data class MyGroupItemDto(
     @SerialName("artist")
     val artist: String?,
+    @SerialName("artistId")
+    val artistId: Long?,
     @SerialName("postImage")
     val postImage: String?,
     @SerialName("postTitle")
@@ -35,6 +39,8 @@ data class MyGroupItemDto(
 data class OtherGroupItemDto(
     @SerialName("artist")
     val artist: String,
+    @SerialName("artistId")
+    val artistId: Long?,
     @SerialName("postImage")
     val postImage: String?,
     @SerialName("postTitle")

--- a/app/src/main/java/com/poti/android/data/remote/service/HomeService.kt
+++ b/app/src/main/java/com/poti/android/data/remote/service/HomeService.kt
@@ -1,0 +1,10 @@
+package com.poti.android.data.remote.service
+
+import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.response.home.HomeResponseDto
+import retrofit2.http.GET
+
+interface HomeService {
+    @GET("/api/v1/home")
+    suspend fun getHomeContent(): BaseResponse<HomeResponseDto>
+}

--- a/app/src/main/java/com/poti/android/data/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/HomeRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.poti.android.data.repository
+
+import com.poti.android.core.network.model.handleApiResponse
+import com.poti.android.core.network.util.HttpResponseHandler
+import com.poti.android.data.mapper.home.toDomain
+import com.poti.android.data.remote.datasource.HomeRemoteDataSource
+import com.poti.android.domain.model.home.HomeContent
+import com.poti.android.domain.repository.HomeRepository
+import javax.inject.Inject
+
+class HomeRepositoryImpl @Inject constructor(
+    private val httpResponseHandler: HttpResponseHandler,
+    private val homeRemoteDataSource: HomeRemoteDataSource,
+) : HomeRepository {
+    override suspend fun getHomeContent(): Result<HomeContent> = httpResponseHandler.safeApiCall {
+        homeRemoteDataSource.getHomeContent()
+            .handleApiResponse()
+            .getOrThrow()
+            .toDomain()
+    }
+}

--- a/app/src/main/java/com/poti/android/domain/model/home/HomeContent.kt
+++ b/app/src/main/java/com/poti/android/domain/model/home/HomeContent.kt
@@ -3,6 +3,7 @@ package com.poti.android.domain.model.home
 data class HomeContent(
     val nickname: String = "",
     val mainArtist: String = "",
+    val mainArtistId: Long = 0L,
     val myGroupItems: List<GroupItem> = emptyList(),
     val otherGroupItems: List<GroupItem> = emptyList(),
     val banners: List<Banner> = emptyList(),
@@ -11,8 +12,9 @@ data class HomeContent(
 data class GroupItem(
     val postTitle: String,
     val artist: String,
+    val artistId: Long,
     val postImage: String,
-    val postCount: Long,
+    val postCount: Int,
     val tag: String,
 )
 

--- a/app/src/main/java/com/poti/android/domain/repository/HomeRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/HomeRepository.kt
@@ -1,0 +1,7 @@
+package com.poti.android.domain.repository
+
+import com.poti.android.domain.model.home.HomeContent
+
+interface HomeRepository {
+    suspend fun getHomeContent(): Result<HomeContent>
+}

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
@@ -37,6 +37,7 @@ val fakeMyGroupItems = listOf(
     GroupItem(
         postTitle = "2026 시즌 콘서트 후드",
         artist = "아이유",
+        artistId = 0L,
         postImage = "",
         postCount = 3,
         tag = "인기",
@@ -44,6 +45,7 @@ val fakeMyGroupItems = listOf(
     GroupItem(
         postTitle = "공식 응원봉 Ver.2",
         artist = "아이유",
+        artistId = 0L,
         postImage = "",
         postCount = 12,
         tag = "NEW",
@@ -51,6 +53,7 @@ val fakeMyGroupItems = listOf(
     GroupItem(
         postTitle = "월드투어 포토북",
         artist = "아이유",
+        artistId = 0L,
         postImage = "",
         postCount = 7,
         tag = "",

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
@@ -2,8 +2,7 @@ package com.poti.android.presentation.party.home
 
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
-import com.poti.android.domain.model.home.Banner
-import com.poti.android.domain.model.home.HomeContent
+import com.poti.android.domain.repository.HomeRepository
 import com.poti.android.presentation.party.home.model.HomeUiEffect
 import com.poti.android.presentation.party.home.model.HomeUiIntent
 import com.poti.android.presentation.party.home.model.HomeUiState
@@ -11,9 +10,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class HomeViewModel @Inject constructor() : BaseViewModel<HomeUiState, HomeUiIntent, HomeUiEffect>(
-    initialState = HomeUiState(),
-) {
+class HomeViewModel @Inject constructor(
+    private val homeRepository: HomeRepository,
+) : BaseViewModel<HomeUiState, HomeUiIntent, HomeUiEffect>(
+        initialState = HomeUiState(),
+    ) {
     override fun processIntent(intent: HomeUiIntent) {
         when (intent) {
             HomeUiIntent.OnFloatingClick -> sendEffect(HomeUiEffect.NavigateToPartyCreate)
@@ -29,21 +30,18 @@ class HomeViewModel @Inject constructor() : BaseViewModel<HomeUiState, HomeUiInt
     }
 
     private fun loadHomeContent() = launchScope {
-        updateState {
-            copy(
-                homeContentLoadState = ApiState.Success(
-                    HomeContent(
-                        nickname = "포티",
-                        banners = listOf(
-                            Banner(1, ""),
-                            Banner(2, ""),
-                            Banner(3, ""),
-                        ),
-                        myGroupItems = fakeMyGroupItems,
-                        otherGroupItems = fakeMyGroupItems,
-                    ),
-                ),
-            )
-        }
+        homeRepository.getHomeContent()
+            .onSuccess { homeContent ->
+                updateState {
+                    copy(homeContentLoadState = ApiState.Success(homeContent))
+                }
+            }
+            .onFailure { throwable ->
+                updateState {
+                    copy(
+                        homeContentLoadState = ApiState.Failure(throwable.message ?: "Failed"),
+                    )
+                }
+            }
     }
 }


### PR DESCRIPTION
## Related issue 🛠️
- closed #66 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 홈 API 연동

## Screenshot 📸

| 스크린샷 1 | 스크린샷 2 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/cd237069-5591-4e39-90fc-8164ea727fd9" width="250" /> | <video src="https://github.com/user-attachments/assets/99f3ba67-ae8e-49cc-9aef-20396ebf6f28" width="250" /> |


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 홈 화면이 서버 연동으로 전환되어 실시간 홈 콘텐츠(배너 포함)와 그룹 항목을 받아옵니다.
  * 각 그룹 항목과 아티스트에 대한 식별자(artistId 등)가 추가되어 더 정확한 콘텐츠 표시가 가능합니다.

* **리팩토링**
  * 홈 콘텐츠 로딩 로직을 API 기반 흐름으로 정비해 초기 하드코딩 데이터를 제거했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->