### PR TITLE
[Fix/#127] qa

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.material3)
 
     // --- Dependency Injection (Hilt) ---
     implementation(libs.androidx.hilt.navigation.compose)

--- a/app/src/main/java/com/poti/android/core/designsystem/component/bottomsheet/PotiBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/bottomsheet/PotiBottomSheet.kt
@@ -65,6 +65,7 @@ fun PotiBottomSheet(
     enabled: Boolean = true,
     subEnabled: Boolean = true,
     shouldDismissOnBackPress: Boolean = true,
+    sheetGesturesEnabled: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val scope = rememberCoroutineScope()
@@ -81,6 +82,7 @@ fun PotiBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
         sheetState = sheetState,
+        sheetGesturesEnabled = sheetGesturesEnabled,
         shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
         containerColor = PotiTheme.colors.white,
         scrimColor = PotiTheme.colors.black.copy(alpha = 0.6f),

--- a/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyJoinBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyJoinBottomSheet.kt
@@ -61,6 +61,7 @@ fun PartyJoinBottomSheet(
         onClick = onNextClick,
         enabled = uiState.isBottomSheetButtonEnable,
         sheetState = sheetState,
+        sheetGesturesEnabled = false,
         modifier = modifier,
     ) {
         Column(

--- a/app/src/main/java/com/poti/android/presentation/party/home/component/GoodsLargeCard.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/component/GoodsLargeCard.kt
@@ -75,7 +75,7 @@ fun GoodsLargeCard(
             if (!tag.isNullOrBlank()) {
                 PotiSecondaryTag(
                     text = tag,
-                    sizeType = PotiTagSize.SMALL,
+                    sizeType = PotiTagSize.LARGE,
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .padding(12.dp),
@@ -119,7 +119,7 @@ fun GoodsLargeCard(
 
             PotiPrimaryTag(
                 text = stringResource(R.string.goods_card_party_count, partyCount),
-                sizeType = PotiPrimaryTagSize.LARGE,
+                sizeType = PotiPrimaryTagSize.SMALL,
                 colorType = PotiPrimaryTagColor.WHITE,
             )
         }

--- a/app/src/main/java/com/poti/android/presentation/party/home/component/GoodsLargeCard.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/component/GoodsLargeCard.kt
@@ -103,7 +103,7 @@ fun GoodsLargeCard(
                     color = PotiTheme.colors.gray800,
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
-                    style = PotiTheme.typography.caption12m,
+                    style = PotiTheme.typography.body14m,
                 )
 
                 Text(
@@ -113,7 +113,7 @@ fun GoodsLargeCard(
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 2,
                     minLines = 2,
-                    style = PotiTheme.typography.body14m,
+                    style = PotiTheme.typography.body16m,
                 )
             }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ lifecycleRuntimeCompose = "2.10.0"
 # --- Compose (UI) ---
 activityCompose = "1.12.2"
 composeBom = "2024.09.00"
+material3 = "1.4.0-alpha02"
 navigationCompose = "2.9.6"
 
 # --- Dependency Injection (Hilt) ---
@@ -62,7 +63,7 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3"}
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 # --- Dependency Injection (Hilt) ---


### PR DESCRIPTION
## Related issue 🛠️
- closed #127

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 굿즈 리스트에서 굿즈 “팟 개수 칩” 크기가 다름. “인기 태그” : 14pt, “팟 개수 태그”도 14pt로
- 굿즈 리스트 페이지 컴포넌트 글자 크기 확인 (16이어야 하는데 아닌 것 같음.)
- 바텀시트 올라오는 거 막을 수 있는지 (후순위)

## Screenshot 📸

https://github.com/user-attachments/assets/f701bf6e-20dc-410d-8eb7-ae1ca2fbe294

## Uncompleted Tasks 😅

## To Reviewers 📢
composeBom을 쓰는 경우 기본적으로 material 1.3.0이 사용되는데요
바텀시트 드래그 막는 기능이 material 1.4.0-alpah02 버전부터 지원됩니다
`libs.version.toml`에 material 버전 적용 후 옵션 적용했어요
```
[versions]
material3 = "1.4.0-alpha02"

[libraries]
androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3"}
```


sheetGesturesEnabled 얘임
```
    ModalBottomSheet(
        onDismissRequest = onDismissRequest,
        modifier = modifier,
        sheetState = sheetState,
        sheetGesturesEnabled = sheetGesturesEnabled,
```
<img width="664" height="421" alt="image" src="https://github.com/user-attachments/assets/5aa428bc-d022-4eac-a1ef-88846da0b061" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 하단 시트의 제스처 상호작용 제어 옵션 추가

* **스타일**
  * 상품 카드의 태그 크기 및 텍스트 스타일 개선으로 시각적 계층 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->