### PR TITLE
[Fix/#112] HistoryList 네비 파라미터 및 스와이프 적용 / 터치영역 확장

### DIFF
--- a/app/src/main/java/com/poti/android/presentation/history/component/HistoryCardItem.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/component/HistoryCardItem.kt
@@ -74,6 +74,10 @@ fun HistoryCardItem(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
+            .noRippleClickable(
+                interactionSource = interactionSource,
+                onClick = onClick,
+            )
             .background(if (isPressed) colors.gray100 else colors.white)
             .padding(8.dp)
             .height(IntrinsicSize.Min),
@@ -139,12 +143,6 @@ fun HistoryCardItem(
             painter = painterResource(id = R.drawable.ic_arrow_right_lg),
             contentDescription = null,
             tint = colors.gray700,
-            modifier = Modifier
-                .fillMaxHeight()
-                .noRippleClickable(
-                    interactionSource = interactionSource,
-                    onClick = onClick,
-                ),
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListScreen.kt
@@ -97,11 +97,9 @@ private fun HistoryListScreen(
                     detectHorizontalDragGestures { change, dragAmount ->
                         change.consume()
 
-                        // 왼 → 오: dragAmount > 0
-                        // 오 → 왼: dragAmount < 0
-                        if (dragAmount > 0 && uiState.selectedTab != PotiHeaderTabType.ENDED) {
+                        if (dragAmount < 0 && uiState.selectedTab != PotiHeaderTabType.ENDED) {
                             onTabChanged(PotiHeaderTabType.ENDED)
-                        } else if (dragAmount < 0 && uiState.selectedTab != PotiHeaderTabType.ONGOING) {
+                        } else if (dragAmount > 0 && uiState.selectedTab != PotiHeaderTabType.ONGOING) {
                             onTabChanged(PotiHeaderTabType.ONGOING)
                         }
                     }

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.history.list
 
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,6 +13,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -58,7 +60,7 @@ fun HistoryListRoute(
         uiState = uiState,
         onBackClick = { viewModel.processIntent(HistoryListUiIntent.OnBackClick) },
         onSwitchModeClick = { viewModel.processIntent(HistoryListUiIntent.OnSwitchModeClick) },
-        onTabSelected = { tab ->
+        onTabChanged = { tab ->
             viewModel.processIntent(HistoryListUiIntent.OnTabSelected(tab))
         },
         onCardClick = { id ->
@@ -73,7 +75,7 @@ private fun HistoryListScreen(
     uiState: HistoryListUiState,
     onBackClick: () -> Unit,
     onSwitchModeClick: () -> Unit,
-    onTabSelected: (PotiHeaderTabType) -> Unit,
+    onTabChanged: (PotiHeaderTabType) -> Unit,
     onCardClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -90,13 +92,26 @@ private fun HistoryListScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
+                .padding(innerPadding)
+                .pointerInput(uiState.selectedTab) {
+                    detectHorizontalDragGestures { change, dragAmount ->
+                        change.consume()
+
+                        // 왼 → 오: dragAmount > 0
+                        // 오 → 왼: dragAmount < 0
+                        if (dragAmount > 0 && uiState.selectedTab != PotiHeaderTabType.ENDED) {
+                            onTabChanged(PotiHeaderTabType.ENDED)
+                        } else if (dragAmount < 0 && uiState.selectedTab != PotiHeaderTabType.ONGOING) {
+                            onTabChanged(PotiHeaderTabType.ONGOING)
+                        }
+                    }
+                },
         ) {
             PotiHeaderSection(
                 selectedTab = uiState.selectedTab,
                 ongoingCount = uiState.ongoingCount,
                 endedCount = uiState.endedCount,
-                onTabSelected = onTabSelected,
+                onTabSelected = onTabChanged,
             )
 
             if (uiState.items.isEmpty()) {
@@ -165,7 +180,7 @@ private fun HistoryListScreenPreview_Ongoing() {
             ),
             onBackClick = {},
             onSwitchModeClick = {},
-            onTabSelected = {},
+            onTabChanged = {},
             onCardClick = {},
         )
     }
@@ -188,7 +203,7 @@ private fun HistoryListScreenPreview_Ended() {
             ),
             onBackClick = {},
             onSwitchModeClick = {},
-            onTabSelected = {},
+            onTabChanged = {},
             onCardClick = {},
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
@@ -28,9 +28,8 @@ class HistoryListViewModel @Inject constructor(
     private val partyRepository: PartyRepository,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<HistoryListUiState, HistoryListUiIntent, HistoryListUiEffect>(
-    initialState = HistoryListUiState(),
-) {
-
+        initialState = HistoryListUiState(),
+    ) {
     private val route = savedStateHandle.toRoute<HistoryRoute.HistoryList>()
     private val initialMode = route.mode
     private val initialType = route.type
@@ -50,13 +49,6 @@ class HistoryListViewModel @Inject constructor(
         }
     }
 
-    //enum class HistorySummaryType {
-    //    ALL,
-    //    IN_PROGRESS,
-    //    COMPLETED,
-    //}
-
-    // ONGOIDN / COMP;LETED
     init {
         updateState {
             copy(

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
@@ -1,6 +1,8 @@
 package com.poti.android.presentation.history.list
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderTabType
@@ -13,6 +15,8 @@ import com.poti.android.presentation.history.list.model.HistoryListUiEffect
 import com.poti.android.presentation.history.list.model.HistoryListUiIntent
 import com.poti.android.presentation.history.list.model.HistoryListUiState
 import com.poti.android.presentation.history.list.model.HistoryMode
+import com.poti.android.presentation.history.navigation.HistoryRoute
+import com.poti.android.presentation.user.component.HistorySummaryType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -22,12 +26,15 @@ import javax.inject.Inject
 class HistoryListViewModel @Inject constructor(
     private val participationRepository: ParticipationRepository,
     private val partyRepository: PartyRepository,
+    savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<HistoryListUiState, HistoryListUiIntent, HistoryListUiEffect>(
-        initialState = HistoryListUiState(
-            mode = HistoryMode.PARTICIPATION,
-            selectedTab = PotiHeaderTabType.ONGOING,
-        ),
-    ) {
+    initialState = HistoryListUiState(),
+) {
+
+    private val route = savedStateHandle.toRoute<HistoryRoute.HistoryList>()
+    private val initialMode = route.mode
+    private val initialType = route.type
+
     override fun processIntent(intent: HistoryListUiIntent) {
         when (intent) {
             HistoryListUiIntent.OnBackClick -> sendEffect(HistoryListUiEffect.NavigateBack)
@@ -43,7 +50,25 @@ class HistoryListViewModel @Inject constructor(
         }
     }
 
+    //enum class HistorySummaryType {
+    //    ALL,
+    //    IN_PROGRESS,
+    //    COMPLETED,
+    //}
+
+    // ONGOIDN / COMP;LETED
     init {
+        updateState {
+            copy(
+                mode = initialMode ?: this.mode,
+                selectedTab = when (initialType) {
+                    null -> this.selectedTab
+                    HistorySummaryType.COMPLETED -> PotiHeaderTabType.ENDED
+                    else -> PotiHeaderTabType.ONGOING
+                },
+            )
+        }
+
         loadUserHistoryList()
     }
 

--- a/app/src/main/java/com/poti/android/presentation/history/navigation/HistoryNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/navigation/HistoryNavigation.kt
@@ -19,8 +19,8 @@ import kotlinx.serialization.Serializable
 sealed interface HistoryRoute : Route {
     @Serializable
     data class HistoryList(
-        val mode: HistoryMode? = HistoryMode.RECRUIT,
-        val type: HistorySummaryType? = HistorySummaryType.ALL,
+        val mode: HistoryMode? = null,
+        val type: HistorySummaryType? = null,
     ) : HistoryRoute
 
     @Serializable


### PR DESCRIPTION
## Related issue 🛠️
- closed #112 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 마이페이지에서 내역 클릭 시, 참여/모집 또는 진행/완료 상태에 따라 탭 반영되도록 수정했습니다
- HistoryListScreen에 스와이프로 탭 전환 기능을 추가했습니다

## Screenshot 📸

| 진입/스와이프 | 터치영역 | 
| --- | --- |
| <video src="https://github.com/user-attachments/assets/afec9360-4bb3-47aa-9ac9-0f44fc7d8943" width="250" /> | <video src="https://github.com/user-attachments/assets/d4dc45b4-2170-4b7d-8358-d043f6f77c6c" width="250" /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 히스토리 화면에서 좌우 스와이프 제스처로 탭을 전환할 수 있는 기능이 추가되었습니다.

* **Chores**
  * 내부 탭 전환 로직 개선 및 라우팅 초기화 최적화가 적용되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->