### PR TITLE
[Fix/#97] placeholder 두 줄 이상일 시 필드 커서 초기 위치 이슈 해결

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/field/PotiBasicField.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/field/PotiBasicField.kt
@@ -91,7 +91,7 @@ internal fun PotiBasicField(
                 Box(
                     modifier = Modifier
                         .weight(1f),
-                    contentAlignment = Alignment.CenterStart,
+                    contentAlignment = Alignment.TopStart,
                 ) {
                     innerTextField()
 

--- a/app/src/main/java/com/poti/android/core/designsystem/component/field/PotiLongTextField.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/field/PotiLongTextField.kt
@@ -115,7 +115,7 @@ private fun PotiLongTextFieldWithLabelPreview() {
         PotiLongTextField(
             value = text,
             onValueChanged = { text = it },
-            placeholder = "플레이스홀더",
+            placeholder = "플레이스홀더\n플레이스",
             label = "라벨",
         )
     }


### PR DESCRIPTION
## Related issue 🛠️
- closed #97

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- placeholder 두 줄 이상일 시 커서 위치 문제 해결

## Screenshot 📸

<img width="200" alt="image" src="https://github.com/user-attachments/assets/07bd3d25-e250-44a7-971b-ed2331c87130" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 텍스트 필드의 콘텐츠 정렬을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->