### PR TITLE
[Fix/#107] 파티 디테일 업로드일 노출 로직 수정

### DIFF
--- a/app/src/main/java/com/poti/android/core/common/extension/StringExt.kt
+++ b/app/src/main/java/com/poti/android/core/common/extension/StringExt.kt
@@ -1,0 +1,15 @@
+package com.poti.android.core.common.extension
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+fun String.toPartyUploadDate(): String? {
+    return try {
+        val dateTime = LocalDateTime.parse(this)
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        dateTime.format(formatter)
+    } catch (_: DateTimeParseException) {
+        null
+    }
+}

--- a/app/src/main/java/com/poti/android/domain/model/party/PartyDetail.kt
+++ b/app/src/main/java/com/poti/android/domain/model/party/PartyDetail.kt
@@ -12,7 +12,7 @@ data class PartyDetail(
     val artistId: Long, // 아티스트 아이디
     val title: String, // 분철글 제목
     val price: Int, // 1인당 가격 (원)
-    val uploadTime: String, // 업로드 시간 (예: "4시간 전")
+    val uploadTime: String, // 업로드 시간 (예: "2026-01-22T06:21:20.697608")
     val deadline: String, // 모집 마감일
     val images: List<PartyImage>, // 상품 이미지 리스트
     val content: String, // 분철글 본문 내용

--- a/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyDetailHeaderInfo.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyDetailHeaderInfo.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
 import com.poti.android.core.common.extension.toMoneyString
+import com.poti.android.core.common.extension.toPartyUploadDate
 import com.poti.android.core.designsystem.component.button.PotiIconButton
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.party.PartyDetail
@@ -65,7 +66,7 @@ fun PartyDetailHeaderInfo(
             }
 
             Text(
-                text = partyDetail.uploadTime,
+                text = stringResource(R.string.party_detail_upload_date_label, (partyDetail.uploadTime.toPartyUploadDate() ?: "")),
                 style = PotiTheme.typography.body14m,
                 color = PotiTheme.colors.gray800,
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     </string-array>
     <string name="party_detail_join_party">분철팟 참여하기</string>
     <string name="party_detail_join_party_closed">마감된 분철팟이에요</string>
+    <string name="party_detail_upload_date_label">"%s 등록"</string>
 
     <!-- PartyJoin -->
     <string name="party_join_option_member_label">멤버</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #107 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 파티 디테일 업로드일을, 서버값을 파싱해 "yyyy-MM-dd 등록" 형식으로 표시되도록 수정했습니다

## Screenshot 📸

| AS-IS (피그마) | TO-BE (인 앱 캡쳐) |
| --- | --- |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/2dc5d8b8-b159-48fa-ad72-af4404efe84e" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/35763afc-2128-4818-8ae4-554b502b051d" /> |


## Uncompleted Tasks 😅
- [ ]

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 파티 상세 정보에서 업로드 날짜 표시 형식을 개선했습니다. 타임스탐프가 지역화된 날짜 형식으로 변환되어 더 읽기 쉬워졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->