### PR TITLE
[Fix/#109] 전체 선택 클릭 시 멤버선택 바텀시트 유지

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/bottomsheet/MemberSelectBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/bottomsheet/MemberSelectBottomSheet.kt
@@ -65,6 +65,7 @@ fun MemberSelectBottomSheet(
     members: List<String>,
     selectedIndices: Set<Int>,
     onMemberClick: (Int) -> Unit,
+    autoCloseSubBtn: Boolean = true,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -77,6 +78,7 @@ fun MemberSelectBottomSheet(
         subEnabled = subEnabled,
         enabled = mainEnabled,
         sheetState = sheetState,
+        autoCloseSub = autoCloseSubBtn,
     ) {
         Text(
             text = stringResource(title),

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -128,6 +128,7 @@ fun PartyCreateRoute(
             members = uiState.sheetDisplayMemberNames,
             onMemberClick = { viewModel.processIntent(CreateUiIntent.OnMemberSelect(it)) },
             selectedIndices = uiState.sheetDisplayMemberIndices,
+            autoCloseSubBtn = false,
         )
     }
 


### PR DESCRIPTION
## Related issue 🛠️
- closed #109 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 등록 뷰 > 멤버 선택 바텀 시트 > 전체 선택 버튼 클릭 시 바텀시트 닫히지 않게 합니다

## Screenshot 📸

| 영상 |
| --- |
| <video src="https://github.com/user-attachments/assets/73085470-68ec-414e-b55a-35fa9918c9cb" width="250" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
간단한 거라 천천히 머징

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 (Refactor)**
  * 멤버 선택 바텀시트의 하위 버튼 자동 닫기 동작을 선택적으로 제어할 수 있도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->