### PR TITLE
[Fix/#133] 굿즈 카테고리 QA 이슈 반영

### DIFF
--- a/app/src/main/java/com/poti/android/presentation/history/participant/component/HistoryDepositBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/participant/component/HistoryDepositBottomSheet.kt
@@ -1,13 +1,10 @@
 package com.poti.android.presentation.history.participant.component
 
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -62,7 +59,7 @@ fun HistoryDepositBottomSheet(
             modifier = Modifier
                 .padding(
                     horizontal = screenWidthDp(16.dp),
-                )
+                ),
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/history/participant/component/HistoryDepositBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/participant/component/HistoryDepositBottomSheet.kt
@@ -1,8 +1,14 @@
 package com.poti.android.presentation.history.participant.component
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -14,14 +20,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
+import com.poti.android.core.common.util.screenWidthDp
 import com.poti.android.core.designsystem.component.bottomsheet.PotiBottomSheet
 import com.poti.android.core.designsystem.component.field.PotiShortTextField
 import com.poti.android.core.designsystem.theme.PotiTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun HistoryDepositBottomSheet(
     onDismissRequest: () -> Unit,
@@ -30,25 +39,32 @@ fun HistoryDepositBottomSheet(
 ) {
     var depositor by remember { mutableStateOf("") }
     var depositTime by remember { mutableStateOf("") }
+    val isKeyboardVisible = WindowInsets.isImeVisible
+    val bottomPadding = remember(isKeyboardVisible) {
+        if (isKeyboardVisible) 60.dp else 226.dp
+    }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     PotiBottomSheet(
         modifier = modifier,
         onDismissRequest = onDismissRequest,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        sheetState = sheetState,
         text = stringResource(R.string.history_deposit_bottomsheet_button),
         onClick = { onConfirmClick(depositor, depositTime) },
-        content = {
-            BottomSheetContent(
-                depositor = depositor,
-                onDepositorChanged = { depositor = it },
-                depositTime = depositTime,
-                onDepositTimeChanged = { depositTime = it },
-                modifier = modifier
-                    .padding(horizontal = 16.dp),
-            )
-        },
         enabled = depositor.isNotBlank() && depositTime.isNotBlank(),
-    )
+    ) {
+        BottomSheetContent(
+            depositor = depositor,
+            onDepositorChanged = { depositor = it },
+            depositTime = depositTime,
+            onDepositTimeChanged = { depositTime = it },
+            bottomPadding = bottomPadding,
+            modifier = Modifier
+                .padding(
+                    horizontal = screenWidthDp(16.dp),
+                )
+        )
+    }
 }
 
 @Composable
@@ -57,6 +73,7 @@ private fun BottomSheetContent(
     onDepositorChanged: (String) -> Unit,
     depositTime: String,
     onDepositTimeChanged: (String) -> Unit,
+    bottomPadding: Dp,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -75,7 +92,8 @@ private fun BottomSheetContent(
             onValueChanged = onDepositTimeChanged,
             placeholder = stringResource(R.string.history_deposit_bottomsheet_deposit_time_placeholder),
             label = stringResource(R.string.history_deposit_bottomsheet_deposit_time_label),
-            modifier = Modifier.padding(bottom = 226.dp),
+            keyboardType = KeyboardType.Number,
+            modifier = Modifier.padding(bottom = bottomPadding),
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.poti.android.presentation.party.home
 
 import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.extension.getSuccessDataOrNull
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.repository.HomeRepository
 import com.poti.android.presentation.party.home.model.HomeUiEffect
@@ -14,12 +15,12 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val homeRepository: HomeRepository,
 ) : BaseViewModel<HomeUiState, HomeUiIntent, HomeUiEffect>(
-        initialState = HomeUiState(),
-    ) {
+    initialState = HomeUiState(),
+) {
     override fun processIntent(intent: HomeUiIntent) {
         when (intent) {
             HomeUiIntent.OnFloatingClick -> sendEffect(NavigateToPartyCreate)
-            is HomeUiIntent.OnMyArtistCategoryClick -> sendEffect(NavigateToMyArtistCategory(intent.artistId))
+            is HomeUiIntent.OnMyArtistCategoryClick -> sendEffect(NavigateToMyArtistCategory(if (uiState.value.artistIdToNull) null else intent.artistId))
             is HomeUiIntent.OnProductCardClick -> sendEffect(NavigateToGoodsPartyList(intent.artistId, intent.title))
             HomeUiIntent.LoadHomeContent -> loadHomeContent()
             HomeUiIntent.OnOtherProductCategoryClick -> sendEffect(NavigateToOtherProductCategory)
@@ -36,6 +37,7 @@ class HomeViewModel @Inject constructor(
                 updateState {
                     copy(homeContentLoadState = ApiState.Success(homeContent))
                 }
+                validateArtistId()
             }
             .onFailure { throwable ->
                 updateState {
@@ -44,5 +46,17 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }
+    }
+
+    private fun validateArtistId() {
+        uiState.value.homeContentLoadState.getSuccessDataOrNull()?.let { content ->
+            val diff = content.myGroupItems.any { item ->
+                item.artistId != content.myGroupItems.first().artistId
+            }
+
+            if (diff) {
+                updateState { copy(artistIdToNull = true) }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
@@ -15,8 +15,8 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val homeRepository: HomeRepository,
 ) : BaseViewModel<HomeUiState, HomeUiIntent, HomeUiEffect>(
-    initialState = HomeUiState(),
-) {
+        initialState = HomeUiState(),
+    ) {
     override fun processIntent(intent: HomeUiIntent) {
         when (intent) {
             HomeUiIntent.OnFloatingClick -> sendEffect(NavigateToPartyCreate)

--- a/app/src/main/java/com/poti/android/presentation/party/home/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/model/Contracts.kt
@@ -8,6 +8,7 @@ import com.poti.android.domain.model.home.HomeContent
 
 data class HomeUiState(
     val homeContentLoadState: ApiState<HomeContent> = ApiState.Loading,
+    val artistIdToNull: Boolean = false,
 ) : UiState
 
 sealed interface HomeUiIntent : UiIntent {

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
@@ -122,13 +122,10 @@ private fun ProductCategoryScreen(
                                 .fillMaxWidth()
                                 .wrapContentWidth(Alignment.End),
                         )
-                    }
-
-                    else {
+                    } else {
                         Spacer(Modifier.height(12.dp))
                     }
                 }
-
 
                 items(productCategory.groupItems) { groupItem ->
                     GoodsLargeCard(

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
@@ -3,7 +3,9 @@ package com.poti.android.presentation.party.product.productcategory
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -111,8 +113,8 @@ private fun ProductCategoryScreen(
                     bottom = 76.dp,
                 ),
             ) {
-                if (isMyArtsit) {
-                    item {
+                item {
+                    if (isMyArtsit) {
                         PotiSmallButton(
                             text = stringResource(selectedSortType.displayRes),
                             onClick = onSortFilterClick,
@@ -121,7 +123,12 @@ private fun ProductCategoryScreen(
                                 .wrapContentWidth(Alignment.End),
                         )
                     }
+
+                    else {
+                        Spacer(Modifier.height(12.dp))
+                    }
                 }
+
 
                 items(productCategory.groupItems) { groupItem ->
                     GoodsLargeCard(

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
@@ -56,6 +56,7 @@ fun ProductCategoryRoute(
     uiState.productCategoryLoadState.onSuccess { goodsCategory ->
         ProductCategoryScreen(
             title = if (viewModel.isMyArtist) stringResource(R.string.home_recommend_goods, goodsCategory.nickname) else stringResource(R.string.home_other_goods),
+            isMyArtsit = viewModel.isMyArtist,
             productCategory = goodsCategory,
             selectedSortType = uiState.selectedSortType,
             isSortBottomSheetVisible = uiState.isSortBottomSheetVisible,
@@ -73,6 +74,7 @@ fun ProductCategoryRoute(
 @Composable
 private fun ProductCategoryScreen(
     title: String,
+    isMyArtsit: Boolean,
     productCategory: ProductCategory,
     selectedSortType: ProductSortType,
     isSortBottomSheetVisible: Boolean,
@@ -109,14 +111,16 @@ private fun ProductCategoryScreen(
                     bottom = 76.dp,
                 ),
             ) {
-                item {
-                    PotiSmallButton(
-                        text = stringResource(selectedSortType.displayRes),
-                        onClick = onSortFilterClick,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .wrapContentWidth(Alignment.End),
-                    )
+                if (isMyArtsit) {
+                    item {
+                        PotiSmallButton(
+                            text = stringResource(selectedSortType.displayRes),
+                            onClick = onSortFilterClick,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .wrapContentWidth(Alignment.End),
+                        )
+                    }
                 }
 
                 items(productCategory.groupItems) { groupItem ->
@@ -154,6 +158,7 @@ private fun ProductCategoryScreenPreview() {
     PotiTheme {
         ProductCategoryScreen(
             title = "",
+            isMyArtsit = false,
             productCategory = dummyProductCategory,
             selectedSortType = ProductSortType.LATEST,
             isSortBottomSheetVisible = false,

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/model/Contracts.kt
@@ -9,7 +9,7 @@ import com.poti.android.domain.model.party.ProductCategory
 data class ProductCategoryUiState(
     val productCategoryLoadState: ApiState<ProductCategory> = ApiState.Loading,
     val isSortBottomSheetVisible: Boolean = false,
-    val selectedSortType: ProductSortType = ProductSortType.LATEST,
+    val selectedSortType: ProductSortType = ProductSortType.HOT,
 ) : UiState
 
 sealed interface ProductCategoryUiIntent : UiIntent {


### PR DESCRIPTION
## Related issue 🛠️
- closed #133

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 홈에 추천 굿즈 랜덤으로 왔다면 카테고리에 artistId=null 전달
- 추천 굿즈 정렬 기본값 인기순으로 변경
- 다른 굿즈 구경하기에 정렬 UI 제거 + 여백 추가
- 참여뷰 입금 바텀시트 키보드 올라올 때 여백 조정

## Screenshot 📸
| 다른 굿즈 구경하기 | 바텀시트 여백 조정 |
| --- | --- |
| <img width="250" src="https://github.com/user-attachments/assets/361e9d91-ae3b-4767-af76-cb6728fc6d41" /> | <video width="250" src="https://github.com/user-attachments/assets/dba69723-b800-4508-a8c7-883ea8215013" /> |

## Uncompleted Tasks 😅


## To Reviewers 📢
키보드 올라올 때 bottomPadding값이 분기로 변경되는데요
이때 바텀시트가 리컴포지션 되면서 뽀잉 하는 효과가 생깁니다
개선 방법을 찾기 어려워 일단 디쌤한테 갠찮다고 확인받고 올려요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 아티스트 ID 검증 로직을 추가하여 불일치 상황 감지 및 처리 개선

* **새로운 기능**
  * 아티스트 ID 무효화 상태 추적 기능 추가

* **개선사항**
  * 마이 아티스트 화면에서 조건부 정렬 버튼 표시
  * 기본 정렬 순서를 인기순으로 변경

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->