### PR TITLE
[Refactor/#143] 등록 뷰 리팩토링

### DIFF
--- a/app/src/main/java/com/poti/android/presentation/party/component/MemberSelectBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/component/MemberSelectBottomSheet.kt
@@ -80,7 +80,7 @@ fun <T> MemberSelectBottomSheet(
         ) {
             items(
                 items = allMembers,
-                key = { memberToId(it) }
+                key = { memberToId(it) },
             ) { member ->
                 val isSelected = memberToId(member) in selectedMemberIds
 

--- a/app/src/main/java/com/poti/android/presentation/party/component/MemberSelectBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/component/MemberSelectBottomSheet.kt
@@ -1,6 +1,5 @@
 package com.poti.android.presentation.party.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,11 +18,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
+import com.poti.android.core.common.util.screenHeightDp
 import com.poti.android.core.common.util.screenWidthDp
 import com.poti.android.core.designsystem.component.bottomsheet.PotiBottomSheet
 import com.poti.android.core.designsystem.component.button.ChipButtonType
 import com.poti.android.core.designsystem.component.button.PotiChipButton
 import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.domain.model.artist.Member
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,8 +64,7 @@ fun <T> MemberSelectBottomSheet(
         Text(
             text = title,
             modifier = Modifier
-                .padding(top = 12.dp, bottom = 16.dp, start = screenWidthDp(16.dp))
-                .background(PotiTheme.colors.white),
+                .padding(top = 12.dp, bottom = 16.dp, start = screenWidthDp(16.dp)),
             color = PotiTheme.colors.black,
             style = PotiTheme.typography.title18sb,
         )
@@ -72,7 +72,7 @@ fun <T> MemberSelectBottomSheet(
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),
             modifier = Modifier
-                .height(492.dp)
+                .height(screenHeightDp(492.dp))
                 .fillMaxWidth(),
             contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 40.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -98,6 +98,10 @@ fun <T> MemberSelectBottomSheet(
 @Preview
 @Composable
 private fun MemberSelectBottomSheetPreview() {
+    val members = (0L..20L).map { id ->
+        Member(id, "원영")
+    }
+
     MemberSelectBottomSheet(
         title = stringResource(R.string.action_button_continue),
         onDismiss = {},
@@ -107,10 +111,10 @@ private fun MemberSelectBottomSheetPreview() {
         subBtnText = stringResource(R.string.action_button_continue),
         onSubBtnClick = {},
         subEnabled = true,
-        allMembers = listOf("원영, 유진"),
-        selectedMembers = listOf("원영"),
+        allMembers = members,
+        selectedMembers = members,
         onMemberClick = {},
-        memberToName = { "" },
-        memberToId = { 0L },
+        memberToName = { it.name },
+        memberToId = { it.memberId },
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/party/component/MemberSelectBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/component/MemberSelectBottomSheet.kt
@@ -1,0 +1,116 @@
+package com.poti.android.presentation.party.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.common.util.screenWidthDp
+import com.poti.android.core.designsystem.component.bottomsheet.PotiBottomSheet
+import com.poti.android.core.designsystem.component.button.ChipButtonType
+import com.poti.android.core.designsystem.component.button.PotiChipButton
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T> MemberSelectBottomSheet(
+    title: String,
+    mainBtnText: String,
+    subBtnText: String,
+    onDismiss: () -> Unit,
+    onMainBtnClick: () -> Unit,
+    onSubBtnClick: () -> Unit,
+    allMembers: List<T>,
+    selectedMembers: List<T>,
+    onMemberClick: (T) -> Unit,
+    memberToName: (T) -> String,
+    memberToId: (T) -> Long,
+    mainEnabled: Boolean,
+    subEnabled: Boolean,
+    autoCloseSubBtn: Boolean = true,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val selectedMemberIds = remember(selectedMembers) {
+        selectedMembers.map { memberToId(it) }.toSet()
+    }
+
+    PotiBottomSheet(
+        onDismissRequest = onDismiss,
+        text = mainBtnText,
+        onClick = onMainBtnClick,
+        subText = subBtnText,
+        onSubClick = onSubBtnClick,
+        subEnabled = subEnabled,
+        enabled = mainEnabled,
+        sheetState = sheetState,
+        autoCloseSub = autoCloseSubBtn,
+    ) {
+        Text(
+            text = title,
+            modifier = Modifier
+                .padding(top = 12.dp, bottom = 16.dp, start = screenWidthDp(16.dp))
+                .background(PotiTheme.colors.white),
+            color = PotiTheme.colors.black,
+            style = PotiTheme.typography.title18sb,
+        )
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            modifier = Modifier
+                .height(492.dp)
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 40.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            items(
+                items = allMembers,
+                key = { memberToId(it) }
+            ) { member ->
+                val isSelected = memberToId(member) in selectedMemberIds
+
+                PotiChipButton(
+                    text = memberToName(member),
+                    onClick = { onMemberClick(member) },
+                    modifier = Modifier.fillMaxWidth(),
+                    type = if (isSelected) ChipButtonType.SELECTED else ChipButtonType.DEFAULT,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun MemberSelectBottomSheetPreview() {
+    MemberSelectBottomSheet(
+        title = stringResource(R.string.action_button_continue),
+        onDismiss = {},
+        mainBtnText = stringResource(R.string.action_button_continue),
+        onMainBtnClick = {},
+        mainEnabled = true,
+        subBtnText = stringResource(R.string.action_button_continue),
+        onSubBtnClick = {},
+        subEnabled = true,
+        allMembers = listOf("원영, 유진"),
+        selectedMembers = listOf("원영"),
+        onMemberClick = {},
+        memberToName = { "" },
+        memberToId = { 0L },
+    )
+}

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyArtistSelectScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyArtistSelectScreen.kt
@@ -92,7 +92,7 @@ private fun PartyArtistSelectScreen(
         ) {
             CreateDropdownField(
                 viewType = ViewType.ARTSIT_SELECT,
-                value = uiState.artistQuery,
+                value = uiState.artistSearchKeyword,
                 onValueChanged = onSearchKeywordChange,
                 searchResults = uiState.artistSearchState.getSuccessDataOrNull() ?: emptyList(),
                 resultToString = { it.name },

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyArtistSelectScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyArtistSelectScreen.kt
@@ -25,8 +25,8 @@ import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.artist.ArtistSearchResult
 import com.poti.android.presentation.party.create.component.CreateDropdownField
 import com.poti.android.presentation.party.create.component.ViewType
-import com.poti.android.presentation.party.create.model.CreateUiEffect
-import com.poti.android.presentation.party.create.model.CreateUiIntent
+import com.poti.android.presentation.party.create.model.CreateUiEffect.*
+import com.poti.android.presentation.party.create.model.CreateUiIntent.*
 import com.poti.android.presentation.party.create.model.CreateUiState
 
 @Composable
@@ -39,17 +39,17 @@ fun PartyArtistSelectRoute(
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
-            CreateUiEffect.NavigateToBack -> onPopBackStack()
+            NavigateToBack -> onPopBackStack()
             else -> Unit
         }
     }
 
     PartyArtistSelectScreen(
         uiState = uiState,
-        onSearchKeywordChange = { viewModel.processIntent(CreateUiIntent.OnArtistSearchKeywordChange(it)) },
-        onArtistSelect = { viewModel.processIntent(CreateUiIntent.OnArtistSelect(it)) },
-        onConfirmClick = { viewModel.processIntent(CreateUiIntent.OnBackToCreate) },
-        onPopBackStack = { viewModel.processIntent(CreateUiIntent.OnBackToCreate) },
+        onSearchKeywordChange = { viewModel.processIntent(OnArtistChange(it)) },
+        onArtistSelect = { viewModel.processIntent(OnArtistSelect(it)) },
+        onConfirmClick = { viewModel.processIntent(OnBackToCreate) },
+        onPopBackStack = { viewModel.processIntent(OnBackToCreate) },
         modifier = modifier,
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyArtistSelectScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyArtistSelectScreen.kt
@@ -92,9 +92,9 @@ private fun PartyArtistSelectScreen(
         ) {
             CreateDropdownField(
                 viewType = ViewType.ARTSIT_SELECT,
-                value = uiState.artistSearchKeyword,
+                value = uiState.artistQuery,
                 onValueChanged = onSearchKeywordChange,
-                searchResults = uiState.artistSearchResultsState.getSuccessDataOrNull() ?: emptyList(),
+                searchResults = uiState.artistSearchState.getSuccessDataOrNull() ?: emptyList(),
                 resultToString = { it.name },
                 onItemClick = { onArtistSelect(it) },
                 placeholder = stringResource(R.string.create_placeholder_artist_search),

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -67,7 +67,7 @@ fun PartyCreateRoute(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(uiState.isInitialized) {
         viewModel.processIntent(InitializeScreen(artistId, artistName, productName))
     }
 
@@ -85,7 +85,7 @@ fun PartyCreateRoute(
 
             ConvertUris -> {
                 val result = uiState.imageUris.toImageInfosForPresigned(context)
-                viewModel.processIntent(OnConvertDone(result))
+                viewModel.processIntent(ConvertDone(result))
             }
 
             is NavigateToDetail -> {
@@ -99,7 +99,7 @@ fun PartyCreateRoute(
             title = stringResource(R.string.create_title_bottomsheet),
             mainBtnText = stringResource(R.string.action_button_done),
             subBtnText = stringResource(R.string.action_button_select_all),
-            onDismiss = { viewModel.processIntent(CloseBottomSheet) },
+            onDismiss = { viewModel.processIntent(OnCloseBottomSheet) },
             onMainBtnClick = { viewModel.processIntent(OnMemberSelectDone) },
             onSubBtnClick = { viewModel.processIntent(OnAllMemberSelect) },
             allMembers = uiState.rawMembers,
@@ -115,19 +115,19 @@ fun PartyCreateRoute(
 
     if (uiState.showDialog) {
         PotiSmallModal(
-            onDismissRequest = { viewModel.processIntent(CloseDialog) },
+            onDismissRequest = { viewModel.processIntent(OnCloseDialog) },
             title = stringResource(R.string.create_exit_dialog_title),
             text = stringResource(R.string.create_exit_dialog_content),
             dismissBtnText = stringResource(R.string.create_exit_dialog_dismiss_text),
             confirmBtnText = stringResource(R.string.create_exit_dialog_confirm_text),
             onDismissBtnClick = { viewModel.processIntent(OnBackConfirm) },
-            onConfirmBtnClick = { viewModel.processIntent(CloseDialog) },
+            onConfirmBtnClick = { viewModel.processIntent(OnCloseDialog) },
         )
     }
 
     PartyCreateScreen(
         uiState = uiState,
-        onScrollComplete = { viewModel.processIntent(OnScrollComplete) },
+        onScrollComplete = { viewModel.processIntent(ScrollComplete) },
         onBackClick = { viewModel.processIntent(OnBack) },
         onImageChanged = { viewModel.processIntent(OnImagesChanged(it)) },
         onSearchArtist = { viewModel.processIntent(OnSearchClick) },

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -14,9 +15,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -169,6 +174,8 @@ private fun PartyCreateScreen(
     val listState = rememberLazyListState()
     val dateTransformation = remember { DateTransformation() }
 
+    var listBottom by remember { mutableStateOf(0f) }
+
     LaunchedEffect(uiState.errorIndexToScroll) {
         uiState.errorIndexToScroll?.let {
             listState.animateScrollToItem(it)
@@ -188,11 +195,15 @@ private fun PartyCreateScreen(
                 text = stringResource(R.string.create_btn_create),
                 onClick = onCreateBtnClick,
             )
-        },
+        }
     ) { innerPadding ->
         LazyColumn(
             state = listState,
-            modifier = Modifier.padding(innerPadding),
+            modifier = Modifier
+                .padding(innerPadding)
+                .onGloballyPositioned { coordinates ->
+                    listBottom = coordinates.boundsInWindow().bottom
+                },
         ) {
             item {
                 Text(
@@ -342,6 +353,7 @@ private fun PartyCreateScreen(
                     onPriceChange = onMemberPriceChanged,
                     onEditBtnClick = onMemberEditBtnClick,
                     errorMessage = uiState.memberError?.let { stringResource(it.message) } ?: "",
+                    layoutBottom = listBottom,
                 )
             }
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -341,7 +341,6 @@ private fun PartyCreateScreen(
                     selectedMembers = uiState.selectedMembers,
                     onPriceChange = onMemberPriceChanged,
                     onEditBtnClick = onMemberEditBtnClick,
-                    showHint = uiState.showMemberHint,
                     errorMessage = uiState.memberError?.let { stringResource(it.message) } ?: "",
                 )
             }

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -67,7 +67,7 @@ fun PartyCreateRoute(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(uiState.isInitialized) {
+    LaunchedEffect(artistId, artistName, productName) {
         viewModel.processIntent(InitializeScreen(artistId, artistName, productName))
     }
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -65,16 +64,9 @@ fun PartyCreateRoute(
     onNavigateToDetail: (Long) -> Unit,
     viewModel: PartyCreateViewModel,
     modifier: Modifier = Modifier,
-    artistId: Long? = null,
-    artistName: String? = null,
-    productName: String? = null,
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
-    LaunchedEffect(artistId, artistName, productName) {
-        viewModel.processIntent(InitializeScreen(artistId, artistName, productName))
-    }
 
     BackHandler {
         viewModel.processIntent(OnBack)
@@ -195,7 +187,7 @@ private fun PartyCreateScreen(
                 text = stringResource(R.string.create_btn_create),
                 onClick = onCreateBtnClick,
             )
-        }
+        },
     ) { innerPadding ->
         LazyColumn(
             state = listState,

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -14,9 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
@@ -26,13 +24,11 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.poti.android.R
 import com.poti.android.core.common.extension.getSuccessDataOrNull
 import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.common.util.screenWidthDp
-import com.poti.android.core.designsystem.component.bottomsheet.MemberSelectBottomSheet
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.display.PotiErrorMessage
@@ -43,14 +39,16 @@ import com.poti.android.core.designsystem.component.navigation.PotiBottomButton
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.artist.MemberPriceOption
+import com.poti.android.domain.model.delivery.DeliveryOption
+import com.poti.android.presentation.party.component.MemberSelectBottomSheet
 import com.poti.android.presentation.party.create.component.CreateDeliverySetting
 import com.poti.android.presentation.party.create.component.CreateDropdownField
 import com.poti.android.presentation.party.create.component.CreateMemberSetting
 import com.poti.android.presentation.party.create.component.CreatePhotoUpload
 import com.poti.android.presentation.party.create.component.SellerNotice
 import com.poti.android.presentation.party.create.component.ViewType
-import com.poti.android.presentation.party.create.model.CreateUiEffect
-import com.poti.android.presentation.party.create.model.CreateUiIntent
+import com.poti.android.presentation.party.create.model.CreateUiEffect.*
+import com.poti.android.presentation.party.create.model.CreateUiIntent.*
 import com.poti.android.presentation.party.create.model.CreateUiState
 import com.poti.android.presentation.party.create.util.DateTransformation
 import com.poti.android.presentation.party.create.util.toImageInfosForPresigned
@@ -67,100 +65,83 @@ fun PartyCreateRoute(
     productName: String? = null,
 ) {
     val context = LocalContext.current
-
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    var showBottomSheet by remember { mutableStateOf(false) }
-    var showDialog by remember { mutableStateOf(false) }
-
-    if (uiState.isDirty) {
-        BackHandler {
-            showDialog = true
-        }
-    }
 
     LaunchedEffect(Unit) {
-        viewModel.processIntent(CreateUiIntent.InitializeScreen(artistId, artistName, productName))
+        viewModel.processIntent(InitializeScreen(artistId, artistName, productName))
+    }
+
+    BackHandler {
+        viewModel.processIntent(OnBack)
     }
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
-            CreateUiEffect.NavigateToBack -> {
-                showDialog = false
+            NavigateToBack -> {
                 onPopBackStack()
             }
 
-            CreateUiEffect.NavigateToSearch -> onNavigateToSearch()
+            NavigateToSearch -> onNavigateToSearch()
 
-            CreateUiEffect.ShowBottomSheet -> {
-                showBottomSheet = true
+            ConvertUris -> {
+                val result = uiState.imageUris.toImageInfosForPresigned(context)
+                viewModel.processIntent(OnConvertDone(result))
             }
 
-            CreateUiEffect.ShowDialog -> {
-                showDialog = true
-            }
-
-            CreateUiEffect.ConvertUris -> {
-                val result = uiState.selectedImages.toImageInfosForPresigned(context)
-                viewModel.processIntent(CreateUiIntent.OnConvertDone(result))
-            }
-
-            is CreateUiEffect.NavigateToDetail -> {
+            is NavigateToDetail -> {
                 onNavigateToDetail(effect.partyId)
             }
         }
     }
 
-    if (showBottomSheet) {
+    if (uiState.showMemberBottomSheet) {
         MemberSelectBottomSheet(
-            title = R.string.create_title_bottomsheet,
-            onDismiss = { showBottomSheet = false },
-            mainBtnText = R.string.action_button_done,
-            onMainBtnClick = {
-                viewModel.processIntent(CreateUiIntent.OnMemberSelectDone)
-                showBottomSheet = false
-            },
-            mainEnabled = uiState.isSheetTouched,
-            subBtnText = R.string.action_button_select_all,
-            onSubBtnClick = {
-                viewModel.processIntent(CreateUiIntent.OnAllMemberSelect)
-            },
+            title = stringResource(R.string.create_title_bottomsheet),
+            mainBtnText = stringResource(R.string.action_button_done),
+            subBtnText = stringResource(R.string.action_button_select_all),
+            onDismiss = { viewModel.processIntent(CloseBottomSheet) },
+            onMainBtnClick = { viewModel.processIntent(OnMemberSelectDone) },
+            onSubBtnClick = { viewModel.processIntent(OnAllMemberSelect) },
+            allMembers = uiState.rawMembers,
+            selectedMembers = uiState.tempSelectedMembers,
+            onMemberClick = { viewModel.processIntent(OnMemberSelect(it)) },
+            memberToName = { it.name },
+            memberToId = { it.memberId },
+            mainEnabled = uiState.isMemberBottomSheetTouched,
             subEnabled = true,
-            members = uiState.sheetDisplayMemberNames,
-            onMemberClick = { viewModel.processIntent(CreateUiIntent.OnMemberSelect(it)) },
-            selectedIndices = uiState.sheetDisplayMemberIndices,
-            autoCloseSubBtn = false,
+            autoCloseSubBtn = false
         )
     }
 
-    if (showDialog) {
+    if (uiState.showDialog) {
         PotiSmallModal(
-            onDismissRequest = { showDialog = false },
+            onDismissRequest = { viewModel.processIntent(CloseDialog) },
             title = stringResource(R.string.create_exit_dialog_title),
             text = stringResource(R.string.create_exit_dialog_content),
             dismissBtnText = stringResource(R.string.create_exit_dialog_dismiss_text),
             confirmBtnText = stringResource(R.string.create_exit_dialog_confirm_text),
-            onDismissBtnClick = { viewModel.processIntent(CreateUiIntent.OnBackConfirm) },
-            onConfirmBtnClick = { showDialog = false },
+            onDismissBtnClick = { viewModel.processIntent(OnBackConfirm) },
+            onConfirmBtnClick = { viewModel.processIntent(CloseDialog) },
         )
     }
 
     PartyCreateScreen(
         uiState = uiState,
-        onScrollComplete = { viewModel.processIntent(CreateUiIntent.OnScrollComplete) },
-        onBackClick = { viewModel.processIntent(CreateUiIntent.OnBackClick) },
-        onImageChanged = { viewModel.processIntent(CreateUiIntent.OnImagesChanged(it)) },
-        onSearchArtist = { viewModel.processIntent(CreateUiIntent.OnSearchClick) },
-        onProductFocusChanged = { viewModel.processIntent(CreateUiIntent.OnProductFocus(it)) },
-        onProductChanged = { viewModel.processIntent(CreateUiIntent.OnProductChange(it)) },
-        onProductSearchItemClick = { viewModel.processIntent(CreateUiIntent.OnProductSelect(it)) },
-        onDeadlineChanged = { viewModel.processIntent(CreateUiIntent.OnDeadlineChange(it)) },
-        onDescriptionChanged = { viewModel.processIntent(CreateUiIntent.OnDescriptionChange(it)) },
-        onAccountNumberChanged = { viewModel.processIntent(CreateUiIntent.OnAccountNumberChange(it)) },
-        onBankChanged = { viewModel.processIntent(CreateUiIntent.OnBankChange(it)) },
-        onMemberPriceChanged = { viewModel.processIntent(CreateUiIntent.OnMemberPriceChange(it)) },
-        onMemberEditBtnClick = { viewModel.processIntent(CreateUiIntent.OnMemberEditClick) },
-        onDeliveryRadioBtnClick = { viewModel.processIntent(CreateUiIntent.OnDeliverySelect(it)) },
-        onCreateBtnClick = { viewModel.processIntent(CreateUiIntent.OnCreateClick) },
+        onScrollComplete = { viewModel.processIntent(OnScrollComplete) },
+        onBackClick = { viewModel.processIntent(OnBack) },
+        onImageChanged = { viewModel.processIntent(OnImagesChanged(it)) },
+        onSearchArtist = { viewModel.processIntent(OnSearchClick) },
+        onProductFocusChanged = { viewModel.processIntent(OnProductFocus(it)) },
+        onProductChanged = { viewModel.processIntent(OnProductChange(it)) },
+        onProductSearchItemClick = { viewModel.processIntent(OnProductSelect(it)) },
+        onDeadlineChanged = { viewModel.processIntent(OnDeadlineChange(it)) },
+        onDescriptionChanged = { viewModel.processIntent(OnDescriptionChange(it)) },
+        onAccountNumberChanged = { viewModel.processIntent(OnAccountNumberChange(it)) },
+        onBankChanged = { viewModel.processIntent(OnBankChange(it)) },
+        onMemberPriceChanged = { viewModel.processIntent(OnMemberPriceChange(it)) },
+        onMemberEditBtnClick = { viewModel.processIntent(OnMemberEditClick) },
+        onDeliveryRadioBtnClick = { viewModel.processIntent(OnDeliverySelect(it)) },
+        onCreateBtnClick = { viewModel.processIntent(OnCreateClick) },
         modifier = modifier,
     )
 }
@@ -181,7 +162,7 @@ private fun PartyCreateScreen(
     onBankChanged: (String) -> Unit,
     onMemberPriceChanged: (MemberPriceOption) -> Unit,
     onMemberEditBtnClick: () -> Unit,
-    onDeliveryRadioBtnClick: (Long) -> Unit,
+    onDeliveryRadioBtnClick: (DeliveryOption) -> Unit,
     onCreateBtnClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -189,9 +170,8 @@ private fun PartyCreateScreen(
     val dateTransformation = remember { DateTransformation() }
 
     LaunchedEffect(uiState.errorIndexToScroll) {
-        val index = uiState.errorIndexToScroll
-        index?.let {
-            listState.animateScrollToItem(index)
+        uiState.errorIndexToScroll?.let {
+            listState.animateScrollToItem(it)
         }
         onScrollComplete()
     }
@@ -225,7 +205,7 @@ private fun PartyCreateScreen(
                 )
 
                 CreatePhotoUpload(
-                    imageUris = uiState.selectedImages,
+                    imageUris = uiState.imageUris,
                     onImageChanged = onImageChanged,
                 )
 
@@ -267,7 +247,7 @@ private fun PartyCreateScreen(
                     viewType = ViewType.CREATE_PARTY,
                     value = uiState.productName,
                     onValueChanged = onProductChanged,
-                    searchResults = uiState.productSearchResultsState.getSuccessDataOrNull() ?: emptyList(),
+                    searchResults = uiState.productSearchState.getSuccessDataOrNull() ?: emptyList(),
                     onItemClick = onProductSearchItemClick,
                     placeholder = stringResource(R.string.create_placeholder_product),
                     label = stringResource(R.string.create_label_product),
@@ -275,7 +255,7 @@ private fun PartyCreateScreen(
                     modifier = Modifier
                         .padding(bottom = 28.dp),
                     fieldErrorMsg = uiState.productError?.let { stringResource(it.message) } ?: "",
-                    selectedString = uiState.selectedProductName,
+                    selectedString = uiState.selectedProduct,
                     readOnly = uiState.isProductFieldReadOnly,
                     onFocusChanged = onProductFocusChanged,
                 )
@@ -357,11 +337,12 @@ private fun PartyCreateScreen(
                 )
 
                 CreateMemberSetting(
-                    neverShowHint = uiState.neverShowHint,
                     status = uiState.memberSettingStatus,
-                    selectedMembersOption = uiState.editOptionDisplayMembers,
+                    selectedMembers = uiState.selectedMembers,
                     onPriceChange = onMemberPriceChanged,
                     onEditBtnClick = onMemberEditBtnClick,
+                    showHint = uiState.showMemberHint,
+                    errorMessage = uiState.memberError?.let { stringResource(it.message) } ?: "",
                 )
             }
 
@@ -371,9 +352,9 @@ private fun PartyCreateScreen(
                 )
 
                 CreateDeliverySetting(
-                    deliveryOptions = uiState.editableDeliveryOptions,
-                    selectedOptionIds = uiState.selectedDeliveryIds,
-                    onDeliveryOptionClick = onDeliveryRadioBtnClick,
+                    allDeliveries = uiState.rawDeliveries,
+                    selectedDeliveries = uiState.selectedDeliveries,
+                    onDeliveryClick = onDeliveryRadioBtnClick,
                 )
             }
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -109,7 +109,7 @@ fun PartyCreateRoute(
             memberToId = { it.memberId },
             mainEnabled = uiState.isMemberBottomSheetTouched,
             subEnabled = true,
-            autoCloseSubBtn = false
+            autoCloseSubBtn = false,
         )
     }
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -55,6 +55,9 @@ class PartyCreateViewModel @Inject constructor(
     initialState = CreateUiState(),
 ) {
     private val params = savedStateHandle.toRoute<PartyCreateGraph>()
+    private val paramArtistId = params.artistId
+    private val paramArtistName = params.artistName
+    private val paramProductName = params.productName
 
     override fun processIntent(intent: CreateUiIntent) {
         when (intent) {
@@ -62,7 +65,7 @@ class PartyCreateViewModel @Inject constructor(
 
             OnCloseDialog -> updateState { copy(showDialog = false) }
 
-            OnBack -> if (uiState.value.isFieldTouched) {
+            OnBack -> if (shouldShowDialog()) {
                 updateState { copy(showDialog = true) }
             } else {
                 updateState { copy(showDialog = false) }
@@ -179,7 +182,7 @@ class PartyCreateViewModel @Inject constructor(
 
     init {
         initializeDeliveryOptions()
-        autoFillParams(params.artistId, params.artistName, params.productName)
+        autoFillParams(paramArtistId, paramArtistName, paramProductName)
 
         viewModelScope.launch {
             uiState
@@ -202,6 +205,24 @@ class PartyCreateViewModel @Inject constructor(
         }
     }
 
+    private fun shouldShowDialog(): Boolean {
+        val state = uiState.value
+
+        val hasUserInput = state.imageUris.isNotEmpty() ||
+            state.selectedArtist?.artistId != paramArtistId ||
+            state.selectedArtist?.name != paramArtistName ||
+            state.productName != (paramProductName ?: "") ||
+            state.selectedProduct.isNotEmpty() ||
+            state.deadline.isNotEmpty() ||
+            state.description.isNotEmpty() ||
+            state.accountNumber.isNotEmpty() ||
+            state.bank.isNotEmpty() ||
+            state.selectedMembers != state.rawMembers ||
+            state.selectedDeliveries != state.rawDeliveries
+
+        return hasUserInput
+    }
+
     private fun autoFillParams(
         artistId: Long?,
         artistName: String?,
@@ -217,7 +238,7 @@ class PartyCreateViewModel @Inject constructor(
         )
 
         handleArtistSelect(initialArtist)
-        updateState { copy(productName = productName, isArtistAutoFilled = true) }
+        updateState { copy(productName = productName, isAutoFilled = true) }
     }
 
     private fun initializeDeliveryOptions() {
@@ -251,7 +272,7 @@ class PartyCreateViewModel @Inject constructor(
                 selectedArtist = newArtist,
                 artistSearchKeyword = newArtist.name,
                 artistError = null,
-                isArtistAutoFilled = false,
+                isAutoFilled = false,
                 productError = if (this.productError == FieldError.ARTIST_EMPTY_ERROR) null else this.productError,
             )
         }

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -90,7 +90,7 @@ class PartyCreateViewModel @Inject constructor(
 
             OnSearchClick -> sendEffect(NavigateToSearch)
 
-            is OnArtistChange -> updateState { copy(isFieldTouched = true, artistQuery = intent.value) }
+            is OnArtistChange -> updateState { copy(isFieldTouched = true, artistSearchKeyword = intent.value) }
 
             is OnArtistSelect -> handleArtistSelect(newArtist = intent.artist)
 
@@ -182,7 +182,7 @@ class PartyCreateViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             uiState
-                .map { it.artistQuery }
+                .map { it.artistSearchKeyword }
                 .debounce(500)
                 .distinctUntilChanged()
                 .collectLatest { keyword ->
@@ -249,7 +249,7 @@ class PartyCreateViewModel @Inject constructor(
         updateState {
             copy(
                 selectedArtist = newArtist,
-                artistQuery = newArtist.name,
+                artistSearchKeyword = newArtist.name,
                 artistError = null,
                 isArtistAutoFilled = false,
                 productError = if (this.productError == FieldError.ARTIST_EMPTY_ERROR) null else this.productError,

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -52,8 +52,8 @@ class PartyCreateViewModel @Inject constructor(
     private val createPartyUseCase: CreatePartyUseCase,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<CreateUiState, CreateUiIntent, CreateUiEffect>(
-    initialState = CreateUiState(),
-) {
+        initialState = CreateUiState(),
+    ) {
     private val params = savedStateHandle.toRoute<PartyCreateGraph>()
     private val paramArtistId = params.artistId
     private val paramArtistName = params.artistName

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -6,6 +6,7 @@ import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.model.artist.ArtistSearchResult
 import com.poti.android.domain.model.artist.MemberPriceOption
+import com.poti.android.domain.model.delivery.DeliveryOption
 import com.poti.android.domain.model.image.ImageInfoForPresigned
 import com.poti.android.domain.usecase.artist.GetMembersWithPriceUseCase
 import com.poti.android.domain.usecase.image.UploadImagesUseCase
@@ -22,16 +23,18 @@ import com.poti.android.presentation.party.create.util.isTodayOrAfter
 import com.poti.android.presentation.party.create.util.toDashedDate
 import com.poti.android.presentation.party.create.util.toDateOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import com.poti.android.presentation.party.create.model.CreateUiIntent.*
+import com.poti.android.presentation.party.create.model.CreateUiEffect.*
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.launch
-import javax.inject.Inject
+import kotlinx.coroutines.flow.map
+import kotlin.text.filter
 
 const val IMAGE_TYPE = "POST"
 
@@ -45,127 +48,121 @@ class PartyCreateViewModel @Inject constructor(
     private val searchProductUseCase: SearchProductUseCase,
     private val createPartyUseCase: CreatePartyUseCase,
 ) : BaseViewModel<CreateUiState, CreateUiIntent, CreateUiEffect>(
-        initialState = CreateUiState(),
-    ) {
-    private val artistSearchKeywordForDebounce = MutableStateFlow("")
-    private val productSearchKeywordForDebounce = MutableStateFlow("")
-
+    initialState = CreateUiState(),
+) {
     override fun processIntent(intent: CreateUiIntent) {
         when (intent) {
-            is CreateUiIntent.InitializeScreen -> {
+            is InitializeScreen -> if (!uiState.value.isInitialized) {
+                updateState { CreateUiState() }
                 initializeDeliveryOptions()
                 autoFillParams(intent.artistId, intent.artistName, intent.productName)
             }
 
-            CreateUiIntent.CleanScreen -> updateState { CreateUiState() }
+            OnCloseBottomSheet -> updateState { copy(showMemberBottomSheet = false) }
 
-            CreateUiIntent.OnBackClick -> {
-                if (uiState.value.isDirty) {
-                    sendEffect(CreateUiEffect.ShowDialog)
-                } else {
-                    updateState { CreateUiState() }
-                    sendEffect(CreateUiEffect.NavigateToBack)
-                }
+            OnCloseDialog -> updateState { copy(showDialog = false) }
+
+            OnBack -> if (uiState.value.isFieldTouched) {
+                updateState { copy(showDialog = true) }
+            } else {
+                updateState { copy(showDialog = false) }
+                sendEffect(NavigateToBack)
+                updateState { copy(isInitialized = false) }
             }
 
-            is CreateUiIntent.OnBackConfirm -> {
-                updateState { CreateUiState() }
-                sendEffect(CreateUiEffect.NavigateToBack)
+            OnBackConfirm -> {
+                updateState { copy(showDialog = false) }
+                sendEffect(NavigateToBack)
+                updateState { copy(isInitialized = false) }
             }
 
-            is CreateUiIntent.OnBackToCreate -> sendEffect(CreateUiEffect.NavigateToBack)
-
-            CreateUiIntent.OnScrollComplete -> updateState { copy(errorIndexToScroll = null) }
-
-            is CreateUiIntent.OnImagesChanged -> {
-                updateState {
-                    copy(
-                        isDirty = true,
-                        selectedImages = intent.uris.toPersistentList(),
-                        imageError = if (intent.uris.isNotEmpty()) null else this.imageError,
-                    )
-                }
+            OnBackToCreate -> {
+                sendEffect(NavigateToBack)
             }
 
-            is CreateUiIntent.OnArtistSelect -> {
-                handleArtistSelect(newArtist = intent.artist)
+            is OnImagesChanged -> updateState {
+                copy(
+                    isFieldTouched = true,
+                    imageUris = intent.uris.toPersistentList(),
+                    imageError = if (intent.uris.isNotEmpty()) null else this.imageError,
+                )
             }
 
-            is CreateUiIntent.OnAccountNumberChange -> {
-                handleAccountNumberChange(newValue = intent.value)
+            OnSearchClick -> sendEffect(NavigateToSearch)
+
+            is OnArtistChange -> updateState { copy(isFieldTouched = true, artistQuery = intent.value) }
+
+            is OnArtistSelect -> handleArtistSelect(newArtist = intent.artist)
+
+            is OnProductFocus -> if (uiState.value.isProductFieldReadOnly && intent.focused) {
+                updateState { copy(productError = FieldError.ARTIST_EMPTY_ERROR, isFieldTouched = true) }
             }
 
-            is CreateUiIntent.OnBankChange -> {
-                handleBankChange(newValue = intent.value)
+            is OnProductChange -> updateState {
+                copy(
+                    isFieldTouched = true,
+                    productName = intent.value,
+                    productError = if (intent.value.isNotBlank()) null else this.productError,
+                    selectedProduct = "",
+                )
             }
 
-            is CreateUiIntent.OnDeadlineChange -> {
-                handleDeadlineChange(newValue = intent.value)
+            is OnProductSelect -> updateState { copy(productName = intent.product, selectedProduct = intent.product) }
+
+            is OnDeadlineChange -> handleDeadlineChange(newValue = intent.value)
+
+            is OnDescriptionChange -> updateState {
+                copy(
+                    isFieldTouched = true,
+                    description = intent.value,
+                    descriptionError = if (intent.value.isNotBlank()) null else this.descriptionError,
+                )
             }
 
-            is CreateUiIntent.OnDeliverySelect -> {
-                handleDeliverySelect(newId = intent.deliveryId)
+            is OnAccountNumberChange -> updateState {
+                copy(
+                    isFieldTouched = true,
+                    accountNumber = intent.value.filter { it.isDigit() },
+                    accountNumberError = if (intent.value.isNotBlank()) null else this.accountNumberError,
+                )
             }
 
-            is CreateUiIntent.OnDescriptionChange -> {
-                handleDescriptionChange(newValue = intent.value)
+            is OnBankChange -> updateState {
+                copy(
+                    isFieldTouched = true,
+                    bank = intent.value,
+                    bankError = if (intent.value.isNotBlank()) null else this.bankError,
+                )
             }
 
-            is CreateUiIntent.OnMemberPriceChange -> {
-                handleMemberPriceChange(newOption = intent.option)
+            OnMemberEditClick -> updateState {
+                copy(
+                    showMemberBottomSheet = true,
+                    isMemberBottomSheetTouched = false,
+                    tempSelectedMembers = this.selectedMembers,
+                )
             }
 
-            is CreateUiIntent.OnProductFocus -> {
-                if (uiState.value.isProductFieldReadOnly && intent.focused) {
-                    updateState { copy(productError = FieldError.ARTIST_EMPTY_ERROR, isDirty = true) }
-                }
-            }
+            is OnMemberSelect -> handleMemberSelect(newMember = intent.member)
 
-            is CreateUiIntent.OnProductChange -> {
-                handleProductChange(newValue = intent.value)
-            }
+            OnAllMemberSelect -> handleAllMemberSelect()
 
-            is CreateUiIntent.OnProductSelect -> {
-                updateState { copy(productName = intent.product, selectedProductName = intent.product) }
-            }
+            OnMemberSelectDone -> handleMemberSelectDone()
 
-            CreateUiIntent.OnSearchClick -> {
-                sendEffect(CreateUiEffect.NavigateToSearch)
-            }
+            is OnMemberPriceChange -> handleMemberPriceChange(newMember = intent.member)
 
-            CreateUiIntent.OnAllMemberSelect -> {
-                handleAllMemberSelect()
-            }
+            is OnDeliverySelect -> handleDeliverySelect(newDelivery = intent.delivery)
 
-            is CreateUiIntent.OnMemberSelect -> {
-                handleMemberSelect(newIndex = intent.index)
-            }
-
-            CreateUiIntent.OnMemberSelectDone -> {
-                handleMemberSelectDone()
-            }
-
-            CreateUiIntent.OnMemberEditClick -> {
-                resetDisplayMembers()
-                sendEffect(CreateUiEffect.ShowBottomSheet)
-            }
-
-            is CreateUiIntent.OnArtistSearchKeywordChange -> {
-                handleArtistSearchKeywordChange(intent.value)
-            }
-
-            CreateUiIntent.OnCreateClick -> {
+            OnCreateClick -> {
                 if (uiState.value.createPartyState is ApiState.Loading) return
                 if (validateInputs()) return
 
-                updateState {
-                    copy(createPartyState = ApiState.Loading)
-                }
+                updateState { copy(createPartyState = ApiState.Loading) }
 
-                sendEffect(CreateUiEffect.ConvertUris)
+                sendEffect(ConvertUris)
             }
 
-            is CreateUiIntent.OnConvertDone -> {
+            is ConvertDone -> {
                 if (intent.result.isEmpty()) {
                     updateState {
                         copy(createPartyState = ApiState.Failure("convert fail"))
@@ -177,25 +174,27 @@ class PartyCreateViewModel @Inject constructor(
                     uploadImagesAndCreateParty(intent.result)
                 }
             }
+
+            ScrollComplete -> updateState { copy(errorIndexToScroll = null) }
         }
     }
 
     init {
         viewModelScope.launch {
-            artistSearchKeywordForDebounce
+            uiState
+                .map { it.artistQuery }
                 .debounce(500)
                 .distinctUntilChanged()
-                .filter { it.isNotBlank() }
                 .collectLatest { keyword ->
                     searchArtist(keyword)
                 }
         }
 
         viewModelScope.launch {
-            productSearchKeywordForDebounce
+            uiState
+                .map { it.productName }
                 .debounce(500)
                 .distinctUntilChanged()
-                .filter { it.isNotBlank() }
                 .collectLatest { keyword ->
                     searchProdut(keyword)
                 }
@@ -217,123 +216,88 @@ class PartyCreateViewModel @Inject constructor(
         )
 
         handleArtistSelect(initialArtist)
-        updateState { copy(productName = productName, neverShowSearchEmptyScreen = true) }
+        updateState { copy(productName = productName, isArtistAutoFilled = true) }
     }
 
     private fun initializeDeliveryOptions() {
         viewModelScope.launch {
             getDeliveryOptionsUseCase()
                 .onSuccess { result ->
+                    val deliveries = result.toPersistentList()
+
                     updateState {
                         copy(
-                            deliveryOptionsState = ApiState.Success(result.toPersistentList()),
-                            editableDeliveryOptions = result.toPersistentList(),
-                            selectedDeliveryIds = this.selectedDeliveryIds + result.first().deliveryId,
+                            deliveriesState = ApiState.Success(deliveries),
+                            rawDeliveries = deliveries,
+                            selectedDeliveries = deliveries,
+                            isInitialized = true,
                         )
                     }
                 }.onFailure { e ->
                     updateState {
                         copy(
-                            deliveryOptionsState = ApiState.Failure(e.message ?: "get delivery fail"),
+                            deliveriesState = ApiState.Failure(e.message ?: "get delivery fail"),
                         )
                     }
                 }
-        }
-    }
-
-    private fun handleAccountNumberChange(newValue: String) {
-        updateState {
-            copy(
-                isDirty = true,
-                accountNumber = newValue.filter { it.isDigit() },
-                accountNumberError = if (newValue.isNotBlank()) null else this.accountNumberError,
-            )
         }
     }
 
     private fun handleArtistSelect(newArtist: ArtistSearchResult) {
-        if (newArtist == uiState.value.selectedArtist) {
-            updateState { copy(artistSearchKeyword = newArtist.name) }
-            return
-        }
+        val needToLoadMembers = newArtist != uiState.value.selectedArtist
 
-        viewModelScope.launch {
-            getMembersWithPriceUseCase(newArtist.artistId)
-                .onSuccess { members ->
-                    val selectedMemberIds = getAllMemberIdSet(members)
-
-                    updateState {
-                        val errorBefore = this.memberSettingStatus == MemberSettingStatus.ERROR_NO_PRICE || this.memberSettingStatus == MemberSettingStatus.ERROR_NO_MEMBER
-                        copy(
-                            isDirty = true,
-                            selectedArtist = newArtist,
-                            artistSearchKeyword = newArtist.name,
-                            artistError = null,
-                            memberOptionsState = ApiState.Success(members.toPersistentList()),
-                            editableMemberOptions = members.toPersistentList(),
-                            selectedMemberIds = selectedMemberIds,
-                            memberSettingStatus = MemberSettingStatus.IN_PROGRESS,
-                            neverShowHint = errorBefore,
-                            productError = if (this.productError == FieldError.ARTIST_EMPTY_ERROR) null else this.productError,
-                        )
-                    }
-                }
-                .onFailure { e ->
-                    updateState {
-                        copy(
-                            memberOptionsState = ApiState.Failure(e.message ?: "get members fail"),
-                        )
-                    }
-                }
-        }
-    }
-
-    private fun getAllMemberIdSet(
-        members: List<MemberPriceOption>,
-    ): Set<Long> = members.map { option -> option.memberId }.toSet()
-
-    private fun handleArtistSearchKeywordChange(newValue: String) {
         updateState {
             copy(
-                isDirty = true,
-                artistSearchKeyword = newValue,
-                neverShowSearchEmptyScreen = false,
+                selectedArtist = newArtist,
+                artistQuery = newArtist.name,
+                artistError = null,
+                isArtistAutoFilled = false,
+                productError = if (this.productError == FieldError.ARTIST_EMPTY_ERROR) null else this.productError,
             )
         }
 
-        artistSearchKeywordForDebounce.value = newValue
+        if (needToLoadMembers) {
+            viewModelScope.launch { getMembersByArtistId(newArtist.artistId) }
+        }
     }
 
-    private suspend fun searchArtist(keyword: String) {
-        searchArtistUseCase(keyword = keyword)
-            .onSuccess { result ->
-                updateState {
-                    copy(
-                        artistSearchResultsState = ApiState.Success(result.toPersistentList()),
-                    )
-                }
-            }
-            .onFailure {
-                updateState {
-                    copy(
-                        artistSearchResultsState = ApiState.Failure(it.message ?: "FAIL"),
-                    )
-                }
-            }
-    }
+    private suspend fun getMembersByArtistId(artistId: Long) = getMembersWithPriceUseCase(artistId)
+        .onSuccess { data ->
+            val members = data.toPersistentList()
 
-    private fun handleProductChange(newValue: String) {
-        updateState {
-            copy(
-                isDirty = true,
-                productName = newValue,
-                productError = if (newValue.isNotBlank()) null else this.productError,
-                selectedProductName = "",
-            )
+            updateState {
+                copy(
+                    membersState = ApiState.Success(members),
+                    rawMembers = members,
+                    selectedMembers = members,
+                    memberSettingStatus = MemberSettingStatus.EDITABLE,
+                    memberError = null
+                )
+            }
+        }
+        .onFailure { e ->
+            updateState {
+                copy(
+                    membersState = ApiState.Failure(e.message ?: "get members fail"),
+                )
+            }
         }
 
-        productSearchKeywordForDebounce.value = newValue
-    }
+    private suspend fun searchArtist(keyword: String) = searchArtistUseCase(keyword = keyword)
+        .onSuccess { result ->
+            updateState {
+                copy(
+                    artistSearchState = ApiState.Success(result.toPersistentList()),
+                )
+            }
+        }
+        .onFailure {
+            updateState {
+                copy(
+                    artistSearchState = ApiState.Failure(it.message ?: "artist search fail"),
+                )
+            }
+        }
 
     private suspend fun searchProdut(keyword: String) {
         uiState.value.selectedArtist?.let { artist ->
@@ -344,27 +308,17 @@ class PartyCreateViewModel @Inject constructor(
                 .onSuccess { result ->
                     updateState {
                         copy(
-                            productSearchResultsState = ApiState.Success(result.toPersistentList()),
+                            productSearchState = ApiState.Success(result.toPersistentList()),
                         )
                     }
                 }
                 .onFailure {
                     updateState {
                         copy(
-                            productSearchResultsState = ApiState.Failure(it.message ?: "FAIL"),
+                            productSearchState = ApiState.Failure(it.message ?: "product search fail"),
                         )
                     }
                 }
-        }
-    }
-
-    private fun handleBankChange(newValue: String) {
-        updateState {
-            copy(
-                isDirty = true,
-                bank = newValue,
-                bankError = if (newValue.isNotBlank()) null else this.bankError,
-            )
         }
     }
 
@@ -373,177 +327,129 @@ class PartyCreateViewModel @Inject constructor(
 
         updateState {
             copy(
-                isDirty = true,
+                isFieldTouched = true,
                 deadline = newValue,
                 deadlineError = if (newValue.isNotBlank()) null else this.deadlineError,
             )
         }
     }
 
-    private fun handleDescriptionChange(newValue: String) {
-        updateState {
-            copy(
-                isDirty = true,
-                description = newValue,
-                descriptionError = if (newValue.isNotBlank()) null else this.descriptionError,
-            )
-        }
-    }
-
-    private fun handleDeliverySelect(newId: Long) {
-        val currentIds = uiState.value.selectedDeliveryIds
-        if (currentIds.size < 2 && newId in currentIds) return
-
-        val newIds = if (newId in currentIds) {
-            currentIds - newId
+    private fun handleAllMemberSelect() {
+        val newMembers = if (uiState.value.rawMembers.size == uiState.value.tempSelectedMembers.size) {
+            persistentListOf()
         } else {
-            currentIds + newId
+            uiState.value.rawMembers
         }
 
         updateState {
             copy(
-                isDirty = true,
-                selectedDeliveryIds = newIds,
+                tempSelectedMembers = newMembers,
+                isMemberBottomSheetTouched = true,
             )
         }
     }
 
-    private fun handleMemberPriceChange(newOption: MemberPriceOption) {
-        var currentPrice: String? = null
+    private fun handleMemberSelect(newMember: MemberPriceOption) {
+        val currentMembers = uiState.value.tempSelectedMembers
 
-        val newOptions = uiState.value.editableMemberOptions.map { option ->
-            if (option.memberId == newOption.memberId) {
-                currentPrice = option.price
-                newOption
-            } else {
-                option
-            }
+        val newMembers = if (currentMembers.any { it.memberId == newMember.memberId }) {
+            currentMembers.filter { it.memberId != newMember.memberId }
+        } else {
+            currentMembers + newMember
         }.toPersistentList()
 
-        val clearError = currentPrice.isNullOrBlank() && newOption.price.isNotBlank()
-
         updateState {
             copy(
-                editableMemberOptions = newOptions,
-                memberSettingStatus = if (clearError) MemberSettingStatus.IN_PROGRESS else this.memberSettingStatus,
-            )
-        }
-    }
-
-    private fun handleMemberSelect(newIndex: Int) {
-        val currentIndices = uiState.value.sheetDisplayMemberIndices
-
-        val newIndices = if (newIndex in currentIndices) {
-            currentIndices - newIndex
-        } else {
-            currentIndices + newIndex
-        }
-
-        updateState {
-            copy(
-                sheetDisplayMemberIndices = newIndices,
-                isSheetTouched = true,
-            )
-        }
-    }
-
-    private fun resetDisplayMembers() {
-        val selectedIndices = uiState.value.editableMemberOptions.mapIndexedNotNull { index, option ->
-            if (option.memberId in uiState.value.selectedMemberIds) {
-                index
-            } else {
-                null
-            }
-        }.toSet()
-
-        updateState {
-            copy(
-                sheetDisplayMemberIndices = selectedIndices,
-                isSheetTouched = false,
-            )
-        }
-    }
-
-    private fun handleAllMemberSelect() {
-        val newIndices = if (uiState.value.sheetDisplayMemberIndices.size == uiState.value.editableMemberOptions.size) {
-            setOf()
-        } else {
-            uiState.value.editableMemberOptions.indices.toSet()
-        }
-
-        updateState {
-            copy(
-                sheetDisplayMemberIndices = newIndices,
-                isSheetTouched = true,
+                tempSelectedMembers = newMembers,
+                isMemberBottomSheetTouched = true,
             )
         }
     }
 
     private fun handleMemberSelectDone() {
-        val newIds = uiState.value.editableMemberOptions.mapIndexedNotNull { index, option ->
-            if (index in uiState.value.sheetDisplayMemberIndices) {
-                option.memberId
-            } else {
-                null
+        val selectedMembers = uiState.value.tempSelectedMembers.sortedBy { temp ->
+            uiState.value.rawMembers.indexOfFirst { raw ->
+                raw.memberId == temp.memberId
             }
-        }.toSet()
-
-        val newMemberOptions = clearUnselectedOptionPrices(newIds)
+        }.toPersistentList()
 
         updateState {
             copy(
-                selectedMemberIds = newIds,
-                editableMemberOptions = newMemberOptions,
-                memberSettingStatus = if (newIds.isNotEmpty()) MemberSettingStatus.IN_PROGRESS else this.memberSettingStatus,
+                selectedMembers = selectedMembers,
+                memberSettingStatus = if (selectedMembers.isEmpty()) MemberSettingStatus.MEMBER_NOT_SELECTED else MemberSettingStatus.EDITABLE,
+                showMemberBottomSheet = false,
             )
         }
     }
 
-    private fun clearUnselectedOptionPrices(newIds: Set<Long>): ImmutableList<MemberPriceOption> {
-        return uiState.value.editableMemberOptions.map { option ->
-            if (option.memberId in newIds) {
-                option
-            } else {
-                option.copy(price = "")
-            }
+    private fun handleMemberPriceChange(newMember: MemberPriceOption) {
+        val newMembers = uiState.value.selectedMembers.map { member ->
+            if (member.memberId == newMember.memberId) newMember
+            else member
         }.toPersistentList()
+
+        updateState {
+            copy(
+                selectedMembers = newMembers,
+                memberError = if (!hasInvalidPrice()) null else this.memberError,
+            )
+        }
     }
 
+    private fun handleDeliverySelect(newDelivery: DeliveryOption) {
+        val currentDeliveries = uiState.value.selectedDeliveries
+
+        if (currentDeliveries.size < 2 && newDelivery in currentDeliveries) return
+
+        val newDeliveries = if (currentDeliveries.any { it.deliveryId == newDelivery.deliveryId }) {
+            currentDeliveries.filter { it.deliveryId != newDelivery.deliveryId }
+        } else {
+            currentDeliveries + newDelivery
+        }.toPersistentList()
+
+        updateState {
+            copy(
+                selectedDeliveries = newDeliveries,
+                isFieldTouched = true,
+            )
+        }
+    }
+
+    private fun hasInvalidPrice(): Boolean =
+        uiState.value.selectedMembers.any { it.price == "0" || it.price.isBlank() }
+
     private fun validateInputs(): Boolean {
-        val imageError = if (uiState.value.selectedImages.isEmpty()) FieldError.IMAGE_EMPTY_ERROR else null
+        val imageError = if (uiState.value.imageUris.isEmpty()) FieldError.IMAGE_EMPTY_ERROR else null
         val artistError = if (uiState.value.selectedArtist == null) FieldError.ARTIST_EMPTY_ERROR else null
         val productError = if (uiState.value.productName.isBlank()) FieldError.PRODUCT_EMPTY_ERROR else null
-        val deadlineError = when (val date = uiState.value.deadline.toDateOrNull()) {
-            null -> if (uiState.value.deadline.isBlank()) {
-                FieldError.DEADLINE_EMPTY_ERROR
-            } else {
-                FieldError.DEADLINE_INVALID_ERROR
+        val deadlineError = when (uiState.value.deadline.isBlank()) {
+            true -> FieldError.DEADLINE_EMPTY_ERROR
+            false -> {
+                val date = uiState.value.deadline.toDateOrNull()
+                when {
+                    date == null -> FieldError.DEADLINE_INVALID_ERROR
+                    !date.isTodayOrAfter() -> FieldError.DEADLINE_PAST_ERROR
+                    else -> null
+                }
             }
-
-            else -> if (!date.isTodayOrAfter()) FieldError.DEADLINE_PAST_ERROR else null
         }
         val descriptionError = if (uiState.value.description.isBlank()) FieldError.DESCRIPTION_ERROR else null
         val accountNumberError = if (uiState.value.accountNumber.isBlank()) FieldError.ACCOUNT_NUMBER_ERROR else null
         val bankError = if (uiState.value.bank.isBlank()) FieldError.BANK_ERROR else null
-
-        val selectedMemberIds = uiState.value.selectedMemberIds
-        val currentSettingStatus = when {
-            selectedMemberIds.isEmpty() -> MemberSettingStatus.ERROR_NO_MEMBER
-            uiState.value.editableMemberOptions.isEmpty() -> MemberSettingStatus.DEFAULT
-            uiState.value.editableMemberOptions.any { option -> option.memberId in selectedMemberIds && option.price.isBlank() } -> MemberSettingStatus.ERROR_NO_PRICE
-            else -> uiState.value.memberSettingStatus
+        val memberError = when {
+            uiState.value.selectedMembers.isEmpty() -> FieldError.MEMBER_EMPTY_ERROR
+            hasInvalidPrice() -> FieldError.MEMBER_PRICE_ERROR
+            else -> null
         }
-
-        val hasMemberOptionError = currentSettingStatus == MemberSettingStatus.ERROR_NO_MEMBER || currentSettingStatus == MemberSettingStatus.ERROR_NO_PRICE
 
         val hasError = imageError != null || artistError != null || productError != null ||
             deadlineError != null || descriptionError != null ||
-            accountNumberError != null || bankError != null || hasMemberOptionError
+            accountNumberError != null || bankError != null || memberError != null
 
         if (hasError) {
             updateState {
                 copy(
-                    isDirty = true,
+                    isFieldTouched = true,
                     imageError = imageError,
                     artistError = artistError,
                     productError = productError,
@@ -551,8 +457,7 @@ class PartyCreateViewModel @Inject constructor(
                     descriptionError = descriptionError,
                     accountNumberError = accountNumberError,
                     bankError = bankError,
-                    memberSettingStatus = currentSettingStatus,
-                    neverShowHint = if (hasMemberOptionError) true else this.neverShowHint,
+                    memberError = memberError,
                 )
             }
             getScrollIndex()?.let {
@@ -572,61 +477,50 @@ class PartyCreateViewModel @Inject constructor(
             uiState.value.descriptionError != null -> 4
             uiState.value.accountNumberError != null -> 5
             uiState.value.bankError != null -> 6
-            uiState.value.memberSettingStatus == MemberSettingStatus.ERROR_NO_PRICE || uiState.value.memberSettingStatus == MemberSettingStatus.ERROR_NO_MEMBER -> 7
+            uiState.value.memberError != null -> 7
             else -> null
         }
 
         return firstErrorFieldIndex
     }
 
-    private suspend fun uploadPartyInfo(
-        urls: List<String>,
-    ): Result<Long> =
-        createPartyUseCase(
-            artistId = uiState.value.selectedArtist?.artistId ?: 0L,
-            product = uiState.value.productName,
-            description = uiState.value.description,
-            deadline = uiState.value.deadline.toDashedDate(),
-            bank = uiState.value.bank,
-            accountNumber = uiState.value.accountNumber,
-            imageUrls = urls,
-            options = uiState.value.editableMemberOptions.filter { option -> option.memberId in uiState.value.selectedMemberIds },
-            shippings = uiState.value.editableDeliveryOptions.filter { option -> option.deliveryId in uiState.value.selectedDeliveryIds },
-        )
+    private suspend fun uploadPartyInfo(urls: List<String>): Result<Long> = createPartyUseCase(
+        artistId = uiState.value.selectedArtist?.artistId ?: 0L,
+        product = uiState.value.productName,
+        description = uiState.value.description,
+        deadline = uiState.value.deadline.toDashedDate(),
+        bank = uiState.value.bank,
+        accountNumber = uiState.value.accountNumber,
+        imageUrls = urls,
+        options = uiState.value.selectedMembers,
+        shippings = uiState.value.selectedDeliveries,
+    )
 
-    private suspend fun uploadImagesAndCreateParty(
-        imageInfos: List<ImageInfoForPresigned>,
-    ) {
-        uploadImagesUseCase(IMAGE_TYPE, imageInfos)
-            .onSuccess { urls ->
-                createParty(urls)
+    private suspend fun uploadImagesAndCreateParty(imageInfos: List<ImageInfoForPresigned>) = uploadImagesUseCase(IMAGE_TYPE, imageInfos)
+        .onSuccess { urls ->
+            createParty(urls)
+        }
+        .onFailure {
+            updateState {
+                copy(
+                    createPartyState = ApiState.Failure(it.message ?: "image upload fail"),
+                )
             }
-            .onFailure {
-                updateState {
-                    copy(
-                        createPartyState = ApiState.Failure(it.message ?: "image upload fail"),
-                    )
-                }
-            }
-    }
+        }
 
-    private suspend fun createParty(
-        urls: List<String>,
-    ) {
-        uploadPartyInfo(urls)
-            .onSuccess { partyId ->
-                updateState {
-                    copy(createPartyState = ApiState.Success(partyId))
-                }
-                sendEffect(CreateUiEffect.NavigateToDetail(partyId))
-                updateState { CreateUiState() }
+    private suspend fun createParty(urls: List<String>) = uploadPartyInfo(urls)
+        .onSuccess { partyId ->
+            updateState {
+                copy(createPartyState = ApiState.Success(partyId))
             }
-            .onFailure {
-                updateState {
-                    copy(
-                        createPartyState = ApiState.Failure(it.message ?: "create party fail"),
-                    )
-                }
+            sendEffect(NavigateToDetail(partyId))
+            updateState { CreateUiState() }
+        }
+        .onFailure {
+            updateState {
+                copy(
+                    createPartyState = ApiState.Failure(it.message ?: "create party fail"),
+                )
             }
-    }
+        }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -196,7 +196,7 @@ class PartyCreateViewModel @Inject constructor(
                 .debounce(500)
                 .distinctUntilChanged()
                 .collectLatest { keyword ->
-                    searchProdut(keyword)
+                    searchProduct(keyword)
                 }
         }
     }
@@ -299,7 +299,7 @@ class PartyCreateViewModel @Inject constructor(
             }
         }
 
-    private suspend fun searchProdut(keyword: String) {
+    private suspend fun searchProduct(keyword: String) {
         uiState.value.selectedArtist?.let { artist ->
             searchProductUseCase(
                 keyword = keyword,

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -28,6 +28,7 @@ import com.poti.android.presentation.party.create.util.isTodayOrAfter
 import com.poti.android.presentation.party.create.util.toDashedDate
 import com.poti.android.presentation.party.create.util.toDateOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.FlowPreview
@@ -409,7 +410,7 @@ class PartyCreateViewModel @Inject constructor(
         updateState {
             copy(
                 selectedMembers = newMembers,
-                memberError = if (!hasInvalidPrice()) null else this.memberError,
+                memberError = if (!hasInvalidPrice(newMembers)) null else this.memberError,
             )
         }
     }
@@ -432,8 +433,8 @@ class PartyCreateViewModel @Inject constructor(
         }
     }
 
-    private fun hasInvalidPrice(): Boolean =
-        uiState.value.selectedMembers.any { it.price == "0" || it.price.isBlank() }
+    private fun hasInvalidPrice(members: ImmutableList<MemberPriceOption>): Boolean =
+        members.any { it.price == "0" || it.price.isBlank() }
 
     private fun validateInputs(): Boolean {
         val imageError = if (uiState.value.imageUris.isEmpty()) FieldError.IMAGE_EMPTY_ERROR else null
@@ -455,7 +456,7 @@ class PartyCreateViewModel @Inject constructor(
         val bankError = if (uiState.value.bank.isBlank()) FieldError.BANK_ERROR else null
         val memberError = when {
             uiState.value.selectedMembers.isEmpty() -> FieldError.MEMBER_EMPTY_ERROR
-            hasInvalidPrice() -> FieldError.MEMBER_PRICE_ERROR
+            hasInvalidPrice(uiState.value.selectedMembers) -> FieldError.MEMBER_PRICE_ERROR
             else -> null
         }
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -15,7 +15,9 @@ import com.poti.android.domain.usecase.party.GetDeliveryOptionsUseCase
 import com.poti.android.domain.usecase.party.SearchArtistUseCase
 import com.poti.android.domain.usecase.party.SearchProductUseCase
 import com.poti.android.presentation.party.create.model.CreateUiEffect
+import com.poti.android.presentation.party.create.model.CreateUiEffect.*
 import com.poti.android.presentation.party.create.model.CreateUiIntent
+import com.poti.android.presentation.party.create.model.CreateUiIntent.*
 import com.poti.android.presentation.party.create.model.CreateUiState
 import com.poti.android.presentation.party.create.model.FieldError
 import com.poti.android.presentation.party.create.model.MemberSettingStatus
@@ -23,17 +25,15 @@ import com.poti.android.presentation.party.create.util.isTodayOrAfter
 import com.poti.android.presentation.party.create.util.toDashedDate
 import com.poti.android.presentation.party.create.util.toDateOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.launch
-import javax.inject.Inject
-import com.poti.android.presentation.party.create.model.CreateUiIntent.*
-import com.poti.android.presentation.party.create.model.CreateUiEffect.*
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 import kotlin.text.filter
 
 const val IMAGE_TYPE = "POST"
@@ -48,8 +48,8 @@ class PartyCreateViewModel @Inject constructor(
     private val searchProductUseCase: SearchProductUseCase,
     private val createPartyUseCase: CreatePartyUseCase,
 ) : BaseViewModel<CreateUiState, CreateUiIntent, CreateUiEffect>(
-    initialState = CreateUiState(),
-) {
+        initialState = CreateUiState(),
+    ) {
     override fun processIntent(intent: CreateUiIntent) {
         when (intent) {
             is InitializeScreen -> if (!uiState.value.isInitialized) {
@@ -271,7 +271,7 @@ class PartyCreateViewModel @Inject constructor(
                     rawMembers = members,
                     selectedMembers = members,
                     memberSettingStatus = MemberSettingStatus.EDITABLE,
-                    memberError = null
+                    memberError = null,
                 )
             }
         }
@@ -384,8 +384,11 @@ class PartyCreateViewModel @Inject constructor(
 
     private fun handleMemberPriceChange(newMember: MemberPriceOption) {
         val newMembers = uiState.value.selectedMembers.map { member ->
-            if (member.memberId == newMember.memberId) newMember
-            else member
+            if (member.memberId == newMember.memberId) {
+                newMember
+            } else {
+                member
+            }
         }.toPersistentList()
 
         updateState {

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -1,7 +1,9 @@
 package com.poti.android.presentation.party.create
 
 import androidx.core.text.isDigitsOnly
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.model.artist.ArtistSearchResult
@@ -21,6 +23,7 @@ import com.poti.android.presentation.party.create.model.CreateUiIntent.*
 import com.poti.android.presentation.party.create.model.CreateUiState
 import com.poti.android.presentation.party.create.model.FieldError
 import com.poti.android.presentation.party.create.model.MemberSettingStatus
+import com.poti.android.presentation.party.create.navigation.PartyCreateGraph
 import com.poti.android.presentation.party.create.util.isTodayOrAfter
 import com.poti.android.presentation.party.create.util.toDashedDate
 import com.poti.android.presentation.party.create.util.toDateOrNull
@@ -47,17 +50,14 @@ class PartyCreateViewModel @Inject constructor(
     private val searchArtistUseCase: SearchArtistUseCase,
     private val searchProductUseCase: SearchProductUseCase,
     private val createPartyUseCase: CreatePartyUseCase,
+    savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<CreateUiState, CreateUiIntent, CreateUiEffect>(
-        initialState = CreateUiState(),
-    ) {
+    initialState = CreateUiState(),
+) {
+    private val params = savedStateHandle.toRoute<PartyCreateGraph>()
+
     override fun processIntent(intent: CreateUiIntent) {
         when (intent) {
-            is InitializeScreen -> if (!uiState.value.isInitialized) {
-                updateState { CreateUiState() }
-                initializeDeliveryOptions()
-                autoFillParams(intent.artistId, intent.artistName, intent.productName)
-            }
-
             OnCloseBottomSheet -> updateState { copy(showMemberBottomSheet = false) }
 
             OnCloseDialog -> updateState { copy(showDialog = false) }
@@ -67,13 +67,11 @@ class PartyCreateViewModel @Inject constructor(
             } else {
                 updateState { copy(showDialog = false) }
                 sendEffect(NavigateToBack)
-                updateState { copy(isInitialized = false) }
             }
 
             OnBackConfirm -> {
                 updateState { copy(showDialog = false) }
                 sendEffect(NavigateToBack)
-                updateState { copy(isInitialized = false) }
             }
 
             OnBackToCreate -> {
@@ -180,6 +178,9 @@ class PartyCreateViewModel @Inject constructor(
     }
 
     init {
+        initializeDeliveryOptions()
+        autoFillParams(params.artistId, params.artistName, params.productName)
+
         viewModelScope.launch {
             uiState
                 .map { it.artistSearchKeyword }
@@ -230,7 +231,6 @@ class PartyCreateViewModel @Inject constructor(
                             deliveriesState = ApiState.Success(deliveries),
                             rawDeliveries = deliveries,
                             selectedDeliveries = deliveries,
-                            isInitialized = true,
                         )
                     }
                 }.onFailure { e ->
@@ -517,7 +517,6 @@ class PartyCreateViewModel @Inject constructor(
                 copy(createPartyState = ApiState.Success(partyId))
             }
             sendEffect(NavigateToDetail(partyId))
-            updateState { CreateUiState() }
         }
         .onFailure {
             updateState {

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -83,7 +83,6 @@ class PartyCreateViewModel @Inject constructor(
 
             is OnImagesChanged -> updateState {
                 copy(
-                    isFieldTouched = true,
                     imageUris = intent.uris.toPersistentList(),
                     imageError = if (intent.uris.isNotEmpty()) null else this.imageError,
                 )
@@ -91,17 +90,16 @@ class PartyCreateViewModel @Inject constructor(
 
             OnSearchClick -> sendEffect(NavigateToSearch)
 
-            is OnArtistChange -> updateState { copy(isFieldTouched = true, artistSearchKeyword = intent.value) }
+            is OnArtistChange -> updateState { copy(artistSearchKeyword = intent.value) }
 
             is OnArtistSelect -> handleArtistSelect(newArtist = intent.artist)
 
             is OnProductFocus -> if (uiState.value.isProductFieldReadOnly && intent.focused) {
-                updateState { copy(productError = FieldError.ARTIST_EMPTY_ERROR, isFieldTouched = true) }
+                updateState { copy(productError = FieldError.ARTIST_EMPTY_ERROR) }
             }
 
             is OnProductChange -> updateState {
                 copy(
-                    isFieldTouched = true,
                     productName = intent.value,
                     productError = if (intent.value.isNotBlank()) null else this.productError,
                     selectedProduct = "",
@@ -114,7 +112,6 @@ class PartyCreateViewModel @Inject constructor(
 
             is OnDescriptionChange -> updateState {
                 copy(
-                    isFieldTouched = true,
                     description = intent.value,
                     descriptionError = if (intent.value.isNotBlank()) null else this.descriptionError,
                 )
@@ -122,7 +119,6 @@ class PartyCreateViewModel @Inject constructor(
 
             is OnAccountNumberChange -> updateState {
                 copy(
-                    isFieldTouched = true,
                     accountNumber = intent.value.filter { it.isDigit() },
                     accountNumberError = if (intent.value.isNotBlank()) null else this.accountNumberError,
                 )
@@ -130,7 +126,6 @@ class PartyCreateViewModel @Inject constructor(
 
             is OnBankChange -> updateState {
                 copy(
-                    isFieldTouched = true,
                     bank = intent.value,
                     bankError = if (intent.value.isNotBlank()) null else this.bankError,
                 )
@@ -348,7 +343,6 @@ class PartyCreateViewModel @Inject constructor(
 
         updateState {
             copy(
-                isFieldTouched = true,
                 deadline = newValue,
                 deadlineError = if (newValue.isNotBlank()) null else this.deadlineError,
             )
@@ -434,7 +428,6 @@ class PartyCreateViewModel @Inject constructor(
         updateState {
             copy(
                 selectedDeliveries = newDeliveries,
-                isFieldTouched = true,
             )
         }
     }
@@ -473,7 +466,6 @@ class PartyCreateViewModel @Inject constructor(
         if (hasError) {
             updateState {
                 copy(
-                    isFieldTouched = true,
                     imageError = imageError,
                     artistError = artistError,
                     productError = productError,

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/CreateDeliverySetting.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/CreateDeliverySetting.kt
@@ -19,9 +19,9 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun CreateDeliverySetting(
-    deliveryOptions: ImmutableList<DeliveryOption>,
-    selectedOptionIds: Set<Long>,
-    onDeliveryOptionClick: (Long) -> Unit,
+    allDeliveries: ImmutableList<DeliveryOption>,
+    selectedDeliveries: ImmutableList<DeliveryOption>,
+    onDeliveryClick: (DeliveryOption) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -42,13 +42,13 @@ fun CreateDeliverySetting(
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            deliveryOptions.forEach { option ->
+            allDeliveries.forEach { option ->
                 EditOptionPrice(
                     option = option.name,
                     value = option.price.toString(),
                     onValueChanged = {},
-                    isChecked = option.deliveryId in selectedOptionIds,
-                    onCheckboxClick = { onDeliveryOptionClick(option.deliveryId) },
+                    isChecked = selectedDeliveries.any { it.deliveryId == option.deliveryId },
+                    onCheckboxClick = { onDeliveryClick(option) },
                     enabled = false,
                 )
             }
@@ -64,13 +64,11 @@ private fun CreateDeliverySettingPreview() {
         DeliveryOption(deliveryId = 2, name = "준등기", price = 1800),
     )
 
-    val selectedOptionIds = setOf(1.toLong())
-
     PotiTheme {
         CreateDeliverySetting(
-            deliveryOptions = deliveryOptions,
-            selectedOptionIds = selectedOptionIds,
-            onDeliveryOptionClick = {},
+            allDeliveries = deliveryOptions,
+            selectedDeliveries = deliveryOptions,
+            onDeliveryClick = {},
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/CreateMemberSetting.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/CreateMemberSetting.kt
@@ -88,7 +88,7 @@ fun CreateMemberSetting(
         }
 
         when (status) {
-            MemberSettingStatus.ARTITST_NOT_SELECTED -> PotiEmptyStateInline(stringResource(R.string.create_placeholder_need_artist))
+            MemberSettingStatus.ARTIST_NOT_SELECTED -> PotiEmptyStateInline(stringResource(R.string.create_placeholder_need_artist))
             MemberSettingStatus.MEMBER_NOT_SELECTED -> PotiEmptyStateInline(stringResource(R.string.create_placeholder_need_member))
             MemberSettingStatus.EDITABLE -> {
                 Column {
@@ -115,7 +115,7 @@ fun CreateMemberSetting(
             }
         }
 
-        if (status != MemberSettingStatus.ARTITST_NOT_SELECTED) {
+        if (status != MemberSettingStatus.ARTIST_NOT_SELECTED) {
             Box {
                 PotiInlineButton(
                     text = stringResource(R.string.create_btn_member_edit),
@@ -153,7 +153,7 @@ private fun CreateMemberSettingPreview() {
             verticalArrangement = Arrangement.spacedBy(40.dp),
         ) {
             CreateMemberSetting(
-                status = MemberSettingStatus.ARTITST_NOT_SELECTED,
+                status = MemberSettingStatus.ARTIST_NOT_SELECTED,
                 selectedMembers = persistentListOf(),
                 onPriceChange = {},
                 onEditBtnClick = {},

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/CreateMemberSetting.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/CreateMemberSetting.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
+import com.poti.android.core.common.util.screenWidthDp
 import com.poti.android.core.designsystem.component.button.PotiInlineButton
 import com.poti.android.core.designsystem.component.display.PotiEmptyStateInline
 import com.poti.android.core.designsystem.component.display.PotiErrorMessage
@@ -41,16 +42,13 @@ private const val BOTTOM_BTN_HEIGHT_DP = 70
 @Composable
 fun CreateMemberSetting(
     status: MemberSettingStatus,
-    selectedMembersOption: ImmutableList<MemberPriceOption>,
+    selectedMembers: ImmutableList<MemberPriceOption>,
     onPriceChange: (MemberPriceOption) -> Unit,
     onEditBtnClick: () -> Unit,
+    showHint: Boolean,
+    errorMessage: String,
     modifier: Modifier = Modifier,
-    neverShowHint: Boolean = false,
 ) {
-    var showHint by remember(status, neverShowHint) {
-        mutableStateOf(if (neverShowHint) false else status != MemberSettingStatus.DEFAULT)
-    }
-
     var isEditBtnInScreen by remember { mutableStateOf(false) }
     val density = LocalDensity.current
     val configuration = LocalConfiguration.current
@@ -66,9 +64,11 @@ fun CreateMemberSetting(
         with(density) { BOTTOM_BTN_HEIGHT_DP.dp.roundToPx() }
     }
 
+    var hideHint by remember { mutableStateOf(false) }
+
     Column(
         modifier = modifier
-            .padding(vertical = 24.dp, horizontal = 16.dp),
+            .padding(vertical = 24.dp, horizontal = screenWidthDp(16.dp)),
         verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
         Row(
@@ -82,20 +82,18 @@ fun CreateMemberSetting(
                 style = PotiTheme.typography.title18sb,
             )
 
-            when (status) {
-                MemberSettingStatus.ERROR_NO_MEMBER -> PotiErrorMessage(stringResource(R.string.create_msg_need_member))
-                MemberSettingStatus.ERROR_NO_PRICE -> PotiErrorMessage(stringResource(R.string.create_msg_need_price))
-                else -> Unit
+            if (errorMessage.isNotEmpty()) {
+                PotiErrorMessage(errorMessage)
             }
         }
 
-        when {
-            status == MemberSettingStatus.DEFAULT -> PotiEmptyStateInline(stringResource(R.string.create_placeholder_need_artist))
-            selectedMembersOption.isEmpty() -> PotiEmptyStateInline(stringResource(R.string.create_placeholder_need_member))
-            else -> {
+        when (status) {
+            MemberSettingStatus.ARTITST_NOT_SELECTED -> PotiEmptyStateInline(stringResource(R.string.create_placeholder_need_artist))
+            MemberSettingStatus.MEMBER_NOT_SELECTED -> PotiEmptyStateInline(stringResource(R.string.create_placeholder_need_member))
+            MemberSettingStatus.EDITABLE -> {
                 Column {
-                    selectedMembersOption.forEachIndexed { index, option ->
-                        val isLastOption = index == selectedMembersOption.size - 1
+                    selectedMembers.forEachIndexed { index, option ->
+                        val isLastOption = index == selectedMembers.size - 1
 
                         EditOptionPrice(
                             option = option.name,
@@ -110,23 +108,19 @@ fun CreateMemberSetting(
                             },
                             modifier = Modifier.padding(bottom = if (isLastOption) 0.dp else 20.dp),
                             imeAction = if (isLastOption) ImeAction.Done else ImeAction.Next,
-                            onFocusChanged = { focused ->
-                                if (focused) {
-                                    showHint = false
-                                }
-                            },
+                            onFocusChanged = { _ -> hideHint = true },
                         )
                     }
                 }
             }
         }
 
-        if (status != MemberSettingStatus.DEFAULT) {
+        if (status != MemberSettingStatus.ARTITST_NOT_SELECTED) {
             Box {
                 PotiInlineButton(
                     text = stringResource(R.string.create_btn_member_edit),
                     onClick = {
-                        showHint = false
+                        hideHint = true
                         onEditBtnClick()
                     },
                     modifier = Modifier
@@ -137,7 +131,7 @@ fun CreateMemberSetting(
                         },
                 )
 
-                if (showHint && isEditBtnInScreen && !isKeyboardVisible) {
+                if (!hideHint && showHint && isEditBtnInScreen && !isKeyboardVisible) {
                     HintToolTip()
                 }
             }
@@ -159,46 +153,34 @@ private fun CreateMemberSettingPreview() {
             verticalArrangement = Arrangement.spacedBy(40.dp),
         ) {
             CreateMemberSetting(
-                status = MemberSettingStatus.DEFAULT,
-                selectedMembersOption = persistentListOf(),
+                status = MemberSettingStatus.ARTITST_NOT_SELECTED,
+                selectedMembers = persistentListOf(),
                 onPriceChange = {},
                 onEditBtnClick = {},
+                showHint = true,
+                errorMessage = "",
             )
 
             CreateMemberSetting(
-                status = MemberSettingStatus.IN_PROGRESS,
-                selectedMembersOption = persistentListOf(),
+                status = MemberSettingStatus.MEMBER_NOT_SELECTED,
+                selectedMembers = persistentListOf(),
                 onPriceChange = {},
                 onEditBtnClick = {},
+                showHint = true,
+                errorMessage = "",
             )
 
             CreateMemberSetting(
-                status = MemberSettingStatus.IN_PROGRESS,
-                selectedMembersOption = persistentListOf(
+                status = MemberSettingStatus.EDITABLE,
+                selectedMembers = persistentListOf(
                     MemberPriceOption(memberId = 1, name = "원영", price = "5000"),
                     MemberPriceOption(memberId = 1, name = "유진", price = ""),
                     MemberPriceOption(memberId = 1, name = "레이", price = "4000"),
                 ),
                 onPriceChange = {},
                 onEditBtnClick = {},
-            )
-
-            CreateMemberSetting(
-                status = MemberSettingStatus.ERROR_NO_MEMBER,
-                selectedMembersOption = persistentListOf(),
-                onPriceChange = {},
-                onEditBtnClick = {},
-            )
-
-            CreateMemberSetting(
-                status = MemberSettingStatus.ERROR_NO_PRICE,
-                selectedMembersOption = persistentListOf(
-                    MemberPriceOption(memberId = 1, name = "원영", price = "5000"),
-                    MemberPriceOption(memberId = 1, name = "유진", price = ""),
-                    MemberPriceOption(memberId = 1, name = "레이", price = "4000"),
-                ),
-                onPriceChange = {},
-                onEditBtnClick = {},
+                showHint = true,
+                errorMessage = "모든 멤버에 가격을 설정해주세요",
             )
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/CreateMemberSetting.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/CreateMemberSetting.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -37,31 +36,19 @@ import com.poti.android.presentation.party.create.model.MemberSettingStatus
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-private const val BOTTOM_BTN_HEIGHT_DP = 70
-
 @Composable
 fun CreateMemberSetting(
     status: MemberSettingStatus,
     selectedMembers: ImmutableList<MemberPriceOption>,
     onPriceChange: (MemberPriceOption) -> Unit,
     onEditBtnClick: () -> Unit,
+    layoutBottom: Float,
     errorMessage: String,
     modifier: Modifier = Modifier,
 ) {
-    var isEditBtnInScreen by remember { mutableStateOf(false) }
+    var isEditBtnInLayout by remember { mutableStateOf(false) }
     val density = LocalDensity.current
-    val configuration = LocalConfiguration.current
     val isKeyboardVisible = WindowInsets.ime.getBottom(density) > 0
-
-    val screenHeight = remember(configuration.screenHeightDp) {
-        with(density) {
-            configuration.screenHeightDp.dp.roundToPx()
-        }
-    }
-
-    val bottomBtnHeight = remember {
-        with(density) { BOTTOM_BTN_HEIGHT_DP.dp.roundToPx() }
-    }
 
     var hideHint by remember { mutableStateOf(false) }
 
@@ -125,12 +112,15 @@ fun CreateMemberSetting(
                     modifier = Modifier
                         .fillMaxWidth()
                         .onGloballyPositioned { coordinates ->
-                            val buttonTop = coordinates.positionInWindow().y
-                            isEditBtnInScreen = buttonTop < screenHeight - bottomBtnHeight
+                            val top = coordinates.positionInWindow().y
+                            val isVisible = (top < layoutBottom) && (top > 0)
+                            if (isEditBtnInLayout != isVisible) {
+                                isEditBtnInLayout = isVisible
+                            }
                         },
                 )
 
-                if (!hideHint && isEditBtnInScreen && !isKeyboardVisible) {
+                if (!hideHint && isEditBtnInLayout && !isKeyboardVisible) {
                     HintToolTip()
                 }
             }
@@ -156,6 +146,7 @@ private fun CreateMemberSettingPreview() {
                 selectedMembers = persistentListOf(),
                 onPriceChange = {},
                 onEditBtnClick = {},
+                layoutBottom = 0f,
                 errorMessage = "",
             )
 
@@ -164,6 +155,7 @@ private fun CreateMemberSettingPreview() {
                 selectedMembers = persistentListOf(),
                 onPriceChange = {},
                 onEditBtnClick = {},
+                layoutBottom = 0f,
                 errorMessage = "",
             )
 
@@ -176,6 +168,7 @@ private fun CreateMemberSettingPreview() {
                 ),
                 onPriceChange = {},
                 onEditBtnClick = {},
+                layoutBottom = 0f,
                 errorMessage = "모든 멤버에 가격을 설정해주세요",
             )
         }

--- a/app/src/main/java/com/poti/android/presentation/party/create/component/CreateMemberSetting.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/component/CreateMemberSetting.kt
@@ -45,7 +45,6 @@ fun CreateMemberSetting(
     selectedMembers: ImmutableList<MemberPriceOption>,
     onPriceChange: (MemberPriceOption) -> Unit,
     onEditBtnClick: () -> Unit,
-    showHint: Boolean,
     errorMessage: String,
     modifier: Modifier = Modifier,
 ) {
@@ -99,16 +98,16 @@ fun CreateMemberSetting(
                             option = option.name,
                             value = option.price,
                             onValueChanged = { newPrice ->
-                                val newOption = MemberPriceOption(
-                                    memberId = option.memberId,
-                                    name = option.name,
-                                    price = newPrice,
-                                )
+                                val newOption = option.copy(price = newPrice)
                                 onPriceChange(newOption)
                             },
                             modifier = Modifier.padding(bottom = if (isLastOption) 0.dp else 20.dp),
                             imeAction = if (isLastOption) ImeAction.Done else ImeAction.Next,
-                            onFocusChanged = { _ -> hideHint = true },
+                            onFocusChanged = { focused ->
+                                if (focused) {
+                                    hideHint = true
+                                }
+                            },
                         )
                     }
                 }
@@ -131,7 +130,7 @@ fun CreateMemberSetting(
                         },
                 )
 
-                if (!hideHint && showHint && isEditBtnInScreen && !isKeyboardVisible) {
+                if (!hideHint && isEditBtnInScreen && !isKeyboardVisible) {
                     HintToolTip()
                 }
             }
@@ -157,7 +156,6 @@ private fun CreateMemberSettingPreview() {
                 selectedMembers = persistentListOf(),
                 onPriceChange = {},
                 onEditBtnClick = {},
-                showHint = true,
                 errorMessage = "",
             )
 
@@ -166,7 +164,6 @@ private fun CreateMemberSettingPreview() {
                 selectedMembers = persistentListOf(),
                 onPriceChange = {},
                 onEditBtnClick = {},
-                showHint = true,
                 errorMessage = "",
             )
 
@@ -179,7 +176,6 @@ private fun CreateMemberSettingPreview() {
                 ),
                 onPriceChange = {},
                 onEditBtnClick = {},
-                showHint = true,
                 errorMessage = "모든 멤버에 가격을 설정해주세요",
             )
         }

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -33,6 +33,8 @@ enum class FieldError(
     DESCRIPTION_ERROR(R.string.create_error_need_description),
     ACCOUNT_NUMBER_ERROR(R.string.create_error_need_account_number),
     BANK_ERROR(R.string.create_error_need_bank),
+    MEMBER_EMPTY_ERROR(R.string.create_error_need_member),
+    MEMBER_PRICE_ERROR(R.string.create_error_need_price)
 }
 
 data class CreateUiState(
@@ -62,7 +64,7 @@ data class CreateUiState(
     val bankError: FieldError? = null,
 
     val membersState: ApiState<List<MemberPriceOption>> = ApiState.Init,
-    val rawMembers: List<MemberPriceOption> = emptyList(),
+    val rawMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
     val selectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
     val tempSelectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
     val memberSettingStatus: MemberSettingStatus = MemberSettingStatus.ARTITST_NOT_SELECTED,
@@ -77,6 +79,7 @@ data class CreateUiState(
 
     val createPartyState: ApiState<Long> = ApiState.Init,
 
+    val isInitialized: Boolean = false,
     val isArtistAutoFilled: Boolean = false,
     val isFieldTouched: Boolean = false,
     val showDialog: Boolean = false,
@@ -88,26 +91,23 @@ data class CreateUiState(
 }
 
 sealed interface CreateUiIntent : UiIntent {
-    data object CloseBottomSheet : CreateUiIntent
-
-    data object CloseDialog : CreateUiIntent
     data class InitializeScreen(val artistId: Long?, val artistName: String?, val productName: String?) : CreateUiIntent
 
-    data object CleanScreen : CreateUiIntent
+    data object OnCloseBottomSheet : CreateUiIntent
 
-    data object OnScrollComplete : CreateUiIntent
+    data object OnCloseDialog : CreateUiIntent
 
     data object OnBack : CreateUiIntent
 
     data object OnBackConfirm : CreateUiIntent
 
-    data object OnBackToCreate : CreateUiIntent
+    data object OnBackToCreate: CreateUiIntent
 
     data class OnImagesChanged(val uris: List<Uri>) : CreateUiIntent
 
     data object OnSearchClick : CreateUiIntent
 
-    data class OnArtistSearchKeywordChange(val value: String) : CreateUiIntent
+    data class OnArtistChange(val value: String) : CreateUiIntent
 
     data class OnArtistSelect(val artist: ArtistSearchResult) : CreateUiIntent
 
@@ -139,7 +139,9 @@ sealed interface CreateUiIntent : UiIntent {
 
     data object OnCreateClick : CreateUiIntent
 
-    data class OnConvertDone(val result: List<ImageInfoForPresigned>) : CreateUiIntent
+    data object ScrollComplete : CreateUiIntent
+
+    data class ConvertDone(val result: List<ImageInfoForPresigned>) : CreateUiIntent
 }
 
 sealed interface CreateUiEffect : UiEffect {

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -68,13 +68,13 @@ data class CreateUiState(
     val rawDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
     val selectedDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
     val createPartyState: ApiState<Long> = ApiState.Init,
-    val isArtistAutoFilled: Boolean = false,
+    val isAutoFilled: Boolean = false,
     val isFieldTouched: Boolean = false,
     val showDialog: Boolean = false,
     val errorIndexToScroll: Int? = null,
 ) : UiState {
     val isProductFieldReadOnly = selectedArtist == null
-    val isArtistSearchResultsEmpty = !isArtistAutoFilled && artistSearchKeyword.isNotEmpty() && (artistSearchState.getSuccessDataOrNull()?.isEmpty() ?: false)
+    val isArtistSearchResultsEmpty = !isAutoFilled && artistSearchKeyword.isNotEmpty() && (artistSearchState.getSuccessDataOrNull()?.isEmpty() ?: false)
     val isArtistSelectDoneBtnEnabled = selectedArtist != null
 }
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -16,7 +16,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 enum class MemberSettingStatus {
-    ARTITST_NOT_SELECTED,
+    ARTIST_NOT_SELECTED,
     MEMBER_NOT_SELECTED,
     EDITABLE,
 }
@@ -60,7 +60,7 @@ data class CreateUiState(
     val rawMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
     val selectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
     val tempSelectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
-    val memberSettingStatus: MemberSettingStatus = MemberSettingStatus.ARTITST_NOT_SELECTED,
+    val memberSettingStatus: MemberSettingStatus = MemberSettingStatus.ARTIST_NOT_SELECTED,
     val showMemberHint: Boolean = false,
     val showMemberBottomSheet: Boolean = false,
     val isMemberBottomSheetTouched: Boolean = false,

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -68,7 +68,6 @@ data class CreateUiState(
     val rawDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
     val selectedDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
     val createPartyState: ApiState<Long> = ApiState.Init,
-    val isInitialized: Boolean = false,
     val isArtistAutoFilled: Boolean = false,
     val isFieldTouched: Boolean = false,
     val showDialog: Boolean = false,
@@ -80,8 +79,6 @@ data class CreateUiState(
 }
 
 sealed interface CreateUiIntent : UiIntent {
-    data class InitializeScreen(val artistId: Long?, val artistName: String?, val productName: String?) : CreateUiIntent
-
     data object OnCloseBottomSheet : CreateUiIntent
 
     data object OnCloseDialog : CreateUiIntent

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -41,7 +41,7 @@ data class CreateUiState(
     val imageUris: List<Uri> = emptyList(),
     val imageError: FieldError? = null,
     val selectedArtist: ArtistSearchResult? = null,
-    val artistQuery: String = "",
+    val artistSearchKeyword: String = "",
     val artistSearchState: ApiState<List<ArtistSearchResult>> = ApiState.Init,
     val artistError: FieldError? = null,
     val selectedProduct: String = "",
@@ -75,7 +75,7 @@ data class CreateUiState(
     val errorIndexToScroll: Int? = null,
 ) : UiState {
     val isProductFieldReadOnly = selectedArtist == null
-    val isArtistSearchResultsEmpty = !isArtistAutoFilled && artistQuery.isNotEmpty() && (artistSearchState.getSuccessDataOrNull()?.isEmpty() ?: false)
+    val isArtistSearchResultsEmpty = !isArtistAutoFilled && artistSearchKeyword.isNotEmpty() && (artistSearchState.getSuccessDataOrNull()?.isEmpty() ?: false)
     val isArtistSelectDoneBtnEnabled = selectedArtist != null
 }
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -69,7 +69,6 @@ data class CreateUiState(
     val selectedDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
     val createPartyState: ApiState<Long> = ApiState.Init,
     val isAutoFilled: Boolean = false,
-    val isFieldTouched: Boolean = false,
     val showDialog: Boolean = false,
     val errorIndexToScroll: Int? = null,
 ) : UiState {

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -61,7 +61,6 @@ data class CreateUiState(
     val selectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
     val tempSelectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
     val memberSettingStatus: MemberSettingStatus = MemberSettingStatus.ARTIST_NOT_SELECTED,
-    val showMemberHint: Boolean = false,
     val showMemberBottomSheet: Boolean = false,
     val isMemberBottomSheetTouched: Boolean = false,
     val memberError: FieldError? = null,

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -34,35 +34,28 @@ enum class FieldError(
     ACCOUNT_NUMBER_ERROR(R.string.create_error_need_account_number),
     BANK_ERROR(R.string.create_error_need_bank),
     MEMBER_EMPTY_ERROR(R.string.create_error_need_member),
-    MEMBER_PRICE_ERROR(R.string.create_error_need_price)
+    MEMBER_PRICE_ERROR(R.string.create_error_need_price),
 }
 
 data class CreateUiState(
     val imageUris: List<Uri> = emptyList(),
     val imageError: FieldError? = null,
-
     val selectedArtist: ArtistSearchResult? = null,
     val artistQuery: String = "",
     val artistSearchState: ApiState<List<ArtistSearchResult>> = ApiState.Init,
     val artistError: FieldError? = null,
-
     val selectedProduct: String = "",
     val productName: String = "",
     val productSearchState: ApiState<List<String>> = ApiState.Init,
     val productError: FieldError? = null,
-
     val deadline: String = "",
     val deadlineError: FieldError? = null,
-
     val description: String = "",
     val descriptionError: FieldError? = null,
-
     val accountNumber: String = "",
     val accountNumberError: FieldError? = null,
-
     val bank: String = "",
     val bankError: FieldError? = null,
-
     val membersState: ApiState<List<MemberPriceOption>> = ApiState.Init,
     val rawMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
     val selectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
@@ -72,13 +65,10 @@ data class CreateUiState(
     val showMemberBottomSheet: Boolean = false,
     val isMemberBottomSheetTouched: Boolean = false,
     val memberError: FieldError? = null,
-
     val deliveriesState: ApiState<List<DeliveryOption>> = ApiState.Init,
     val rawDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
     val selectedDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
-
     val createPartyState: ApiState<Long> = ApiState.Init,
-
     val isInitialized: Boolean = false,
     val isArtistAutoFilled: Boolean = false,
     val isFieldTouched: Boolean = false,
@@ -101,7 +91,7 @@ sealed interface CreateUiIntent : UiIntent {
 
     data object OnBackConfirm : CreateUiIntent
 
-    data object OnBackToCreate: CreateUiIntent
+    data object OnBackToCreate : CreateUiIntent
 
     data class OnImagesChanged(val uris: List<Uri>) : CreateUiIntent
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -14,13 +14,11 @@ import com.poti.android.domain.model.delivery.DeliveryOption
 import com.poti.android.domain.model.image.ImageInfoForPresigned
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 
 enum class MemberSettingStatus {
-    DEFAULT,
-    IN_PROGRESS,
-    ERROR_NO_MEMBER,
-    ERROR_NO_PRICE,
+    ARTITST_NOT_SELECTED,
+    MEMBER_NOT_SELECTED,
+    EDITABLE,
 }
 
 enum class FieldError(
@@ -38,54 +36,68 @@ enum class FieldError(
 }
 
 data class CreateUiState(
-    val isDirty: Boolean = false,
-    val neverShowHint: Boolean = false,
-    val selectedImages: ImmutableList<Uri> = persistentListOf(),
-    val selectedArtist: ArtistSearchResult? = null,
-    val productName: String = "",
-    val productSearchResultsState: ApiState<ImmutableList<String>> = ApiState.Init,
-    val deadline: String = "",
-    val description: String = "",
-    val accountNumber: String = "",
-    val bank: String = "",
-    val memberSettingStatus: MemberSettingStatus = MemberSettingStatus.DEFAULT,
-    val memberOptionsState: ApiState<ImmutableList<MemberPriceOption>> = ApiState.Init,
-    val editableMemberOptions: ImmutableList<MemberPriceOption> = persistentListOf(),
-    val selectedMemberIds: Set<Long> = setOf(),
-    val deliveryOptionsState: ApiState<ImmutableList<DeliveryOption>> = ApiState.Init,
-    val sheetDisplayMemberIndices: Set<Int> = setOf(),
-    val editableDeliveryOptions: ImmutableList<DeliveryOption> = persistentListOf(),
-    val selectedDeliveryIds: Set<Long> = setOf(),
+    val imageUris: List<Uri> = emptyList(),
     val imageError: FieldError? = null,
+
+    val selectedArtist: ArtistSearchResult? = null,
+    val artistQuery: String = "",
+    val artistSearchState: ApiState<List<ArtistSearchResult>> = ApiState.Init,
     val artistError: FieldError? = null,
+
+    val selectedProduct: String = "",
+    val productName: String = "",
+    val productSearchState: ApiState<List<String>> = ApiState.Init,
     val productError: FieldError? = null,
+
+    val deadline: String = "",
     val deadlineError: FieldError? = null,
+
+    val description: String = "",
     val descriptionError: FieldError? = null,
+
+    val accountNumber: String = "",
     val accountNumberError: FieldError? = null,
+
+    val bank: String = "",
     val bankError: FieldError? = null,
-    val artistSearchKeyword: String = "",
-    val isSheetTouched: Boolean = false,
+
+    val membersState: ApiState<List<MemberPriceOption>> = ApiState.Init,
+    val rawMembers: List<MemberPriceOption> = emptyList(),
+    val selectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
+    val tempSelectedMembers: ImmutableList<MemberPriceOption> = persistentListOf(),
+    val memberSettingStatus: MemberSettingStatus = MemberSettingStatus.ARTITST_NOT_SELECTED,
+    val showMemberHint: Boolean = false,
+    val showMemberBottomSheet: Boolean = false,
+    val isMemberBottomSheetTouched: Boolean = false,
+    val memberError: FieldError? = null,
+
+    val deliveriesState: ApiState<List<DeliveryOption>> = ApiState.Init,
+    val rawDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
+    val selectedDeliveries: ImmutableList<DeliveryOption> = persistentListOf(),
+
     val createPartyState: ApiState<Long> = ApiState.Init,
-    val artistSearchResultsState: ApiState<ImmutableList<ArtistSearchResult>> = ApiState.Init,
-    val neverShowSearchEmptyScreen: Boolean = false,
-    val selectedProductName: String = "",
+
+    val isArtistAutoFilled: Boolean = false,
+    val isFieldTouched: Boolean = false,
+    val showDialog: Boolean = false,
     val errorIndexToScroll: Int? = null,
 ) : UiState {
     val isProductFieldReadOnly = selectedArtist == null
-    val sheetDisplayMemberNames = editableMemberOptions.map { option -> option.name }
-    val editOptionDisplayMembers = editableMemberOptions.filter { option -> option.memberId in selectedMemberIds }.toPersistentList()
-    val isArtistSearchResultsEmpty = !neverShowSearchEmptyScreen && artistSearchKeyword.isNotEmpty() && (artistSearchResultsState.getSuccessDataOrNull()?.isEmpty() ?: true)
+    val isArtistSearchResultsEmpty = !isArtistAutoFilled && artistQuery.isNotEmpty() && (artistSearchState.getSuccessDataOrNull()?.isEmpty() ?: false)
     val isArtistSelectDoneBtnEnabled = selectedArtist != null
 }
 
 sealed interface CreateUiIntent : UiIntent {
+    data object CloseBottomSheet : CreateUiIntent
+
+    data object CloseDialog : CreateUiIntent
     data class InitializeScreen(val artistId: Long?, val artistName: String?, val productName: String?) : CreateUiIntent
 
     data object CleanScreen : CreateUiIntent
 
     data object OnScrollComplete : CreateUiIntent
 
-    data object OnBackClick : CreateUiIntent
+    data object OnBack : CreateUiIntent
 
     data object OnBackConfirm : CreateUiIntent
 
@@ -115,15 +127,15 @@ sealed interface CreateUiIntent : UiIntent {
 
     data object OnMemberEditClick : CreateUiIntent
 
-    data class OnMemberSelect(val index: Int) : CreateUiIntent
+    data class OnMemberSelect(val member: MemberPriceOption) : CreateUiIntent
 
     data object OnAllMemberSelect : CreateUiIntent
 
     data object OnMemberSelectDone : CreateUiIntent
 
-    data class OnMemberPriceChange(val option: MemberPriceOption) : CreateUiIntent
+    data class OnMemberPriceChange(val member: MemberPriceOption) : CreateUiIntent
 
-    data class OnDeliverySelect(val deliveryId: Long) : CreateUiIntent
+    data class OnDeliverySelect(val delivery: DeliveryOption) : CreateUiIntent
 
     data object OnCreateClick : CreateUiIntent
 
@@ -134,10 +146,6 @@ sealed interface CreateUiEffect : UiEffect {
     data object NavigateToBack : CreateUiEffect
 
     data object NavigateToSearch : CreateUiEffect
-
-    data object ShowBottomSheet : CreateUiEffect
-
-    data object ShowDialog : CreateUiEffect
 
     data object ConvertUris : CreateUiEffect
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/navigation/PartyCreateNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/navigation/PartyCreateNavigation.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
+import androidx.navigation.navigation
 import com.poti.android.core.common.extension.sharedViewModel
 import com.poti.android.core.navigation.Route
 import com.poti.android.presentation.party.create.PartyArtistSelectRoute
@@ -15,13 +15,16 @@ import com.poti.android.presentation.party.create.PartyCreateViewModel
 import com.poti.android.presentation.party.detail.navigation.navigateToPartyDetailFromCreate
 import kotlinx.serialization.Serializable
 
+@Serializable
+data class PartyCreateGraph(
+    val artistId: Long? = null,
+    val artistName: String? = null,
+    val productName: String? = null,
+)
+
 sealed interface PartyCreateRoute : Route {
     @Serializable
-    data class Create(
-        val artistId: Long? = null,
-        val artistName: String? = null,
-        val productName: String? = null,
-    ) : PartyCreateRoute
+    data object Create : PartyCreateRoute
 
     @Serializable
     data object ArtistSelect : PartyCreateRoute
@@ -32,7 +35,7 @@ fun NavController.navigateToPartyCreate(
     artistName: String? = null,
     productName: String? = null,
 ) {
-    navigate(PartyCreateRoute.Create(artistId, artistName, productName))
+    navigate(PartyCreateGraph(artistId, artistName, productName))
 }
 
 fun NavController.navigateToPartyArtistSelect() {
@@ -43,27 +46,27 @@ fun NavGraphBuilder.partyCreateNavGraph(
     navController: NavController,
     paddingValues: PaddingValues,
 ) {
-    composable<PartyCreateRoute.Create> { entry ->
-        val viewModel: PartyCreateViewModel = entry.sharedViewModel(navController)
-        val params = entry.toRoute<PartyCreateRoute.Create>()
+    navigation<PartyCreateGraph>(
+        startDestination = PartyCreateRoute.Create,
+    ) {
+        composable<PartyCreateRoute.Create> { entry ->
+            val viewModel: PartyCreateViewModel = entry.sharedViewModel(navController)
 
-        PartyCreateRoute(
-            onPopBackStack = navController::popBackStack,
-            onNavigateToSearch = navController::navigateToPartyArtistSelect,
-            onNavigateToDetail = navController::navigateToPartyDetailFromCreate,
-            viewModel = viewModel,
-            modifier = Modifier.padding(paddingValues),
-            artistId = params.artistId,
-            artistName = params.artistName,
-            productName = params.productName,
-        )
-    }
-    composable<PartyCreateRoute.ArtistSelect> { entry ->
-        val viewModel: PartyCreateViewModel = entry.sharedViewModel(navController)
-        PartyArtistSelectRoute(
-            onPopBackStack = navController::popBackStack,
-            viewModel = viewModel,
-            modifier = Modifier.padding(paddingValues),
-        )
+            PartyCreateRoute(
+                onPopBackStack = navController::popBackStack,
+                onNavigateToSearch = navController::navigateToPartyArtistSelect,
+                onNavigateToDetail = navController::navigateToPartyDetailFromCreate,
+                viewModel = viewModel,
+                modifier = Modifier.padding(paddingValues),
+            )
+        }
+        composable<PartyCreateRoute.ArtistSelect> { entry ->
+            val viewModel: PartyCreateViewModel = entry.sharedViewModel(navController)
+            PartyArtistSelectRoute(
+                onPopBackStack = navController::popBackStack,
+                viewModel = viewModel,
+                modifier = Modifier.padding(paddingValues),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/create/navigation/PartyCreateNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/navigation/PartyCreateNavigation.kt
@@ -39,15 +39,6 @@ fun NavController.navigateToPartyArtistSelect() {
     navigate(PartyCreateRoute.ArtistSelect)
 }
 
-fun NavController.navigateToPartyCreateFromArtistSelect() {
-    navigate(PartyCreateRoute.Create(null, null, null)) {
-        popUpTo(PartyCreateRoute.Create(null, null, null)) {
-            inclusive = false
-        }
-        launchSingleTop = true
-    }
-}
-
 fun NavGraphBuilder.partyCreateNavGraph(
     navController: NavController,
     paddingValues: PaddingValues,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
     <string name="party_join_order_address_placeholder">예) 서울시 솝트구 다솝로 37</string>
     <string name="party_join_order_address_error">주소를 입력해주세요</string>
     <string name="party_join_order_contact_label">연락처</string>
-    <string name="party_join_order_contact_placeholder">예) 010-1234-5678</string>
+    <string name="party_join_order_contact_placeholder">예) 010–1234–5678</string>
     <string name="party_join_order_contact_error">연락처를 입력해주세요</string>
     <string name="party_join_confirm_modal_title">참여가 완료되었어요</string>
     <string name="party_join_confirm_modal_text">모집이 끝나면 입금이 시작돼요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,8 +96,6 @@
     <string name="create_label_won">원</string>
     <string name="create_msg_hint">모집자 본인이 보유할 멤버는 꼭 제외해주세요!</string>
     <string name="create_title_member_setting">멤버 설정</string>
-    <string name="create_msg_need_member">멤버를 1명 이상 추가해주세요</string>
-    <string name="create_msg_need_price">모든 멤버에 가격을 설정해주세요</string>
     <string name="create_placeholder_need_artist">아티스트를 먼저 선택해주세요</string>
     <string name="create_placeholder_need_member">선택한 멤버가 없어요</string>
     <string name="create_btn_member_edit">멤버 편집</string>
@@ -124,6 +122,8 @@
     <string name="create_error_need_description">설명을 입력해주세요</string>
     <string name="create_error_need_account_number">계좌번호를 입력해주세요</string>
     <string name="create_error_need_bank">은행 정보를 입력해주세요</string>
+    <string name="create_error_need_member">멤버를 1명 이상 추가해주세요</string>
+    <string name="create_error_need_price">모든 멤버에 가격을 설정해주세요</string>
     <string name="create_title_bottomsheet">멤버 편집</string>
     <string name="create_header_artist_search">아티스트 검색</string>
     <string name="create_message_artist_search_empty_result">검색 결과가 없어요\n다른 키워드로 다시 검색해보세요</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #143 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
등록 뷰 코드를 전면적으로 수정했어요

- UiState 리팩토링
   - 기존 선택된 옵션을 Set<Long> 객체에 id 값만 저장하였으나, UI 렌더링을 위해 매번 필터링 필요하며 전체 선택 등 수행 시 복잡한 상태관리 > 옵션 클래스 자체를 List<T>로 저장하도록 변경
   - 기존 Route에서 관리되던 showBottomSheet/showDialog를 UiState로 이동
   - 멤버 설정 상태 (MemberSettingStatus)에서 에러 상태 제거 및 FieldError에 멤버 설정 관련 에러 상태 추가해 에러 일괄 관리
   - UI에 배치되는 순으로 프로퍼티 순서 변경 및 용도에 맞게 묶어 줄바꿈으로 구분
- 뷰모델 리팩토링
   - uiState 변경에 따른 데이터 가공 로직 대응
   - 단순 sendEffect/updateState는 processIntent 내부에서 수행
   - 데이터 가공 등의 추가 로직이 있는 경우 함수 분리
   - UI에 배치되는 순으로 순서 변경
   - 아티스트/상품 검색 디바운싱은 별도의 Flow 생성 없이 uiState 자체에 filter 걸어 수행
- import 리팩토링
  - UiEffect, UiItent 항상 앞에 붙여주는 대신 import문에서 *로 전체 불러와 바로 OnBack 이런 식으로 사용해보았는데 어떠한가요?

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
죄송함니다 마지막 폐급PR입니다 기존 코드가 폐급뚱뚱코드였기때문에 리팩토링하며 다시 폐급PR을 올릴수박에 없엇음니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 재사용 가능한 멤버 선택 바텀시트 UI 추가(타이틀, 2열 그리드, 선택 토글, 주요/보조 액션, 미리보기).

* **Bug Fixes**
  * 멤버 관련 오류 메시지 및 금액 검증 안내 개선.
  * 연락처 플레이스홀더 표기 일부 정정.

* **Refactor**
  * 파티 생성 화면의 상태·인텐트·입력 흐름 대대적 개편 및 UI 바인딩 정리.
  * 배송·멤버 선택 컴포넌트의 데이터 형태 및 핸들링 변경.

* **Chores**
  * 내비게이션 경로 처리 단순화 및 일부 도우미 제거; 뷰모델 초기화 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->