### PR TITLE
[Refactor/#155] 분철글 페이지네이션

### DIFF
--- a/app/src/main/java/com/poti/android/data/mapper/party/ProductPartyListMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/party/ProductPartyListMapper.kt
@@ -10,6 +10,8 @@ fun ProductPartyListResponseDto.toDomain(): ProductPartyList =
         partyTitle = postTitle,
         artistName = artist,
         partySummaries = pots.map { it.toDomain() },
+        currentPage = currentPage,
+        hasNext = hasNext,
     )
 
 private fun PartyDto.toDomain(): PartySummary =

--- a/app/src/main/java/com/poti/android/data/mock/MockFallback.kt
+++ b/app/src/main/java/com/poti/android/data/mock/MockFallback.kt
@@ -21,6 +21,6 @@ suspend inline fun <T> executeWithUiMock(
 ): Result<T> {
     if (!useMock) return real()
 
-    Timber.d("UI mock build enabled. Skipping real write and returning mock data.")
+    Timber.d("UI mock build enabled. Skipping real call and returning mock data.")
     return suspendRunCatching { mock() }
 }

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -110,12 +110,26 @@ object UiMockData {
         nickname = "포티",
         mainArtist = "IVE",
         mainArtistId = 1,
-        groupItems = listOf(
-            com.poti.android.domain.model.party.GroupItem("IVE", 1, "", "공식 응원봉", 3, "인기"),
-            com.poti.android.domain.model.party.GroupItem("IVE", 1, "", "콘서트 MD 세트", 5, "NEW"),
-            com.poti.android.domain.model.party.GroupItem("IVE", 1, "", "포토카드 랜덤팩", 2, null),
-            com.poti.android.domain.model.party.GroupItem("IVE", 1, "", "시즌그리팅", 7, "마감임박"),
-        ),
+        groupItems = List(24) { index ->
+            val titles = listOf(
+                "공식 응원봉",
+                "콘서트 MD 세트",
+                "포토카드 랜덤팩",
+                "시즌그리팅",
+                "월드투어 후드",
+                "앨범 럭키드로우",
+            )
+            val tags = listOf("인기", "NEW", null, "마감임박")
+
+            com.poti.android.domain.model.party.GroupItem(
+                artist = if (index % 2 == 0) "IVE" else "aespa",
+                artistId = if (index % 2 == 0) 1 else 2,
+                postImage = "",
+                postTitle = "${titles[index % titles.size]} ${index + 1}",
+                postCount = (index % 9) + 1,
+                tag = tags[index % tags.size],
+            )
+        },
         myGroupItems = emptyList(),
     )
 

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -122,11 +122,27 @@ object UiMockData {
     val productPartyList = ProductPartyList(
         partyTitle = "러브다이브 위드뮤",
         artistName = "IVE",
-        partySummaries = listOf(
-            com.poti.android.domain.model.party.PartySummary(1, 21_300, "", 3, 5, listOf("원영", "유진"), "", "포티공주", 4.8),
-            com.poti.android.domain.model.party.PartySummary(2, 21_300, "", 6, 6, listOf("레이", "이서"), "", "굿즈요정", 4.5),
-            com.poti.android.domain.model.party.PartySummary(3, 18_000, "", 1, 4, listOf("가을", "리즈"), "", "공구마스터", 5.0),
-        ),
+        partySummaries = List(24) { index ->
+            val partyId = index + 1L
+            val availableMembers = when (index % 4) {
+                0 -> listOf("원영", "유진")
+                1 -> listOf("레이", "이서")
+                2 -> listOf("가을", "리즈")
+                else -> listOf("안유진", "장원영", "리즈")
+            }
+
+            com.poti.android.domain.model.party.PartySummary(
+                partyId = partyId,
+                price = 18_000 + (index % 5) * 1_000,
+                productImageUrl = "",
+                currentCount = (index % 5) + 1,
+                totalCount = 6,
+                availableMembers = availableMembers,
+                profileImageUrl = "",
+                nickname = "분철러${index + 1}",
+                rating = 4.0 + (index % 10) / 10.0,
+            )
+        },
     )
 
     val partyDetail = PartyDetail(

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -41,6 +41,8 @@ import com.poti.android.domain.model.user.UserSummary
 import com.poti.android.domain.type.HistoryListType
 import com.poti.android.domain.type.ParticipantStatusType
 import com.poti.android.domain.type.PartyStatusType
+import com.poti.android.domain.model.party.GroupItem as PartyGroupItem
+import com.poti.android.domain.model.party.PartySummary as PartyListSummary
 
 object UiMockData {
     private val historyPartySummary = PartySummary(
@@ -121,7 +123,7 @@ object UiMockData {
             )
             val tags = listOf("인기", "NEW", null, "마감임박")
 
-            com.poti.android.domain.model.party.GroupItem(
+            PartyGroupItem(
                 artist = if (index % 2 == 0) "IVE" else "aespa",
                 artistId = if (index % 2 == 0) 1 else 2,
                 postImage = "",
@@ -145,7 +147,7 @@ object UiMockData {
                 else -> listOf("안유진", "장원영", "리즈")
             }
 
-            com.poti.android.domain.model.party.PartySummary(
+            PartyListSummary(
                 partyId = partyId,
                 price = 18_000 + (index % 5) * 1_000,
                 productImageUrl = "",

--- a/app/src/main/java/com/poti/android/data/repository/ArtistRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/ArtistRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.poti.android.core.network.util.HttpResponseHandler
 import com.poti.android.data.mapper.artist.toDomain
 import com.poti.android.data.mapper.artist.toPriceDomain
 import com.poti.android.data.mock.UiMockData
-import com.poti.android.data.mock.useUiMockWhenEnabled
+import com.poti.android.data.mock.executeWithUiMock
 import com.poti.android.data.remote.datasource.ArtistRemoteDataSource
 import com.poti.android.domain.model.artist.Artist
 import com.poti.android.domain.model.artist.Member
@@ -17,25 +17,40 @@ class ArtistRepositoryImpl @Inject constructor(
     private val httpResponseHandler: HttpResponseHandler,
     private val artistRemoteDataSource: ArtistRemoteDataSource,
 ) : ArtistRepository {
-    override suspend fun getArtists(): Result<List<Artist>> = httpResponseHandler.safeApiCall {
-        artistRemoteDataSource.getArtists()
-            .handleApiResponse()
-            .getOrThrow()
-            .toDomain()
-    }.useUiMockWhenEnabled { UiMockData.artists }
+    override suspend fun getArtists(): Result<List<Artist>> = executeWithUiMock(
+        mock = { UiMockData.artists },
+        real = {
+            httpResponseHandler.safeApiCall {
+                artistRemoteDataSource.getArtists()
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
 
-    override suspend fun getMemberList(artistId: Long): Result<List<Member>> = httpResponseHandler.safeApiCall {
-        artistRemoteDataSource.getMemberList(artistId)
-            .handleApiResponse()
-            .getOrThrow()
-            .toDomain()
-    }.useUiMockWhenEnabled { UiMockData.members }
+    override suspend fun getMemberList(artistId: Long): Result<List<Member>> = executeWithUiMock(
+        mock = { UiMockData.members },
+        real = {
+            httpResponseHandler.safeApiCall {
+                artistRemoteDataSource.getMemberList(artistId)
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
 
     override suspend fun getMemberListWithPrice(artistId: Long): Result<List<MemberPriceOption>> =
-        httpResponseHandler.safeApiCall {
-            artistRemoteDataSource.getMemberList(artistId)
-                .handleApiResponse()
-                .getOrThrow()
-                .toPriceDomain()
-        }.useUiMockWhenEnabled { UiMockData.memberPriceOptions }
+        executeWithUiMock(
+            mock = { UiMockData.memberPriceOptions },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    artistRemoteDataSource.getMemberList(artistId)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toPriceDomain()
+                }
+            },
+        )
 }

--- a/app/src/main/java/com/poti/android/data/repository/FileUploadRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/FileUploadRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.poti.android.data.repository
 import com.poti.android.core.common.util.suspendRunCatching
 import com.poti.android.core.network.util.HttpResponseHandler
 import com.poti.android.data.local.datasource.FileLocalDataSource
+import com.poti.android.data.mock.executeWithUiMock
 import com.poti.android.data.remote.datasource.FileUploadRemoteDataSource
 import com.poti.android.domain.repository.FileUploadRepository
 import java.io.File
@@ -16,9 +17,14 @@ class FileUploadRepositoryImpl @Inject constructor(
     override suspend fun uploadImage(
         uploadUrl: String,
         file: File,
-    ): Result<Unit> = httpResponseHandler.safeApiCall {
-        fileUploadRemoteDataSource.uploadImage(uploadUrl, file)
-    }
+    ): Result<Unit> = executeWithUiMock(
+        mock = { Unit },
+        real = {
+            httpResponseHandler.safeApiCall {
+                fileUploadRemoteDataSource.uploadImage(uploadUrl, file)
+            }
+        },
+    )
 
     override suspend fun createImage(uriString: String): Result<File> = suspendRunCatching {
         fileLocalDataSource.createImageFile(uriString)

--- a/app/src/main/java/com/poti/android/data/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/HomeRepositoryImpl.kt
@@ -4,7 +4,7 @@ import com.poti.android.core.network.model.handleApiResponse
 import com.poti.android.core.network.util.HttpResponseHandler
 import com.poti.android.data.mapper.home.toDomain
 import com.poti.android.data.mock.UiMockData
-import com.poti.android.data.mock.useUiMockWhenEnabled
+import com.poti.android.data.mock.executeWithUiMock
 import com.poti.android.data.remote.datasource.HomeRemoteDataSource
 import com.poti.android.domain.model.home.HomeContent
 import com.poti.android.domain.model.party.ProductCategory
@@ -15,28 +15,37 @@ class HomeRepositoryImpl @Inject constructor(
     private val httpResponseHandler: HttpResponseHandler,
     private val homeRemoteDataSource: HomeRemoteDataSource,
 ) : HomeRepository {
-    override suspend fun getHomeContent(): Result<HomeContent> = httpResponseHandler.safeApiCall {
-        homeRemoteDataSource.getHomeContent()
-            .handleApiResponse()
-            .getOrThrow()
-            .toDomain()
-    }.useUiMockWhenEnabled { UiMockData.homeContent }
+    override suspend fun getHomeContent(): Result<HomeContent> = executeWithUiMock(
+        mock = { UiMockData.homeContent },
+        real = {
+            httpResponseHandler.safeApiCall {
+                homeRemoteDataSource.getHomeContent()
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
 
     override suspend fun getGoodsCategoryList(
         page: Int?,
         size: Int?,
         sort: String?,
         artistId: Long?,
-    ): Result<ProductCategory> =
-        httpResponseHandler.safeApiCall {
-            homeRemoteDataSource.getGoodsCategoryList(
-                page = page,
-                size = size,
-                sort = sort,
-                artistId = artistId,
-            )
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled { UiMockData.productCategory }
+    ): Result<ProductCategory> = executeWithUiMock(
+        mock = { UiMockData.productCategory },
+        real = {
+            httpResponseHandler.safeApiCall {
+                homeRemoteDataSource.getGoodsCategoryList(
+                    page = page,
+                    size = size,
+                    sort = sort,
+                    artistId = artistId,
+                )
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
 }

--- a/app/src/main/java/com/poti/android/data/repository/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/HomeRepositoryImpl.kt
@@ -33,7 +33,17 @@ class HomeRepositoryImpl @Inject constructor(
         sort: String?,
         artistId: Long?,
     ): Result<ProductCategory> = executeWithUiMock(
-        mock = { UiMockData.productCategory },
+        mock = {
+            val requestedPage = page ?: 0
+            val requestedSize = size ?: UiMockData.productCategory.groupItems.size
+            val groupItems = UiMockData.productCategory.groupItems
+                .drop(requestedPage * requestedSize)
+                .take(requestedSize)
+
+            UiMockData.productCategory.copy(
+                groupItems = groupItems,
+            )
+        },
         real = {
             httpResponseHandler.safeApiCall {
                 homeRemoteDataSource.getGoodsCategoryList(

--- a/app/src/main/java/com/poti/android/data/repository/ParticipationRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/ParticipationRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.poti.android.core.network.util.HttpResponseHandler
 import com.poti.android.data.mapper.history.toDomain
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.data.mock.executeWithUiMock
-import com.poti.android.data.mock.useUiMockWhenEnabled
 import com.poti.android.data.remote.datasource.ParticipantRemoteDataSource
 import com.poti.android.domain.model.history.MyPartyList
 import com.poti.android.domain.model.history.ParticipantDetail
@@ -17,22 +16,30 @@ class ParticipationRepositoryImpl @Inject constructor(
     private val participationRemoteDataSource: ParticipantRemoteDataSource,
 ) : ParticipationRepository {
     override suspend fun getMyParticipationList(status: String): Result<MyPartyList> =
-        httpResponseHandler.safeApiCall {
-            participationRemoteDataSource.getMyPartyList(status)
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled { UiMockData.myPartyList(status, participation = true) }
+        executeWithUiMock(
+            mock = { UiMockData.myPartyList(status, participation = true) },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    participationRemoteDataSource.getMyPartyList(status)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toDomain()
+                }
+            },
+        )
 
     override suspend fun getParticipantDetail(participationId: Long): Result<ParticipantDetail> =
-        httpResponseHandler.safeApiCall {
-            participationRemoteDataSource.getParticipantDetail(participationId)
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled {
-            UiMockData.participantDetail.copy(participationId = participationId)
-        }
+        executeWithUiMock(
+            mock = { UiMockData.participantDetail.copy(participationId = participationId) },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    participationRemoteDataSource.getParticipantDetail(participationId)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toDomain()
+                }
+            },
+        )
 
     override suspend fun patchDeliveryConfirm(participationId: Long): Result<Long> =
         executeWithUiMock(

--- a/app/src/main/java/com/poti/android/data/repository/PartyRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/PartyRepositoryImpl.kt
@@ -11,7 +11,6 @@ import com.poti.android.data.mapper.party.toDomain
 import com.poti.android.data.mapper.party.toRequestDto
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.data.mock.executeWithUiMock
-import com.poti.android.data.mock.useUiMockWhenEnabled
 import com.poti.android.data.remote.datasource.PartyRemoteDataSource
 import com.poti.android.data.remote.dto.request.party.CreatePartyRequestDto
 import com.poti.android.domain.model.artist.ArtistSearchResult
@@ -34,27 +33,34 @@ class PartyRepositoryImpl @Inject constructor(
     override suspend fun searchProductTitle(
         artistId: Long,
         keyword: String,
-    ): Result<List<String>> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource.searchProductTitle(artistId, keyword)
-                .handleApiResponse()
-                .getOrThrow()
-                .titles
-        }.useUiMockWhenEnabled {
+    ): Result<List<String>> = executeWithUiMock(
+        mock = {
             UiMockData.productCategory.groupItems
                 .map { it.postTitle }
                 .filter { it.contains(keyword, ignoreCase = true) }
-        }
+        },
+        real = {
+            httpResponseHandler.safeApiCall {
+                partyRemoteDataSource.searchProductTitle(artistId, keyword)
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .titles
+            }
+        },
+    )
 
     override suspend fun searchArtist(keyword: String): Result<List<ArtistSearchResult>> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource.searchArtist(keyword)
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled {
-            UiMockData.artistSearchResults.filter { it.name.contains(keyword, ignoreCase = true) }
-        }
+        executeWithUiMock(
+            mock = { UiMockData.artistSearchResults.filter { it.name.contains(keyword, ignoreCase = true) } },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    partyRemoteDataSource.searchArtist(keyword)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toDomain()
+                }
+            },
+        )
 
     override suspend fun createPost(
         artistId: Long,
@@ -91,29 +97,44 @@ class PartyRepositoryImpl @Inject constructor(
     )
 
     override suspend fun getShippingOptions(): Result<List<DeliveryOption>> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource
-                .getShippingOptions()
-                .handleApiResponse()
-                .getOrThrow()
-                .map { it.toDomain() }
-        }.useUiMockWhenEnabled { UiMockData.deliveryOptions }
+        executeWithUiMock(
+            mock = { UiMockData.deliveryOptions },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    partyRemoteDataSource
+                        .getShippingOptions()
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .map { it.toDomain() }
+                }
+            },
+        )
 
     override suspend fun getPartyDetail(partyId: Long): Result<PartyDetail> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource.getPartyDetail(partyId = partyId)
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled { UiMockData.partyDetail.copy(postId = partyId) }
+        executeWithUiMock(
+            mock = { UiMockData.partyDetail.copy(postId = partyId) },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    partyRemoteDataSource.getPartyDetail(partyId = partyId)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toDomain()
+                }
+            },
+        )
 
     override suspend fun getPartyJoinOptions(partyId: Long): Result<PartyJoinOption> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource.getPartyJoinOptions(partyId = partyId)
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled { UiMockData.partyJoinOption }
+        executeWithUiMock(
+            mock = { UiMockData.partyJoinOption },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    partyRemoteDataSource.getPartyJoinOptions(partyId = partyId)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toDomain()
+                }
+            },
+        )
 
     override suspend fun postPartyJoin(joinInfo: PartyJoinInfo): Result<Long> =
         executeWithUiMock(
@@ -129,28 +150,43 @@ class PartyRepositoryImpl @Inject constructor(
         )
 
     override suspend fun getMyRecruitList(status: String): Result<MyPartyList> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource.getMyRecruitList(status)
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled { UiMockData.myPartyList(status, participation = false) }
+        executeWithUiMock(
+            mock = { UiMockData.myPartyList(status, participation = false) },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    partyRemoteDataSource.getMyRecruitList(status)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toDomain()
+                }
+            },
+        )
 
     override suspend fun getRecruitDetail(postId: Long): Result<RecruiterDetail> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource.getRecruitDetail(postId)
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled { UiMockData.recruiterDetail.copy(recruitId = postId) }
+        executeWithUiMock(
+            mock = { UiMockData.recruiterDetail.copy(recruitId = postId) },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    partyRemoteDataSource.getRecruitDetail(postId)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toDomain()
+                }
+            },
+        )
 
     override suspend fun getRecruitPostParticipant(postId: Long): Result<ParticipantManageDetail> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource.getRecruitPostParticipant(postId)
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled { UiMockData.participantManageDetail }
+        executeWithUiMock(
+            mock = { UiMockData.participantManageDetail },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    partyRemoteDataSource.getRecruitPostParticipant(postId)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .toDomain()
+                }
+            },
+        )
 
     override suspend fun getProductPartyList(
         page: Int?,

--- a/app/src/main/java/com/poti/android/data/repository/PartyRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/PartyRepositoryImpl.kt
@@ -159,20 +159,35 @@ class PartyRepositoryImpl @Inject constructor(
         artistId: Long,
         sort: String,
         memberIds: List<Long>?,
-    ): Result<ProductPartyList> =
-        httpResponseHandler.safeApiCall {
-            partyRemoteDataSource.getProductPartyList(
-                page = page,
-                size = size,
-                title = title,
-                artistId = artistId,
-                sort = sort,
-                memberIds = memberIds,
+    ): Result<ProductPartyList> = executeWithUiMock(
+        mock = {
+            val requestedPage = page ?: 0
+            val requestedSize = size ?: UiMockData.productPartyList.partySummaries.size
+            val partySummaries = UiMockData.productPartyList.partySummaries
+                .drop(requestedPage * requestedSize)
+                .take(requestedSize)
+
+            UiMockData.productPartyList.copy(
+                partyTitle = title,
+                partySummaries = partySummaries,
+                currentPage = requestedPage,
+                hasNext = (requestedPage + 1) * requestedSize < UiMockData.productPartyList.partySummaries.size,
             )
-                .handleApiResponse()
-                .getOrThrow()
-                .toDomain()
-        }.useUiMockWhenEnabled {
-            UiMockData.productPartyList.copy(partyTitle = title)
-        }
+        },
+        real = {
+            httpResponseHandler.safeApiCall {
+                partyRemoteDataSource.getProductPartyList(
+                    page = page,
+                    size = size,
+                    title = title,
+                    artistId = artistId,
+                    sort = sort,
+                    memberIds = memberIds,
+                )
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
 }

--- a/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.poti.android.core.network.util.HttpResponseHandler
 import com.poti.android.data.mapper.user.toDomain
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.data.mock.executeWithUiMock
-import com.poti.android.data.mock.useUiMockWhenEnabled
 import com.poti.android.data.remote.datasource.UserRemoteDataSource
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
@@ -38,28 +37,43 @@ class UserRepositoryImpl @Inject constructor(
     )
 
     override suspend fun postNicknameDuplicate(nickname: String): Result<Boolean> =
-        httpResponseHandler.safeApiCall {
-            val requestDto = NicknameDuplicateRequestDto(
-                nickname = nickname,
-            )
-            userRemoteDataSource
-                .postNicknameDuplicate(nicknameDuplicateRequest = requestDto)
-                .handleApiResponse()
-                .getOrThrow()
-                .isDuplicated
-        }.useUiMockWhenEnabled { false }
+        executeWithUiMock(
+            mock = { false },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    val requestDto = NicknameDuplicateRequestDto(
+                        nickname = nickname,
+                    )
+                    userRemoteDataSource
+                        .postNicknameDuplicate(nicknameDuplicateRequest = requestDto)
+                        .handleApiResponse()
+                        .getOrThrow()
+                        .isDuplicated
+                }
+            },
+        )
 
-    override suspend fun getUserMyPage(): Result<UserMyPage> = httpResponseHandler.safeApiCall {
-        userRemoteDataSource.getUserMyPage()
-            .handleApiResponse()
-            .getOrThrow()
-            .toDomain()
-    }.useUiMockWhenEnabled { UiMockData.userMyPage }
+    override suspend fun getUserMyPage(): Result<UserMyPage> = executeWithUiMock(
+        mock = { UiMockData.userMyPage },
+        real = {
+            httpResponseHandler.safeApiCall {
+                userRemoteDataSource.getUserMyPage()
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
 
-    override suspend fun getUserProfile(userId: Long): Result<UserProfile> = httpResponseHandler.safeApiCall {
-        userRemoteDataSource.getUserProfile(userId)
-            .handleApiResponse()
-            .getOrThrow()
-            .toDomain()
-    }.useUiMockWhenEnabled { UiMockData.userProfile.copy(userId = userId) }
+    override suspend fun getUserProfile(userId: Long): Result<UserProfile> = executeWithUiMock(
+        mock = { UiMockData.userProfile.copy(userId = userId) },
+        real = {
+            httpResponseHandler.safeApiCall {
+                userRemoteDataSource.getUserProfile(userId)
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
 }

--- a/app/src/main/java/com/poti/android/domain/model/party/ProductPartyList.kt
+++ b/app/src/main/java/com/poti/android/domain/model/party/ProductPartyList.kt
@@ -4,6 +4,8 @@ data class ProductPartyList(
     val partyTitle: String,
     val artistName: String,
     val partySummaries: List<PartySummary>,
+    val currentPage: Int = 0,
+    val hasNext: Boolean = false,
 )
 
 data class PartySummary(

--- a/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListScreen.kt
@@ -9,8 +9,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -88,11 +92,14 @@ fun ProductPartyListRoute(
         ),
         partySortType = uiState.partySortType,
         memberFilterText = uiState.memberFilterText,
+        isPageLoading = uiState.isPartyPageLoading,
+        hasNextPage = uiState.hasNextPartyPage,
         onBackClick = { viewModel.processIntent(ProductPartyListUiIntent.OnBackClick) },
         onFloatingClick = { viewModel.processIntent(ProductPartyListUiIntent.OnFloatingClick) },
         onMemberFilterClick = { viewModel.processIntent(ProductPartyListUiIntent.OnMemberFilterClick) },
         onSortFilterClick = { viewModel.processIntent(ProductPartyListUiIntent.OnSortFilterClick) },
         onCardClick = { potId -> viewModel.processIntent(ProductPartyListUiIntent.OnPartyClick(potId)) },
+        onLoadNextPage = { viewModel.processIntent(ProductPartyListUiIntent.LoadNextProductPartyList) },
         modifier = modifier,
     )
 }
@@ -102,13 +109,35 @@ private fun ProductPartyListScreen(
     productPartyListInfo: ProductPartyList,
     partySortType: PartySortType,
     memberFilterText: String,
+    isPageLoading: Boolean,
+    hasNextPage: Boolean,
     onBackClick: () -> Unit,
     onFloatingClick: () -> Unit,
     onMemberFilterClick: () -> Unit,
     onSortFilterClick: () -> Unit,
     onCardClick: (Long) -> Unit,
+    onLoadNextPage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val listState = rememberLazyListState()
+    val shouldLoadNextPage by remember(listState, hasNextPage, isPageLoading) {
+        derivedStateOf {
+            val lastVisibleItemIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return@derivedStateOf false
+            val totalItemsCount = listState.layoutInfo.totalItemsCount
+
+            hasNextPage &&
+                !isPageLoading &&
+                totalItemsCount > 0 &&
+                lastVisibleItemIndex >= totalItemsCount - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadNextPage) {
+        if (shouldLoadNextPage) {
+            onLoadNextPage()
+        }
+    }
+
     Box(
         modifier = modifier,
     ) {
@@ -120,6 +149,7 @@ private fun ProductPartyListScreen(
             )
 
             LazyColumn(
+                state = listState,
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(
                     start = 16.dp,
@@ -210,10 +240,13 @@ private fun ProductPartyListScreenPreveiw() {
         ),
         partySortType = PartySortType.DEADLINE,
         memberFilterText = "",
+        isPageLoading = false,
+        hasNextPage = false,
         onBackClick = {},
         onFloatingClick = {},
         onMemberFilterClick = {},
         onSortFilterClick = {},
         onCardClick = {},
+        onLoadNextPage = {},
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListViewModel.kt
@@ -13,6 +13,8 @@ import com.poti.android.presentation.party.product.partylist.model.ProductPartyL
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
+private const val PARTY_PAGE_SIZE = 10
+
 @HiltViewModel
 class ProductPartyListViewModel @Inject constructor(
     private val getMembersUseCase: GetMembersUseCase,
@@ -32,6 +34,7 @@ class ProductPartyListViewModel @Inject constructor(
     override fun processIntent(intent: ProductPartyListUiIntent) {
         when (intent) {
             ProductPartyListUiIntent.LoadProductPartyList -> loadPartyList()
+            ProductPartyListUiIntent.LoadNextProductPartyList -> loadPartyList(reset = false)
             ProductPartyListUiIntent.OnBackClick -> sendEffect(ProductPartyListUiEffect.NavigateBack)
             ProductPartyListUiIntent.OnFloatingClick -> sendEffect(
                 ProductPartyListUiEffect.NavigateToPartyCreate(
@@ -74,8 +77,11 @@ class ProductPartyListViewModel @Inject constructor(
         }
     }
 
-    private fun loadPartyList() = launchScope {
+    private fun loadPartyList(reset: Boolean = true) = launchScope {
         val currentState = uiState.value
+        if (!reset && (currentState.isPartyPageLoading || !currentState.hasNextPartyPage)) return@launchScope
+
+        val page = if (reset) 0 else currentState.nextPartyPage
         val sort = currentState.partySortType.request
         val memberIds = if (currentState.selectedMembers.isNotEmpty()) {
             currentState.selectedMembers.map { it.memberId }
@@ -83,29 +89,51 @@ class ProductPartyListViewModel @Inject constructor(
             null
         }
 
-        updateState { copy(productPartyListInfo = ApiState.Loading) }
+        updateState {
+            copy(
+                productPartyListInfo = if (reset) ApiState.Loading else productPartyListInfo,
+                isPartyPageLoading = true,
+            )
+        }
 
         getProductPartyListUseCase(
-            page = 0,
-            size = 100,
+            page = page,
+            size = PARTY_PAGE_SIZE,
             title = title,
             artistId = artistId,
             sort = sort,
             memberIds = memberIds,
         ).onSuccess { partyList ->
+            val currentList = (uiState.value.productPartyListInfo as? ApiState.Success)?.data?.partySummaries.orEmpty()
+            val updatedPartySummaries = if (reset) {
+                partyList.partySummaries
+            } else {
+                currentList + partyList.partySummaries
+            }
+
             updateState {
                 copy(
-                    productPartyListInfo = ApiState.Success(partyList),
+                    productPartyListInfo = ApiState.Success(
+                        partyList.copy(
+                            partySummaries = updatedPartySummaries.distinctBy { it.partyId },
+                        ),
+                    ),
                     cachedTitle = partyList.partyTitle,
                     cachedSubTitle = partyList.artistName,
+                    isPartyPageLoading = false,
+                    hasNextPartyPage = partyList.hasNext,
+                    nextPartyPage = partyList.currentPage + 1,
                 )
             }
         }.onFailure { throwable ->
             updateState {
                 copy(
-                    productPartyListInfo = ApiState.Failure(
-                        throwable.message ?: "Failed",
-                    ),
+                    productPartyListInfo = if (reset) {
+                        ApiState.Failure(throwable.message ?: "Failed")
+                    } else {
+                        productPartyListInfo
+                    },
+                    isPartyPageLoading = false,
                 )
             }
         }

--- a/app/src/main/java/com/poti/android/presentation/party/product/partylist/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/partylist/model/Contracts.kt
@@ -14,6 +14,9 @@ data class ProductPartyListUiState(
     val productPartyListInfo: ApiState<ProductPartyList> = ApiState.Loading,
     val cachedTitle: String = "",
     val cachedSubTitle: String = "",
+    val isPartyPageLoading: Boolean = false,
+    val hasNextPartyPage: Boolean = true,
+    val nextPartyPage: Int = 0,
     val membersLoadState: ApiState<List<Member>> = ApiState.Loading,
     val displayMembers: List<Member> = emptyList(),
     val selectedMembers: List<Member> = emptyList(),
@@ -53,6 +56,8 @@ data class ProductPartyListUiState(
 
 sealed interface ProductPartyListUiIntent : UiIntent {
     data object LoadProductPartyList : ProductPartyListUiIntent
+
+    data object LoadNextProductPartyList : ProductPartyListUiIntent
 
     data object OnBackClick : ProductPartyListUiIntent
 

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
@@ -10,8 +10,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -60,12 +64,15 @@ fun ProductCategoryRoute(
             productCategory = goodsCategory,
             selectedSortType = uiState.selectedSortType,
             isSortBottomSheetVisible = uiState.isSortBottomSheetVisible,
+            isPageLoading = uiState.isProductCategoryPageLoading,
+            hasNextPage = uiState.hasNextProductCategoryPage,
             onBackClick = { viewModel.processIntent(ProductCategoryUiIntent.OnBackClick) },
             onFloatingClick = { viewModel.processIntent(ProductCategoryUiIntent.OnFloatingClick) },
             onSortFilterClick = { viewModel.processIntent(ProductCategoryUiIntent.OnSortFilterClick) },
             onSortSelect = { viewModel.processIntent(ProductCategoryUiIntent.OnSortSelected(it)) },
             onSortDismiss = { viewModel.processIntent(ProductCategoryUiIntent.OnSortDismiss) },
             onCardClick = { artistId, title -> viewModel.processIntent(ProductCategoryUiIntent.OnCardClick(artistId, title)) },
+            onLoadNextPage = { viewModel.processIntent(ProductCategoryUiIntent.OnLoadNextPage) },
             modifier = modifier,
         )
     }
@@ -78,14 +85,36 @@ private fun ProductCategoryScreen(
     productCategory: ProductCategory,
     selectedSortType: ProductSortType,
     isSortBottomSheetVisible: Boolean,
+    isPageLoading: Boolean,
+    hasNextPage: Boolean,
     onBackClick: () -> Unit,
     onFloatingClick: () -> Unit,
     onSortFilterClick: () -> Unit,
     onSortSelect: (ProductSortType) -> Unit,
     onSortDismiss: () -> Unit,
     onCardClick: (Long, String) -> Unit,
+    onLoadNextPage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val listState = rememberLazyListState()
+    val shouldLoadNextPage by remember(listState, hasNextPage, isPageLoading) {
+        derivedStateOf {
+            val lastVisibleItemIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return@derivedStateOf false
+            val totalItemsCount = listState.layoutInfo.totalItemsCount
+
+            hasNextPage &&
+                !isPageLoading &&
+                totalItemsCount > 0 &&
+                lastVisibleItemIndex >= totalItemsCount - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadNextPage) {
+        if (shouldLoadNextPage) {
+            onLoadNextPage()
+        }
+    }
+
     if (isSortBottomSheetVisible) {
         GoodsSortBottomSheet(
             selectedSortType = selectedSortType,
@@ -104,6 +133,7 @@ private fun ProductCategoryScreen(
             )
 
             LazyColumn(
+                state = listState,
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(
                     start = 16.dp,
@@ -164,12 +194,15 @@ private fun ProductCategoryScreenPreview() {
             productCategory = UiMockData.productCategory,
             selectedSortType = ProductSortType.LATEST,
             isSortBottomSheetVisible = false,
+            isPageLoading = false,
+            hasNextPage = false,
             onBackClick = {},
             onFloatingClick = {},
             onSortFilterClick = {},
             onSortSelect = {},
             onSortDismiss = {},
             onCardClick = { _, _ -> },
+            onLoadNextPage = {},
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryViewModel.kt
@@ -13,6 +13,8 @@ import com.poti.android.presentation.party.product.productcategory.model.Product
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
+private const val PRODUCT_CATEGORY_PAGE_SIZE = 10
+
 @HiltViewModel
 class ProductCategoryViewModel @Inject constructor(
     private val getGoodsCategoryListUseCase: GetGoodsCategoryListUseCase,
@@ -40,6 +42,7 @@ class ProductCategoryViewModel @Inject constructor(
                     loadGoodsCategoryList(intent.sortType)
                 }
 
+                ProductCategoryUiIntent.OnLoadNextPage -> loadGoodsCategoryList(reset = false)
                 ProductCategoryUiIntent.OnSortDismiss -> updateState { copy(isSortBottomSheetVisible = false) }
                 is ProductCategoryUiIntent.OnCardClick -> sendEffect(ProductCategoryUiEffect.NavigateToProductPartyList(intent.artistId, intent.title))
             }
@@ -49,27 +52,64 @@ class ProductCategoryViewModel @Inject constructor(
             loadGoodsCategoryList()
         }
 
-        private fun loadGoodsCategoryList(sortType: ProductSortType = uiState.value.selectedSortType) =
+        private fun loadGoodsCategoryList(
+            sortType: ProductSortType = uiState.value.selectedSortType,
+            reset: Boolean = true,
+        ) =
             launchScope {
-                updateState { copy(productCategoryLoadState = ApiState.Loading) }
+                val state = uiState.value
+                if (!reset && (state.isProductCategoryPageLoading || !state.hasNextProductCategoryPage)) return@launchScope
+
+                val page = if (reset) 0 else state.nextProductCategoryPage
+
+                updateState {
+                    copy(
+                        productCategoryLoadState = if (reset) ApiState.Loading else productCategoryLoadState,
+                        isProductCategoryPageLoading = true,
+                    )
+                }
 
                 getGoodsCategoryListUseCase(
-                    page = 0,
-                    size = 100,
+                    page = page,
+                    size = PRODUCT_CATEGORY_PAGE_SIZE,
                     sort = sortType.name,
                     artistId = artistId,
                 )
                     .onSuccess { goodsCategory ->
+                        val currentGroupItems = (uiState.value.productCategoryLoadState as? ApiState.Success)
+                            ?.data
+                            ?.groupItems
+                            .orEmpty()
+                        val updatedGroupItems = if (reset) {
+                            goodsCategory.groupItems
+                        } else {
+                            currentGroupItems + goodsCategory.groupItems
+                        }
+
                         updateState {
-                            copy(productCategoryLoadState = ApiState.Success(goodsCategory))
+                            copy(
+                                productCategoryLoadState = ApiState.Success(
+                                    goodsCategory.copy(
+                                        groupItems = updatedGroupItems.distinctBy { item ->
+                                            item.artistId to item.postTitle
+                                        },
+                                    ),
+                                ),
+                                isProductCategoryPageLoading = false,
+                                hasNextProductCategoryPage = goodsCategory.groupItems.size == PRODUCT_CATEGORY_PAGE_SIZE,
+                                nextProductCategoryPage = page + 1,
+                            )
                         }
                     }
                     .onFailure { throwable ->
                         updateState {
                             copy(
-                                productCategoryLoadState = ApiState.Failure(
-                                    throwable.message ?: "Failed to load goods category",
-                                ),
+                                productCategoryLoadState = if (reset) {
+                                    ApiState.Failure(throwable.message ?: "Failed to load goods category")
+                                } else {
+                                    productCategoryLoadState
+                                },
+                                isProductCategoryPageLoading = false,
                             )
                         }
                     }

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/model/Contracts.kt
@@ -8,6 +8,9 @@ import com.poti.android.domain.model.party.ProductCategory
 
 data class ProductCategoryUiState(
     val productCategoryLoadState: ApiState<ProductCategory> = ApiState.Loading,
+    val isProductCategoryPageLoading: Boolean = false,
+    val hasNextProductCategoryPage: Boolean = true,
+    val nextProductCategoryPage: Int = 0,
     val isSortBottomSheetVisible: Boolean = false,
     val selectedSortType: ProductSortType = ProductSortType.HOT,
 ) : UiState
@@ -20,6 +23,8 @@ sealed interface ProductCategoryUiIntent : UiIntent {
     data object OnSortFilterClick : ProductCategoryUiIntent
 
     data class OnSortSelected(val sortType: ProductSortType) : ProductCategoryUiIntent
+
+    data object OnLoadNextPage : ProductCategoryUiIntent
 
     data object OnSortDismiss : ProductCategoryUiIntent
 


### PR DESCRIPTION
## Related issue 🛠️
- closed #155 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 분철글 피드 페이지네이션 적용
- 굿즈별 분철팟 페이지네이션 적용

## Screenshot 📸

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
분철글 피드 페이지네이션에는 DTO에 currentPage랑 hasNext 필드가 없어서 추가하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 상품 카테고리 목록에 무한 스크롤 페이징 기능 추가
  * 파티 목록 화면에서 스크롤 기반 자동 로딩 지원
  * 페이지네이션 로딩 상태 UI 및 진행 상황 표시 개선

* **Refactor**
  * 내부 테스트 데이터 구조 개선
  * 데이터 로딩 아키텍처 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->