### PR TITLE
[Fix/#141] 가격 0 이후 입력 제한

### DIFF
--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -112,7 +112,7 @@ fun EditOptionPrice(
 
                     val adjusted = when {
                         newValue.isEmpty() -> ""
-                        newValue.all { c -> c == '0' } -> "0"
+                        newValue.all { it == '0' } -> "0"
                         newValue.startsWith("0") -> newValue.dropWhile { it == '0' }
                         else -> newValue
                     }

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -110,7 +110,14 @@ fun EditOptionPrice(
                     if (!newValue.isDigitsOnly()) return@OptionTextField
                     if (newValue.length > MAX_LENGTH) return@OptionTextField
 
-                    onValueChanged(newValue)
+                    val adjusted = when {
+                        newValue.isEmpty() -> ""
+                        newValue.all { c -> c == '0' } -> "0"
+                        newValue.startsWith("0") -> newValue.dropWhile { it == '0' }
+                        else -> newValue
+                    }
+
+                    onValueChanged(adjusted)
                 },
                 imeAction = imeAction,
                 transformation = transformation,

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -139,17 +139,15 @@ private fun OptionTextField(
                 onFocusChanged(focusState.isFocused)
             }
             .drawWithCache {
-                val minPx = 42.dp.toPx()
                 val strokePx = 2.dp.toPx()
                 val yOffset = strokePx / 2 - 4.dp.toPx()
 
                 onDrawBehind {
-                    val underlineWidth = max(size.width, minPx)
                     val y = size.height - yOffset
 
                     drawLine(
                         color = colors.gray300,
-                        start = Offset(size.width - underlineWidth, y),
+                        start = Offset(0f, y),
                         end = Offset(size.width, y),
                         strokeWidth = strokePx,
                         cap = StrokeCap.Round,

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -44,7 +44,6 @@ import com.poti.android.R
 import com.poti.android.core.common.extension.toMoneyString
 import com.poti.android.core.designsystem.component.display.PotiCheckBox
 import com.poti.android.core.designsystem.theme.PotiTheme
-import kotlin.math.max
 
 private const val MAX_LENGTH = 9
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -202,20 +202,15 @@ private fun OptionTextField(
 
 private class PriceVisualTransformation : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
-        val text = text.text
+        val originalText = text.text
 
-        val textWithComma = when (text.length) {
-            0 -> text
-            else -> text.toInt().toMoneyString()
-        }
+        val transformedText = originalText.toIntOrNull()?.toMoneyString() ?: originalText
 
         val offsetMapping = object : OffsetMapping {
             override fun originalToTransformed(offset: Int): Int {
-                if (offset == text.length) {
-                    return textWithComma.length
-                }
+                if (offset >= originalText.length) return transformedText.length
 
-                val numbersAtferCursor = text.length - offset
+                val numbersAtferCursor = originalText.length - offset
 
                 val commasAfterCursor = if (numbersAtferCursor % 3 == 0) {
                     numbersAtferCursor / 3 - 1
@@ -223,26 +218,24 @@ private class PriceVisualTransformation : VisualTransformation {
                     numbersAtferCursor / 3
                 }
 
-                return textWithComma.length - numbersAtferCursor - commasAfterCursor
+                return transformedText.length - numbersAtferCursor - commasAfterCursor
             }
 
             override fun transformedToOriginal(offset: Int): Int {
-                var commasBeforeCursor = 0
+                if (offset >= transformedText.length) return originalText.length
 
-                textWithComma.forEachIndexed { index, char ->
-                    if (index >= offset) return@forEachIndexed
+                // 목표 = 커서 좌측 원본 길이
+                //     = 원본 전체 길이 - 원본 우측 길이
+                //     = 원본 전체 길이 - (변경 우측 길이 - 변형 우측 콤마 개수)
+                val rightOffset = transformedText.length - offset
+                val rightCommas = rightOffset / 4
 
-                    if (char == ',') {
-                        commasBeforeCursor += 1
-                    }
-                }
-
-                return offset - commasBeforeCursor
+                return originalText.length - (rightOffset - rightCommas)
             }
         }
 
         return TransformedText(
-            text = AnnotatedString(textWithComma),
+            text = AnnotatedString(transformedText),
             offsetMapping = offsetMapping,
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -2,12 +2,14 @@ package com.poti.android.presentation.party.create.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -23,7 +25,6 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -34,11 +35,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.text.isDigitsOnly
 import com.poti.android.R
@@ -61,21 +60,8 @@ fun EditOptionPrice(
     imeAction: ImeAction = ImeAction.Done,
     enabled: Boolean = true,
 ) {
-    val density = LocalDensity.current
-    val measurer = rememberTextMeasurer()
-
     val textStyle = PotiTheme.typography.body16sb
     val transformation = remember { PriceVisualTransformation() }
-
-    val transformedText = remember(value) {
-        transformation.filter(AnnotatedString(value)).text.text
-    }
-
-    val textWidth = remember(transformedText, textStyle) {
-        density.run {
-            measurer.measure(transformedText, textStyle).size.width.toDp()
-        }
-    }
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -116,7 +102,6 @@ fun EditOptionPrice(
             textStyle = textStyle,
             onFocusChanged = onFocusChanged,
             enabled = enabled,
-            textWidth = textWidth,
         )
 
         Spacer(Modifier.width(4.dp))
@@ -138,7 +123,6 @@ private fun OptionTextField(
     textStyle: TextStyle,
     onFocusChanged: (Boolean) -> Unit,
     enabled: Boolean,
-    textWidth: Dp,
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
@@ -149,23 +133,23 @@ private fun OptionTextField(
         value = value,
         onValueChange = onValueChanged,
         modifier = modifier
+            .width(IntrinsicSize.Min)
+            .widthIn(2.dp)
             .onFocusChanged { focusState ->
                 onFocusChanged(focusState.isFocused)
             }
             .drawWithCache {
                 val minPx = 42.dp.toPx()
-                val textPx = textWidth.toPx()
-                val underlinePx = max(minPx, textPx)
-
                 val strokePx = 2.dp.toPx()
                 val yOffset = strokePx / 2 - 4.dp.toPx()
 
                 onDrawBehind {
+                    val underlineWidth = max(size.width, minPx)
                     val y = size.height - yOffset
 
                     drawLine(
                         color = colors.gray300,
-                        start = Offset(size.width - underlinePx, y),
+                        start = Offset(size.width - underlineWidth, y),
                         end = Offset(size.width, y),
                         strokeWidth = strokePx,
                         cap = StrokeCap.Round,

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -35,8 +35,10 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.text.isDigitsOnly
 import com.poti.android.R
@@ -71,7 +73,7 @@ fun EditOptionPrice(
 
     val textWidth = remember(transformedText, textStyle) {
         density.run {
-            measurer.measure(transformedText, textStyle).size.width.toDp() + 2.dp
+            measurer.measure(transformedText, textStyle).size.width.toDp()
         }
     }
 
@@ -114,7 +116,7 @@ fun EditOptionPrice(
             textStyle = textStyle,
             onFocusChanged = onFocusChanged,
             enabled = enabled,
-            modifier = Modifier.width(textWidth),
+            textWidth = textWidth,
         )
 
         Spacer(Modifier.width(4.dp))
@@ -136,6 +138,7 @@ private fun OptionTextField(
     textStyle: TextStyle,
     onFocusChanged: (Boolean) -> Unit,
     enabled: Boolean,
+    textWidth: Dp,
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
@@ -150,25 +153,28 @@ private fun OptionTextField(
                 onFocusChanged(focusState.isFocused)
             }
             .drawWithCache {
-                val minWidth = 42.dp.toPx()
-                val strokeWidth = 2.dp.toPx()
-                val yOffset = strokeWidth / 2 - 4.dp.toPx()
+                val minPx = 42.dp.toPx()
+                val textPx = textWidth.toPx()
+                val underlinePx = max(minPx, textPx)
+
+                val strokePx = 2.dp.toPx()
+                val yOffset = strokePx / 2 - 4.dp.toPx()
 
                 onDrawBehind {
-                    val underlineWidth = max(size.width, minWidth)
                     val y = size.height - yOffset
 
                     drawLine(
                         color = colors.gray300,
-                        start = Offset(size.width - underlineWidth, y),
+                        start = Offset(size.width - underlinePx, y),
                         end = Offset(size.width, y),
-                        strokeWidth = strokeWidth,
+                        strokeWidth = strokePx,
                         cap = StrokeCap.Round,
                     )
                 }
             },
         textStyle = textStyle.copy(
             color = PotiTheme.colors.black,
+            textAlign = TextAlign.End,
         ),
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Number,
@@ -242,7 +248,7 @@ private class PriceVisualTransformation : VisualTransformation {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun OptionTextFieldPreview() {
     var text1 by remember { mutableStateOf("") }

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -134,7 +134,7 @@ private fun OptionTextField(
         onValueChange = onValueChanged,
         modifier = modifier
             .width(IntrinsicSize.Min)
-            .widthIn(2.dp)
+            .widthIn(42.dp)
             .onFocusChanged { focusState ->
                 onFocusChanged(focusState.isFocused)
             }
@@ -175,7 +175,7 @@ private fun OptionTextField(
                 )
             },
         ),
-        singleLine = true,
+        maxLines = 1,
         visualTransformation = transformation,
         decorationBox = { innerTextField ->
             innerTextField()

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -110,12 +110,7 @@ fun EditOptionPrice(
                     if (!newValue.isDigitsOnly()) return@OptionTextField
                     if (newValue.length > MAX_LENGTH) return@OptionTextField
 
-                    val adjusted = when {
-                        newValue.isEmpty() -> ""
-                        newValue.all { it == '0' } -> "0"
-                        newValue.startsWith("0") -> newValue.dropWhile { it == '0' }
-                        else -> newValue
-                    }
+                    val adjusted = newValue.toIntOrNull()?.toString() ?: ""
 
                     onValueChanged(adjusted)
                 },

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -8,23 +8,21 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -45,6 +43,7 @@ import com.poti.android.R
 import com.poti.android.core.common.extension.toMoneyString
 import com.poti.android.core.designsystem.component.display.PotiCheckBox
 import com.poti.android.core.designsystem.theme.PotiTheme
+import kotlin.math.max
 
 private const val MAX_LENGTH = 9
 
@@ -100,37 +99,23 @@ fun EditOptionPrice(
 
         Spacer(Modifier.width(12.dp))
 
-        Column(
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-            horizontalAlignment = Alignment.End,
-        ) {
-            OptionTextField(
-                value = value,
-                onValueChanged = { newValue ->
-                    if (!newValue.isDigitsOnly()) return@OptionTextField
-                    if (newValue.length > MAX_LENGTH) return@OptionTextField
+        OptionTextField(
+            value = value,
+            onValueChanged = { newValue ->
+                if (!newValue.isDigitsOnly()) return@OptionTextField
+                if (newValue.length > MAX_LENGTH) return@OptionTextField
 
-                    val adjusted = newValue.toIntOrNull()?.toString() ?: ""
+                val adjusted = newValue.toIntOrNull()?.toString() ?: ""
 
-                    onValueChanged(adjusted)
-                },
-                imeAction = imeAction,
-                transformation = transformation,
-                textStyle = textStyle,
-                onFocusChanged = onFocusChanged,
-                enabled = enabled,
-                modifier = Modifier.width(textWidth),
-            )
-
-            HorizontalDivider(
-                modifier = Modifier
-                    .widthIn(min = 42.dp)
-                    .width(textWidth)
-                    .clip(CircleShape),
-                thickness = 2.dp,
-                color = PotiTheme.colors.gray300,
-            )
-        }
+                onValueChanged(adjusted)
+            },
+            imeAction = imeAction,
+            transformation = transformation,
+            textStyle = textStyle,
+            onFocusChanged = onFocusChanged,
+            enabled = enabled,
+            modifier = Modifier.width(textWidth),
+        )
 
         Spacer(Modifier.width(4.dp))
 
@@ -155,6 +140,7 @@ private fun OptionTextField(
 ) {
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val colors = PotiTheme.colors
 
     BasicTextField(
         value = value,
@@ -162,6 +148,24 @@ private fun OptionTextField(
         modifier = modifier
             .onFocusChanged { focusState ->
                 onFocusChanged(focusState.isFocused)
+            }
+            .drawWithCache {
+                val minWidth = 42.dp.toPx()
+                val strokeWidth = 2.dp.toPx()
+                val yOffset = strokeWidth / 2 - 4.dp.toPx()
+
+                onDrawBehind {
+                    val underlineWidth = max(size.width, minWidth)
+                    val y = size.height - yOffset
+
+                    drawLine(
+                        color = colors.gray300,
+                        start = Offset(size.width - underlineWidth, y),
+                        end = Offset(size.width, y),
+                        strokeWidth = strokeWidth,
+                        cap = StrokeCap.Round,
+                    )
+                }
             },
         textStyle = textStyle.copy(
             color = PotiTheme.colors.black,

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/EditOptionPrice.kt
@@ -194,15 +194,15 @@ private class PriceVisualTransformation : VisualTransformation {
             override fun originalToTransformed(offset: Int): Int {
                 if (offset >= originalText.length) return transformedText.length
 
-                val numbersAtferCursor = originalText.length - offset
+                val numbersAfterCursor = originalText.length - offset
 
-                val commasAfterCursor = if (numbersAtferCursor % 3 == 0) {
-                    numbersAtferCursor / 3 - 1
+                val commasAfterCursor = if (numbersAfterCursor % 3 == 0) {
+                    numbersAfterCursor / 3 - 1
                 } else {
-                    numbersAtferCursor / 3
+                    numbersAfterCursor / 3
                 }
 
-                return transformedText.length - numbersAtferCursor - commasAfterCursor
+                return transformedText.length - numbersAfterCursor - commasAfterCursor
             }
 
             override fun transformedToOriginal(offset: Int): Int {


### PR DESCRIPTION
## Related issue 🛠️
- closed #141 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 0 이후로 숫자 계속 입력하는 경우 toInt에 exception 발생하는 오류가 있었는데욤
- 은행 앱 참고해서 개선해봤어욤
   - 0 이후 다른 숫자 입력 > 다른 숫자로 대체
   - 0만 계속 입력 > 0 하나만 유지

## Screenshot 📸

| 스크린샷 |
| --- |
| <video src="https://github.com/user-attachments/assets/38563ef5-dde6-4d01-bae4-8699d10d95d2" width="200" /> |

## Uncompleted Tasks 😅

## To Reviewers 📢
입력마다 스트링 객체 생성되는 점이 걸리긴 합니다만 다른 방법이 떠오르지 않네욤,, UX를 위해 희생해도 되는 부분인지 아님 더 좋은 방법이 있을까욤?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 옵션 가격 입력 정규화 개선 — 빈 입력과 선행 영(0) 처리가 올바르게 동작합니다.

* **UI 개선**
  * 입력 필드 레이아웃 단순화 및 맞춤 밑줄 렌더링으로 시각적 피드백 향상, 텍스트 끝 정렬 및 최소 너비 보장.

* **행동 변경**
  * 입력 콜백에 전달되는 값이 원시 문자열 대신 정규화된 숫자 문자열(또는 빈값)으로 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->