### PR TITLE
[Refactor/#166] Figma 컴포넌트 업데이트 반영

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiModalButton.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiModalButton.kt
@@ -24,6 +24,7 @@ import com.poti.android.core.designsystem.theme.PotiTheme
 
 enum class ModalButtonType {
     MAIN,
+    SECONDARY,
     SUB_1,
     SUB_2,
     ;
@@ -34,13 +35,14 @@ enum class ModalButtonType {
     ): Color =
         when (this) {
             MAIN -> if (isPressed) colors.poti800 else colors.poti600
+            SECONDARY -> if (isPressed) colors.gray900 else colors.black
             SUB_1 -> if (isPressed) colors.gray300 else colors.gray100
             SUB_2 -> Color.Transparent
         }
 
     fun getContentColor(colors: PotiColors): Color {
         return when (this) {
-            MAIN -> colors.white
+            MAIN, SECONDARY -> colors.white
             SUB_1 -> colors.gray900
             SUB_2 -> colors.poti600
         }
@@ -96,6 +98,13 @@ private fun PotiModalButtonPreview() {
                 onClick = {},
                 modifier = Modifier.width(259.dp),
                 type = ModalButtonType.MAIN,
+            )
+
+            PotiModalButton(
+                text = "Secondary",
+                onClick = {},
+                modifier = Modifier.width(259.dp),
+                type = ModalButtonType.SECONDARY,
             )
 
             PotiModalButton(

--- a/app/src/main/java/com/poti/android/core/designsystem/component/field/PotiSearchBar.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/field/PotiSearchBar.kt
@@ -1,0 +1,151 @@
+package com.poti.android.core.designsystem.component.field
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.common.extension.noRippleClickable
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+/**
+ * 검색어만 입력받는 단순 검색 바입니다.
+ *
+ * 입력값이 없으면 검색 아이콘을, 있으면 삭제 아이콘을 노출합니다.
+ * 검색 결과를 드롭다운 메뉴로 함께 제공해야 하는 경우에는 [PotiSearchField]를 사용합니다.
+ *
+ * @param value 필드 입력값입니다.
+ * @param onValueChange 필드에 입력된 값을 전달합니다.
+ * @param onSearch 키보드 검색 액션 또는 검색 아이콘 클릭 시 호출됩니다.
+ * @param modifier
+ * @param placeholder 입력값이 없을 때 필드에 표시됩니다.
+ * @param onClear 삭제 아이콘 클릭 시 호출됩니다. 기본값은 입력값을 비웁니다.
+ * @param focusRequester 포커스를 외부에서 제어하고 싶을 때 사용합니다.
+ *
+ * @sample PotiSearchBarPreview
+ */
+@Composable
+fun PotiSearchBar(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onSearch: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = stringResource(R.string.search_bar_placeholder),
+    onClear: () -> Unit = { onValueChange("") },
+    focusRequester: FocusRequester? = null,
+) {
+    val requester = remember { focusRequester ?: FocusRequester() }
+
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .heightIn(min = 48.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(PotiTheme.colors.gray100)
+            .focusRequester(requester),
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        keyboardActions = KeyboardActions(onSearch = { onSearch(value) }),
+        textStyle = PotiTheme.typography.body16m.copy(
+            color = PotiTheme.colors.black,
+        ),
+        decorationBox = { innerTextField ->
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    innerTextField()
+
+                    if (value.isEmpty()) {
+                        Text(
+                            text = placeholder,
+                            style = PotiTheme.typography.body16m,
+                            color = PotiTheme.colors.gray700,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+
+                if (value.isEmpty()) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_search),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(24.dp)
+                            .noRippleClickable { onSearch(value) },
+                        tint = PotiTheme.colors.gray700,
+                    )
+                } else {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_x),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(24.dp)
+                            .noRippleClickable(onClick = onClear),
+                        tint = PotiTheme.colors.black,
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PotiSearchBarPreview() {
+    var emptyValue by remember { mutableStateOf("") }
+    var filledValue by remember { mutableStateOf("검색어를 입력하세요") }
+
+    PotiTheme {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            PotiSearchBar(
+                value = emptyValue,
+                onValueChange = { emptyValue = it },
+                onSearch = {},
+            )
+
+            PotiSearchBar(
+                value = filledValue,
+                onValueChange = { filledValue = it },
+                onSearch = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/core/designsystem/component/field/PotiSearchBar.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/field/PotiSearchBar.kt
@@ -61,7 +61,7 @@ fun PotiSearchBar(
     onClear: () -> Unit = { onValueChange("") },
     focusRequester: FocusRequester? = null,
 ) {
-    val requester = remember { focusRequester ?: FocusRequester() }
+    val requester = remember(focusRequester) { focusRequester ?: FocusRequester() }
 
     BasicTextField(
         value = value,

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,6 +33,9 @@ enum class PotiHeaderPageType(
     CLOSE(R.drawable.ic_x),
 }
 
+/**
+ * @param containerColor 헤더 배경색입니다. 화면 배경이 흰색이 아닌 경우 맞춰서 전달합니다.
+ */
 @Composable
 fun PotiHeaderPage(
     onNavigationClick: () -> Unit,
@@ -41,10 +45,11 @@ fun PotiHeaderPage(
     subTitle: String? = null,
     onTrailingIconClick: (() -> Unit)? = null,
     @DrawableRes trailingIconRes: Int = R.drawable.ic_switch,
+    containerColor: Color = PotiTheme.colors.white,
 ) {
     Row(
         modifier = modifier
-            .background(PotiTheme.colors.white)
+            .background(containerColor)
             .padding(horizontal = 4.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -104,6 +109,7 @@ fun PotiHeaderPage(
  * @param placeholder 입력값이 없을 때 검색 필드에 표시됩니다.
  * @param onClear 삭제 아이콘 클릭 시 호출됩니다.
  * @param focusRequester 포커스를 외부에서 제어하고 싶을 때 사용합니다.
+ * @param containerColor 헤더 배경색입니다. 화면 배경이 흰색이 아닌 경우 맞춰서 전달합니다.
  *
  * @sample PotiHeaderPageSearchPreview
  */
@@ -118,10 +124,11 @@ fun PotiHeaderPageSearch(
     placeholder: String = stringResource(R.string.search_bar_placeholder),
     onClear: () -> Unit = { onValueChange("") },
     focusRequester: FocusRequester? = null,
+    containerColor: Color = PotiTheme.colors.white,
 ) {
     Row(
         modifier = modifier
-            .background(PotiTheme.colors.white)
+            .background(containerColor)
             .padding(horizontal = 4.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -47,18 +48,12 @@ fun PotiHeaderPage(
     @DrawableRes trailingIconRes: Int = R.drawable.ic_switch,
     containerColor: Color = PotiTheme.colors.white,
 ) {
-    Row(
-        modifier = modifier
-            .background(containerColor)
-            .padding(horizontal = 4.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    PotiHeaderPageBase(
+        onNavigationClick = onNavigationClick,
+        modifier = modifier,
+        potiHeaderPageType = potiHeaderPageType,
+        containerColor = containerColor,
     ) {
-        PotiIconButton(
-            iconRes = potiHeaderPageType.iconResId,
-            onClick = onNavigationClick,
-        )
-
         Column(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(2.dp),
@@ -126,6 +121,41 @@ fun PotiHeaderPageSearch(
     focusRequester: FocusRequester? = null,
     containerColor: Color = PotiTheme.colors.white,
 ) {
+    PotiHeaderPageBase(
+        onNavigationClick = onNavigationClick,
+        modifier = modifier,
+        potiHeaderPageType = potiHeaderPageType,
+        containerColor = containerColor,
+    ) {
+        PotiSearchBar(
+            value = value,
+            onValueChange = onValueChange,
+            onSearch = onSearch,
+            modifier = Modifier.weight(1f),
+            placeholder = placeholder,
+            onClear = onClear,
+            focusRequester = focusRequester,
+        )
+    }
+}
+
+/**
+ * 페이지 헤더의 공통 골격입니다. 내비게이션 버튼 뒤에 [content]를 배치합니다.
+ *
+ * @param onNavigationClick 내비게이션 버튼 클릭 시 호출됩니다.
+ * @param modifier
+ * @param potiHeaderPageType 내비게이션 버튼 아이콘 타입입니다.
+ * @param containerColor 헤더 배경색입니다. 화면 배경이 흰색이 아닌 경우 맞춰서 전달합니다.
+ * @param content 내비게이션 버튼 오른쪽에 배치할 내용입니다.
+ */
+@Composable
+private fun PotiHeaderPageBase(
+    onNavigationClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    potiHeaderPageType: PotiHeaderPageType = PotiHeaderPageType.BACK,
+    containerColor: Color = PotiTheme.colors.white,
+    content: @Composable RowScope.() -> Unit,
+) {
     Row(
         modifier = modifier
             .background(containerColor)
@@ -138,15 +168,7 @@ fun PotiHeaderPageSearch(
             onClick = onNavigationClick,
         )
 
-        PotiSearchBar(
-            value = value,
-            onValueChange = onValueChange,
-            onSearch = onSearch,
-            modifier = Modifier.weight(1f),
-            placeholder = placeholder,
-            onClear = onClear,
-            focusRequester = focusRequester,
-        )
+        content()
     }
 }
 

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
@@ -8,13 +8,21 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import com.poti.android.R
 import com.poti.android.core.designsystem.component.button.PotiIconButton
+import com.poti.android.core.designsystem.component.field.PotiSearchBar
 import com.poti.android.core.designsystem.theme.PotiTheme
 
 enum class PotiHeaderPageType(
@@ -32,6 +40,7 @@ fun PotiHeaderPage(
     title: String? = null,
     subTitle: String? = null,
     onTrailingIconClick: (() -> Unit)? = null,
+    @DrawableRes trailingIconRes: Int = R.drawable.ic_switch,
 ) {
     Row(
         modifier = modifier
@@ -54,6 +63,8 @@ fun PotiHeaderPage(
                     text = title,
                     style = PotiTheme.typography.body16sb,
                     color = PotiTheme.colors.black,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
 
@@ -64,16 +75,71 @@ fun PotiHeaderPage(
                         lineHeight = 1.35.em,
                     ),
                     color = PotiTheme.colors.gray700,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }
 
         onTrailingIconClick?.let {
             PotiIconButton(
-                iconRes = R.drawable.ic_switch,
+                iconRes = trailingIconRes,
                 onClick = onTrailingIconClick,
             )
         }
+    }
+}
+
+/**
+ * 검색어 입력이 포함된 헤더입니다.
+ *
+ * 내비게이션 버튼과 [PotiSearchBar]로 구성되며, 검색 화면 상단에 fixed로 사용합니다.
+ *
+ * @param onNavigationClick 내비게이션 버튼 클릭 시 호출됩니다.
+ * @param value 검색 필드 입력값입니다.
+ * @param onValueChange 검색 필드에 입력된 값을 전달합니다.
+ * @param onSearch 키보드 검색 액션 또는 검색 아이콘 클릭 시 호출됩니다.
+ * @param modifier
+ * @param potiHeaderPageType 내비게이션 버튼 아이콘 타입입니다.
+ * @param placeholder 입력값이 없을 때 검색 필드에 표시됩니다.
+ * @param onClear 삭제 아이콘 클릭 시 호출됩니다.
+ * @param focusRequester 포커스를 외부에서 제어하고 싶을 때 사용합니다.
+ *
+ * @sample PotiHeaderPageSearchPreview
+ */
+@Composable
+fun PotiHeaderPageSearch(
+    onNavigationClick: () -> Unit,
+    value: String,
+    onValueChange: (String) -> Unit,
+    onSearch: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    potiHeaderPageType: PotiHeaderPageType = PotiHeaderPageType.BACK,
+    placeholder: String = stringResource(R.string.search_bar_placeholder),
+    onClear: () -> Unit = { onValueChange("") },
+    focusRequester: FocusRequester? = null,
+) {
+    Row(
+        modifier = modifier
+            .background(PotiTheme.colors.white)
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        PotiIconButton(
+            iconRes = potiHeaderPageType.iconResId,
+            onClick = onNavigationClick,
+        )
+
+        PotiSearchBar(
+            value = value,
+            onValueChange = onValueChange,
+            onSearch = onSearch,
+            modifier = Modifier.weight(1f),
+            placeholder = placeholder,
+            onClear = onClear,
+            focusRequester = focusRequester,
+        )
     }
 }
 
@@ -107,6 +173,31 @@ private fun PotiHeaderPagePreview() {
                 title = "헤더 타이틀",
                 subTitle = "서브 타이틀",
                 onTrailingIconClick = {},
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PotiHeaderPageSearchPreview() {
+    var emptyValue by remember { mutableStateOf("") }
+    var filledValue by remember { mutableStateOf("아이브") }
+
+    PotiTheme {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            PotiHeaderPageSearch(
+                onNavigationClick = {},
+                value = emptyValue,
+                onValueChange = { emptyValue = it },
+                onSearch = {},
+            )
+
+            PotiHeaderPageSearch(
+                onNavigationClick = {},
+                value = filledValue,
+                onValueChange = { filledValue = it },
+                onSearch = {},
             )
         }
     }

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPrimary.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPrimary.kt
@@ -2,12 +2,14 @@ package com.poti.android.core.designsystem.component.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,10 +23,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
-import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.designsystem.component.button.PotiIconButton
 import com.poti.android.core.designsystem.theme.PotiTheme
 
@@ -135,7 +137,13 @@ private fun PotiHeaderPrimaryToggleItem(
 ) {
     Text(
         text = text,
-        modifier = modifier.noRippleClickable(onClick = onClick),
+        modifier = modifier.selectable(
+            selected = selected,
+            role = Role.Tab,
+            onClick = onClick,
+            indication = null,
+            interactionSource = remember { MutableInteractionSource() },
+        ),
         style = PotiTheme.typography.title18sb,
         color = if (selected) PotiTheme.colors.black else PotiTheme.colors.gray500,
     )

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPrimary.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPrimary.kt
@@ -6,18 +6,25 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
+import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.designsystem.component.button.PotiIconButton
 import com.poti.android.core.designsystem.theme.PotiTheme
 
@@ -67,6 +74,67 @@ fun PotiHeaderPrimary(
     }
 }
 
+/**
+ * 두 개의 텍스트 탭으로 구성된 헤더입니다.
+ *
+ * 뒤로가기 없이 최상위 탭 화면 상단에 사용하며, 선택된 탭만 강조합니다.
+ * 예: 분철 내역 탭의 모집내역 / 참여내역 전환
+ *
+ * @param firstText 첫 번째 탭 텍스트입니다.
+ * @param secondText 두 번째 탭 텍스트입니다.
+ * @param firstSelected 첫 번째 탭의 선택 여부입니다. false면 두 번째 탭이 선택된 상태입니다.
+ * @param onFirstClick 첫 번째 탭 클릭 시 호출됩니다.
+ * @param onSecondClick 두 번째 탭 클릭 시 호출됩니다.
+ * @param modifier
+ *
+ * @sample PotiHeaderPrimaryTogglePreview
+ */
+@Composable
+fun PotiHeaderPrimaryToggle(
+    firstText: String,
+    secondText: String,
+    firstSelected: Boolean,
+    onFirstClick: () -> Unit,
+    onSecondClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .heightIn(min = 56.dp)
+            .background(PotiTheme.colors.white)
+            .padding(horizontal = 20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        PotiHeaderPrimaryToggleItem(
+            text = firstText,
+            selected = firstSelected,
+            onClick = onFirstClick,
+        )
+
+        PotiHeaderPrimaryToggleItem(
+            text = secondText,
+            selected = !firstSelected,
+            onClick = onSecondClick,
+        )
+    }
+}
+
+@Composable
+private fun PotiHeaderPrimaryToggleItem(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        modifier = modifier.noRippleClickable(onClick = onClick),
+        style = PotiTheme.typography.title18sb,
+        color = if (selected) PotiTheme.colors.black else PotiTheme.colors.gray500,
+    )
+}
+
 @Preview
 @Composable
 private fun PotiHeaderPrimaryPreview() {
@@ -86,5 +154,21 @@ private fun PotiHeaderPrimaryPreview() {
                 onSecondIconClick = {},
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PotiHeaderPrimaryTogglePreview() {
+    var firstSelected by remember { mutableStateOf(true) }
+
+    PotiTheme {
+        PotiHeaderPrimaryToggle(
+            firstText = stringResource(R.string.header_primary_history_recruit),
+            secondText = stringResource(R.string.header_primary_history_participate),
+            firstSelected = firstSelected,
+            onFirstClick = { firstSelected = true },
+            onSecondClick = { firstSelected = false },
+        )
     }
 }

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPrimary.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPrimary.kt
@@ -2,7 +2,6 @@ package com.poti.android.core.designsystem.component.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,7 +22,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
@@ -139,10 +137,9 @@ private fun PotiHeaderPrimaryToggleItem(
         text = text,
         modifier = modifier.selectable(
             selected = selected,
-            role = Role.Tab,
-            onClick = onClick,
+            interactionSource = null,
             indication = null,
-            interactionSource = remember { MutableInteractionSource() },
+            onClick = onClick,
         ),
         style = PotiTheme.typography.title18sb,
         color = if (selected) PotiTheme.colors.black else PotiTheme.colors.gray500,

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPrimary.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPrimary.kt
@@ -28,6 +28,9 @@ import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.designsystem.component.button.PotiIconButton
 import com.poti.android.core.designsystem.theme.PotiTheme
 
+/**
+ * @param containerColor 헤더 배경색입니다. 화면 배경이 흰색이 아닌 경우 맞춰서 전달합니다.
+ */
 @Composable
 fun PotiHeaderPrimary(
     @DrawableRes firstIconRes: Int,
@@ -36,10 +39,11 @@ fun PotiHeaderPrimary(
     onSecondIconClick: () -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null,
+    containerColor: Color = PotiTheme.colors.white,
 ) {
     Row(
         modifier = modifier
-            .background(PotiTheme.colors.white)
+            .background(containerColor)
             .padding(start = 20.dp, end = 4.dp)
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -86,6 +90,7 @@ fun PotiHeaderPrimary(
  * @param onFirstClick 첫 번째 탭 클릭 시 호출됩니다.
  * @param onSecondClick 두 번째 탭 클릭 시 호출됩니다.
  * @param modifier
+ * @param containerColor 헤더 배경색입니다. 화면 배경이 흰색이 아닌 경우 맞춰서 전달합니다.
  *
  * @sample PotiHeaderPrimaryTogglePreview
  */
@@ -97,11 +102,12 @@ fun PotiHeaderPrimaryToggle(
     onFirstClick: () -> Unit,
     onSecondClick: () -> Unit,
     modifier: Modifier = Modifier,
+    containerColor: Color = PotiTheme.colors.white,
 ) {
     Row(
         modifier = modifier
             .heightIn(min = 56.dp)
-            .background(PotiTheme.colors.white)
+            .background(containerColor)
             .padding(horizontal = 20.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderSection.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderSection.kt
@@ -1,13 +1,12 @@
 package com.poti.android.core.designsystem.component.navigation
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.TabRowDefaults
-import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -16,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -35,90 +35,71 @@ fun PotiHeaderSection(
     selectedTab: PotiHeaderTabType,
     ongoingCount: Int,
     endedCount: Int,
-    modifier: Modifier = Modifier,
     onTabSelected: (PotiHeaderTabType) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    TabRow(
-        selectedTabIndex = selectedTab.ordinal,
-        containerColor = PotiTheme.colors.white,
+    Row(
         modifier = modifier,
-        divider = {
-            HorizontalDivider(
-                color = PotiTheme.colors.gray300,
-                thickness = 2.dp,
-            )
-        },
-        indicator = { tabPositions ->
-            TabRowDefaults.SecondaryIndicator(
-                Modifier.tabIndicatorOffset(tabPositions[selectedTab.ordinal]),
-                height = 2.dp,
-                color = PotiTheme.colors.poti600,
-            )
-        },
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         PotiHeaderTabType.entries.forEach { tabType ->
-            PotiHeaderSectionTab(
+            val count = when (tabType) {
+                PotiHeaderTabType.ONGOING -> ongoingCount
+                PotiHeaderTabType.ENDED -> endedCount
+            }
+
+            PotiHeaderSectionChip(
                 tabType = tabType,
-                selectedTab = selectedTab,
-                onTabSelected = { onTabSelected(tabType) },
-                ongoingCount = ongoingCount,
-                endedCount = endedCount,
+                count = count,
+                selected = selectedTab == tabType,
+                onClick = { onTabSelected(tabType) },
             )
         }
     }
 }
 
 @Composable
-private fun PotiHeaderSectionTab(
+private fun PotiHeaderSectionChip(
     tabType: PotiHeaderTabType,
-    selectedTab: PotiHeaderTabType,
-    onTabSelected: (PotiHeaderTabType) -> Unit,
-    ongoingCount: Int,
-    endedCount: Int,
+    count: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isSelected = selectedTab == tabType
-    val count = when (tabType) {
-        PotiHeaderTabType.ONGOING -> ongoingCount
-        PotiHeaderTabType.ENDED -> endedCount
-    }
+    val backgroundColor = if (selected) PotiTheme.colors.gray900 else PotiTheme.colors.gray100
+    val contentColor = if (selected) PotiTheme.colors.white else PotiTheme.colors.gray900
 
-    val activeColor = PotiTheme.colors.black
-    val inactiveColor = PotiTheme.colors.gray700
-
-    Column(
+    Row(
         modifier = modifier
-            .padding(vertical = 8.dp)
-            .noRippleClickable { onTabSelected(tabType) },
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
+            .heightIn(min = 36.dp)
+            .clip(CircleShape)
+            .background(backgroundColor)
+            .noRippleClickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = count.toString(),
-            style = PotiTheme.typography.display18b,
-            color = if (isSelected) activeColor else inactiveColor,
-        )
-        Text(
-            text = stringResource(tabType.labelResId),
-            style = PotiTheme.typography.body14m,
-            color = if (isSelected) activeColor else inactiveColor,
+            text = stringResource(tabType.labelResId, count),
+            style = PotiTheme.typography.body14sb,
+            color = contentColor,
         )
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun PotiHeaderSectionPreview() {
     var selectedTab by remember { mutableStateOf(PotiHeaderTabType.ONGOING) }
 
     PotiTheme {
-        Column {
-            PotiHeaderSection(
-                selectedTab = selectedTab,
-                ongoingCount = 2,
-                endedCount = 5,
-                onTabSelected = { selectedTab = it },
-            )
-        }
+        PotiHeaderSection(
+            selectedTab = selectedTab,
+            ongoingCount = 3,
+            endedCount = 3,
+            onTabSelected = { selectedTab = it },
+            modifier = Modifier.padding(16.dp),
+        )
     }
 }

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderSection.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderSection.kt
@@ -2,9 +2,9 @@ package com.poti.android.core.designsystem.component.navigation
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
@@ -79,13 +78,11 @@ private fun PotiHeaderSectionChip(
             .background(backgroundColor)
             .selectable(
                 selected = selected,
-                role = Role.Tab,
-                onClick = onClick,
+                interactionSource = null,
                 indication = null,
-                interactionSource = remember { MutableInteractionSource() },
+                onClick = onClick,
             )
             .padding(horizontal = 12.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -107,7 +104,9 @@ private fun PotiHeaderSectionPreview() {
             ongoingCount = 3,
             endedCount = 3,
             onTabSelected = { selectedTab = it },
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp)
+                .fillMaxWidth(),
         )
     }
 }

--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderSection.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderSection.kt
@@ -2,10 +2,12 @@ package com.poti.android.core.designsystem.component.navigation
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,10 +19,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
-import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.designsystem.theme.PotiTheme
 
 enum class PotiHeaderTabType(
@@ -75,7 +77,13 @@ private fun PotiHeaderSectionChip(
             .heightIn(min = 36.dp)
             .clip(CircleShape)
             .background(backgroundColor)
-            .noRippleClickable(onClick = onClick)
+            .selectable(
+                selected = selected,
+                role = Role.Tab,
+                onClick = onClick,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+            )
             .padding(horizontal = 12.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/poti/android/presentation/main/MainBottomBar.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainBottomBar.kt
@@ -16,17 +16,21 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.innerShadow
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.poti.android.core.common.extension.topRoundedBorder
@@ -44,10 +48,20 @@ fun MainBottomBar(
         enter = fadeIn(animationSpec = tween(300)) + slideIn(animationSpec = tween(300)) { IntOffset(0, it.height) },
         exit = fadeOut(animationSpec = tween(300)) + slideOut(animationSpec = tween(300)) { IntOffset(0, it.height) },
     ) {
+        val topRoundedShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+
         Row(
             modifier = modifier
                 .fillMaxWidth()
-                .background(PotiTheme.colors.white)
+                .background(PotiTheme.colors.white, topRoundedShape)
+                .innerShadow(
+                    shape = topRoundedShape,
+                    shadow = Shadow(
+                        radius = 4.dp,
+                        color = PotiTheme.colors.white.copy(alpha = 0.5f),
+                        offset = DpOffset(x = 0.dp, y = 4.dp),
+                    ),
+                )
                 .topRoundedBorder(1.dp, PotiTheme.colors.gray300, 20.dp)
                 .padding(16.dp)
                 .navigationBarsPadding(),

--- a/app/src/main/java/com/poti/android/presentation/user/component/BadgeButton.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/BadgeButton.kt
@@ -32,7 +32,7 @@ fun BadgeButton(
         modifier = modifier
             .heightIn(min = 40.dp)
             .clip(CircleShape)
-            .background(PotiTheme.colors.poti200)
+            .background(PotiTheme.colors.poti400)
             .noRippleClickable(onClick)
             .padding(vertical = 8.dp)
             .padding(start = 16.dp, end = 8.dp),
@@ -41,7 +41,7 @@ fun BadgeButton(
     ) {
         Text(
             text = bias,
-            color = PotiTheme.colors.poti800,
+            color = PotiTheme.colors.black,
             style = PotiTheme.typography.body14m,
         )
 
@@ -49,7 +49,7 @@ fun BadgeButton(
             imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_right_sm),
             contentDescription = null,
             modifier = Modifier.size(20.dp),
-            tint = PotiTheme.colors.poti800,
+            tint = PotiTheme.colors.black,
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/component/HistorySummaryCard.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/HistorySummaryCard.kt
@@ -37,12 +37,15 @@ enum class HistorySummaryType {
     COMPLETED,
 }
 
+/**
+ * @param onItemClick null이면 항목을 클릭할 수 없습니다.
+ */
 @Composable
 fun HistorySummaryCard(
     title: String,
     summary: HistorySummary,
-    onItemClick: (HistorySummaryType) -> Unit,
     modifier: Modifier = Modifier,
+    onItemClick: ((HistorySummaryType) -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
@@ -66,7 +69,7 @@ fun HistorySummaryCard(
             HistoryItem(
                 title = stringResource(R.string.user_history_ongoing),
                 count = summary.inProgress,
-                onClick = { onItemClick(HistorySummaryType.IN_PROGRESS) },
+                onClick = onItemClick?.let { { it(HistorySummaryType.IN_PROGRESS) } },
                 colored = true,
             )
 
@@ -75,7 +78,7 @@ fun HistorySummaryCard(
             HistoryItem(
                 title = stringResource(R.string.user_history_ended),
                 count = summary.completed,
-                onClick = { onItemClick(HistorySummaryType.COMPLETED) },
+                onClick = onItemClick?.let { { it(HistorySummaryType.COMPLETED) } },
                 colored = false,
             )
         }
@@ -84,12 +87,13 @@ fun HistorySummaryCard(
 
 /**
  * @param colored 카운트를 강조 색으로 표시할지 여부입니다. 진행중은 true, 종료는 false를 사용합니다.
+ * @param onClick null이면 클릭 및 pressed 효과가 적용되지 않습니다.
  */
 @Composable
 private fun HistoryItem(
     title: String,
     count: Int,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)?,
     colored: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -103,9 +107,15 @@ private fun HistoryItem(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(backgroundColor)
-            .noRippleClickable(
-                interactionSource = interactionSource,
-                onClick = onClick,
+            .then(
+                if (onClick != null) {
+                    Modifier.noRippleClickable(
+                        interactionSource = interactionSource,
+                        onClick = onClick,
+                    )
+                } else {
+                    Modifier
+                },
             )
             .padding(horizontal = 12.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -150,7 +160,6 @@ private fun HistorySummaryCardPreview() {
             HistorySummaryCard(
                 title = "모집 내역",
                 summary = summary,
-                onItemClick = {},
                 modifier = Modifier.width(158.dp),
             )
         }

--- a/app/src/main/java/com/poti/android/presentation/user/component/HistorySummaryCard.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/HistorySummaryCard.kt
@@ -6,16 +6,11 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
-import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -27,10 +22,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
 import com.poti.android.core.common.extension.noRippleClickable
+import com.poti.android.core.designsystem.component.display.PotiDivider
+import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.user.HistorySummary
 import kotlinx.serialization.Serializable
 
+// TODO: [천민재] ALL은 Figma 개편으로 UI에서 제거되었으나, API 응답(HistorySummary.total)과
+//  분철 내역 진입 파라미터로는 여전히 사용되므로 enum 값은 유지한다.
 @Serializable
 enum class HistorySummaryType {
     ALL,
@@ -46,100 +45,81 @@ fun HistorySummaryCard(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.Start,
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(PotiTheme.colors.white)
+            .padding(horizontal = 12.dp)
+            .padding(top = 16.dp, bottom = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = title,
             color = PotiTheme.colors.black,
-            style = PotiTheme.typography.body16sb,
+            style = PotiTheme.typography.body14sb,
         )
 
-        Spacer(Modifier.height(12.dp))
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
-                .background(PotiTheme.colors.gray100)
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            HistoryItem(
-                title = stringResource(R.string.user_history_all),
-                count = summary.total,
-                onClick = { onItemClick(HistorySummaryType.ALL) },
-                modifier = Modifier.weight(1f),
-            )
-
-            VerticalDivider(
-                modifier = Modifier
-                    .height(56.dp)
-                    .clip(CircleShape),
-                thickness = 1.dp,
-                color = PotiTheme.colors.gray300,
-            )
-
             HistoryItem(
                 title = stringResource(R.string.user_history_ongoing),
                 count = summary.inProgress,
                 onClick = { onItemClick(HistorySummaryType.IN_PROGRESS) },
-                modifier = Modifier.weight(1f),
+                colored = true,
             )
 
-            VerticalDivider(
-                modifier = Modifier
-                    .height(56.dp)
-                    .clip(CircleShape),
-                thickness = 1.dp,
-                color = PotiTheme.colors.gray300,
-            )
+            PotiDivider(styleType = PotiDividerStyle.SMALL)
 
             HistoryItem(
                 title = stringResource(R.string.user_history_ended),
                 count = summary.completed,
                 onClick = { onItemClick(HistorySummaryType.COMPLETED) },
-                modifier = Modifier.weight(1f),
+                colored = false,
             )
         }
     }
 }
 
+/**
+ * @param colored 카운트를 강조 색으로 표시할지 여부입니다. 진행중은 true, 종료는 false를 사용합니다.
+ */
 @Composable
 private fun HistoryItem(
     title: String,
     count: Int,
     onClick: () -> Unit,
+    colored: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
-    val backgroundColor = if (isPressed) PotiTheme.colors.gray300 else PotiTheme.colors.gray100
+    val backgroundColor = if (isPressed) PotiTheme.colors.gray100 else PotiTheme.colors.white
+    val countColor = if (colored) PotiTheme.colors.poti600 else PotiTheme.colors.black
 
-    Column(
+    Row(
         modifier = modifier
-            .widthIn(92.dp)
+            .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(backgroundColor)
             .noRippleClickable(
                 interactionSource = interactionSource,
                 onClick = onClick,
             )
-            .padding(vertical = 18.5.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = count.toString(),
-            color = PotiTheme.colors.poti600,
-            style = PotiTheme.typography.title18sb,
+            text = title,
+            color = PotiTheme.colors.gray900,
+            style = PotiTheme.typography.body14sb,
         )
         Text(
-            text = title,
-            color = PotiTheme.colors.gray800,
-            style = PotiTheme.typography.caption12m,
+            text = count.toString(),
+            color = countColor,
+            style = PotiTheme.typography.display18b,
         )
     }
 }
@@ -154,21 +134,24 @@ private fun HistorySummaryCardPreview() {
     )
 
     PotiTheme {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+        Row(
+            modifier = Modifier
+                .background(PotiTheme.colors.gray100)
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             HistorySummaryCard(
                 title = "참여 내역",
                 summary = summary,
                 onItemClick = {},
-                modifier = Modifier.width(328.dp),
+                modifier = Modifier.width(158.dp),
             )
 
             HistorySummaryCard(
-                title = "참여 내역",
+                title = "모집 내역",
                 summary = summary,
                 onItemClick = {},
+                modifier = Modifier.width(158.dp),
             )
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/user/component/UserInfo.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/UserInfo.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -29,47 +29,38 @@ fun UserInfo(
     joinedAt: String,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    Row(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
-            .background(PotiTheme.colors.gray100)
-            .padding(all = 12.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
+            .background(PotiTheme.colors.white)
+            .padding(horizontal = 12.dp, vertical = 16.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        UserInfoItem(
-            infoContent = activityMessage,
-            modifier = Modifier.fillMaxWidth(),
+        UserInfoText(text = activityMessage)
+
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_bullet),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = PotiTheme.colors.gray800,
         )
-        UserInfoItem(
-            infoContent = formatJoinedDate(joinedAt),
-            modifier = Modifier.fillMaxWidth(),
-        )
+
+        UserInfoText(text = formatJoinedDate(joinedAt))
     }
 }
 
 @Composable
-private fun UserInfoItem(
-    infoContent: String,
+private fun UserInfoText(
+    text: String,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    Text(
+        text = text,
         modifier = modifier,
-        horizontalArrangement = Arrangement.Start,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_bullet),
-            contentDescription = null,
-            tint = PotiTheme.colors.gray800,
-        )
-
-        Text(
-            text = infoContent,
-            color = PotiTheme.colors.black,
-            style = PotiTheme.typography.caption12m,
-        )
-    }
+        color = PotiTheme.colors.gray800,
+        style = PotiTheme.typography.body14m,
+    )
 }
 
 private fun formatJoinedDate(joinedAt: String): String {
@@ -87,7 +78,9 @@ private fun formatJoinedDate(joinedAt: String): String {
 private fun UserInfoCardPreview() {
     PotiTheme {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier
+                .background(PotiTheme.colors.gray100)
+                .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             UserInfo(

--- a/app/src/main/java/com/poti/android/presentation/user/component/UserProfile.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/UserProfile.kt
@@ -22,11 +22,14 @@ import coil.request.ImageRequest
 import com.poti.android.R
 import com.poti.android.core.designsystem.theme.PotiTheme
 
+/**
+ * @param email null이면 이메일을 노출하지 않습니다. 타인의 프로필 조회 시 null을 전달합니다.
+ */
 @Composable
 fun UserProfile(
     nickname: String,
-    email: String,
     modifier: Modifier = Modifier,
+    email: String? = null,
     imageUrl: String? = "",
 ) {
     Column(
@@ -57,13 +60,15 @@ fun UserProfile(
             style = PotiTheme.typography.body16sb,
         )
 
-        Spacer(Modifier.height(2.dp))
+        email?.let {
+            Spacer(Modifier.height(2.dp))
 
-        Text(
-            text = email,
-            color = PotiTheme.colors.gray700,
-            style = PotiTheme.typography.caption12m,
-        )
+            Text(
+                text = it,
+                color = PotiTheme.colors.gray700,
+                style = PotiTheme.typography.caption12m,
+            )
+        }
     }
 }
 
@@ -78,6 +83,11 @@ private fun UserProfilePreview() {
             UserProfile(
                 nickname = "포티포티포티",
                 email = "poti@app.jam",
+                modifier = Modifier,
+            )
+
+            UserProfile(
+                nickname = "포티포티포티",
                 modifier = Modifier,
             )
         }

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.user.mypage
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,11 +8,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -83,38 +86,51 @@ private fun MyPageScreen(
             onFirstIconClick = {},
             secondIconRes = R.drawable.ic_alarm,
             onSecondIconClick = {},
+            containerColor = PotiTheme.colors.gray100,
         )
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .background(PotiTheme.colors.gray100)
                 .verticalScroll(scrollState)
                 .padding(
                     horizontal = 16.dp,
                     vertical = 20.dp,
                 ),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            UserProfile(
-                imageUrl = userMyPage.profileImageUrl,
-                nickname = userMyPage.nickname,
-                email = userMyPage.email,
-            )
-
-            Row(
-                modifier = Modifier,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(PotiTheme.colors.white)
+                    .padding(horizontal = 12.dp)
+                    .padding(top = 32.dp, bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                RatingBadge(
-                    rating = userMyPage.ratingAvg,
+                UserProfile(
+                    imageUrl = userMyPage.profileImageUrl,
+                    nickname = userMyPage.nickname,
+                    email = userMyPage.email,
                 )
 
-                BadgeButton(
-                    bias = biasText,
-                    onClick = onArtistClick,
+                Row(
                     modifier = Modifier,
-                )
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RatingBadge(
+                        rating = userMyPage.ratingAvg,
+                    )
+
+                    BadgeButton(
+                        bias = biasText,
+                        onClick = onArtistClick,
+                        modifier = Modifier,
+                    )
+                }
             }
 
             UserInfo(

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -93,10 +93,7 @@ private fun MyPageScreen(
                 .fillMaxSize()
                 .background(PotiTheme.colors.gray100)
                 .verticalScroll(scrollState)
-                .padding(
-                    horizontal = 16.dp,
-                    vertical = 20.dp,
-                ),
+                .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -106,7 +103,7 @@ private fun MyPageScreen(
                     .clip(RoundedCornerShape(12.dp))
                     .background(PotiTheme.colors.white)
                     .padding(horizontal = 12.dp)
-                    .padding(top = 32.dp, bottom = 12.dp),
+                    .padding(top = 57.dp, bottom = 37.dp),
                 verticalArrangement = Arrangement.spacedBy(24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -123,19 +123,24 @@ private fun MyPageScreen(
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            HistorySummaryCard(
-                title = stringResource(R.string.user_history_participate),
-                summary = userMyPage.participationSummary,
-                onItemClick = { type -> onHistoryClick(HistoryMode.PARTICIPATION, type) },
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-            )
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                HistorySummaryCard(
+                    title = stringResource(R.string.user_history_participate),
+                    summary = userMyPage.participationSummary,
+                    onItemClick = { type -> onHistoryClick(HistoryMode.PARTICIPATION, type) },
+                    modifier = Modifier.weight(1f),
+                )
 
-            HistorySummaryCard(
-                title = stringResource(R.string.user_history_recruit),
-                summary = userMyPage.recruitSummary,
-                onItemClick = { type -> onHistoryClick(HistoryMode.RECRUIT, type) },
-                modifier = Modifier.fillMaxWidth(),
-            )
+                HistorySummaryCard(
+                    title = stringResource(R.string.user_history_recruit),
+                    summary = userMyPage.recruitSummary,
+                    onItemClick = { type -> onHistoryClick(HistoryMode.RECRUIT, type) },
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
@@ -77,10 +77,7 @@ private fun ProfileScreen(
                 .fillMaxSize()
                 .background(PotiTheme.colors.gray100)
                 .verticalScroll(scrollState)
-                .padding(
-                    horizontal = 16.dp,
-                    vertical = 20.dp,
-                ),
+                .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -90,11 +87,10 @@ private fun ProfileScreen(
                     .clip(RoundedCornerShape(12.dp))
                     .background(PotiTheme.colors.white)
                     .padding(horizontal = 12.dp)
-                    .padding(top = 32.dp, bottom = 12.dp),
+                    .padding(top = 67.dp, bottom = 47.dp),
                 verticalArrangement = Arrangement.spacedBy(24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                // 타인의 프로필에서는 이메일을 노출하지 않는다.
                 UserProfile(
                     imageUrl = userProfile.profileImageUrl,
                     nickname = userProfile.nickname,

--- a/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.user.profile
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,11 +8,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -66,28 +69,41 @@ private fun ProfileScreen(
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,
+            containerColor = PotiTheme.colors.gray100,
         )
 
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .background(PotiTheme.colors.gray100)
                 .verticalScroll(scrollState)
                 .padding(
                     horizontal = 16.dp,
                     vertical = 20.dp,
                 ),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // 타인의 프로필에서는 이메일을 노출하지 않는다.
-            UserProfile(
-                imageUrl = userProfile.profileImageUrl,
-                nickname = userProfile.nickname,
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(PotiTheme.colors.white)
+                    .padding(horizontal = 12.dp)
+                    .padding(top = 32.dp, bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // 타인의 프로필에서는 이메일을 노출하지 않는다.
+                UserProfile(
+                    imageUrl = userProfile.profileImageUrl,
+                    nickname = userProfile.nickname,
+                )
 
-            RatingBadge(
-                rating = userProfile.ratingAvg.toString(),
-            )
+                RatingBadge(
+                    rating = userProfile.ratingAvg.toString(),
+                )
+            }
 
             UserInfo(
                 activityMessage = userProfile.activityMessage,

--- a/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
@@ -2,6 +2,7 @@ package com.poti.android.presentation.user.profile
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -78,10 +79,10 @@ private fun ProfileScreen(
             verticalArrangement = Arrangement.spacedBy(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            // 타인의 프로필에서는 이메일을 노출하지 않는다.
             UserProfile(
                 imageUrl = userProfile.profileImageUrl,
                 nickname = userProfile.nickname,
-                email = userProfile.email,
             )
 
             RatingBadge(
@@ -94,12 +95,26 @@ private fun ProfileScreen(
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            HistorySummaryCard(
-                title = stringResource(R.string.user_history_recruit),
-                summary = userProfile.recruitSummary,
-                onItemClick = { type -> },
+            // 타인의 모집/참여 내역은 조회할 수 없으므로 onItemClick을 전달하지 않는다.
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-            )
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                // TODO: [천민재] 변경된 디자인에는 참여 내역 카드가 추가되었으나,
+                //  프로필 API(ProfileResponse)가 아직 participationSummary를 내려주지 않는다.
+                //  서버 반영 후 UserProfile.participationSummary로 교체할 것.
+                HistorySummaryCard(
+                    title = stringResource(R.string.user_history_participate),
+                    summary = HistorySummary(total = 0, inProgress = 0, completed = 0),
+                    modifier = Modifier.weight(1f),
+                )
+
+                HistorySummaryCard(
+                    title = stringResource(R.string.user_history_recruit),
+                    summary = userProfile.recruitSummary,
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
 
     <!-- Field Component -->
     <string name="field_label_name">이름</string>
+    <string name="search_bar_placeholder">검색어를 입력하세요</string>
 
 
     <!-- LoginScreen -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <!-- Navigation Component -->
     <string name="header_section_ongoing">진행중 %1$d</string>
     <string name="header_section_ended">종료 %1$d</string>
+    <string name="header_primary_history_recruit">모집내역</string>
+    <string name="header_primary_history_participate">참여내역</string>
 
     <!-- Button Component -->
     <string name="action_button_next">다음</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,8 +7,8 @@
     <string name="bottom_nav_my_page">마이페이지</string>
 
     <!-- Navigation Component -->
-    <string name="header_section_ongoing">진행 중</string>
-    <string name="header_section_ended">종료</string>
+    <string name="header_section_ongoing">진행중 %1$d</string>
+    <string name="header_section_ended">종료 %1$d</string>
 
     <!-- Button Component -->
     <string name="action_button_next">다음</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,7 +222,6 @@
     <!-- User Component -->
     <string name="user_history_recruit">모집 내역</string>
     <string name="user_history_participate">참여 내역</string>
-    <string name="user_history_all">전체</string>
     <string name="user_history_ongoing">진행중</string>
     <string name="user_history_ended">종료</string>
     <string name="user_my_page_title">마이</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #166 

## Work Description ✏️

Figma 컴포넌트 가이드 갱신분을 반영했습니다.
**컴포넌트를 먼저 고치고 → 화면에 적용**하는 순서로 커밋을 나눴습니다.

### 디자인 시스템

| 컴포넌트 | 변경 |
| --- | --- |
| `PotiHeaderSection` | 카운트 탭 → **칩 형태**로 재작성. 카운트는 `진행중 3`처럼 라벨에 포함 |
| `PotiSearchBar` | **신규 컴포넌트** — 검색 입력 바 |
| `PotiHeaderPageSearch` | **신규 컴포넌트** — 뒤로가기 + 검색 바 형태의 헤더 |
| `PotiHeaderPrimaryToggle` | **신규 컴포넌트** — `모집내역 \| 참여내역` 토글 헤더 |
| `PotiHeaderPage` | 타이틀 말줄임표, trailing 아이콘 파라미터화 |
| `PotiModalButton` | `SECONDARY` 타입 추가 |
| `BadgeButton` | 배경, 텍스트 색 변경 |
| 헤더 4종 | `containerColor` 파라미터 추가 (기본값 흰색) — `PotiHeaderPage` · `PotiHeaderPageSearch` · `PotiHeaderPrimary` · `PotiHeaderPrimaryToggle` |

### 마이페이지 · 프로필

| 항목 | 변경 |
| --- | --- |
| **명암 반전** | 화면 배경 회색 + 섹션 흰 카드 (기존과 반대) |
| `HistorySummaryCard` | 3칸 가로 → **2행 세로**. 카드 2개를 가로로 나란히 배치 |
| `UserInfo` | 2행 → **1행**, 두 텍스트 사이 bullet 1개 |
| `UserProfile` | `email` nullable → **타인 프로필에서 이메일 숨김** |
| 내역 카드 클릭 | 프로필에서는 클릭 효과 제거 (타인 내역은 조회 불가) |

### 바텀 내비게이션

- inset shadow 적용 (Compose 내장 `Modifier.innerShadow()`)

## Screenshot 📸

| 마이페이지 | 프로필 |
| --- | --- |
| <img width="265" height="582" alt="스크린샷 2026-07-28 오후 6 24 35" src="https://github.com/user-attachments/assets/04f2f081-0564-4ae8-ba7c-675e9b34b128" /> | <img width="204" height="429" alt="스크린샷 2026-07-28 오후 6 25 06" src="https://github.com/user-attachments/assets/530323d9-4160-469b-83f5-8db3093145b4" /> |

| header-section (칩) | header-page |
| --- | --- |
| <img width="208" height="94" alt="스크린샷 2026-07-28 오후 6 27 56" src="https://github.com/user-attachments/assets/5c7ca184-f35c-4db2-bf91-28cba96a8ee8" /> | <img width="418" height="191" alt="스크린샷 2026-07-28 오후 6 28 41" src="https://github.com/user-attachments/assets/14fd019d-c23c-404c-8d68-fe9f41a3d141" /> |

## Uncompleted Tasks 😅

- [ ] **프로필 참여 내역 카드에 데이터 없음** — `ProfileResponse`에 `participationSummary`가 없어
      임시로 `0`을 표시합니다. 서버 추가 후 후속 PR에서 연결 예정 (코드에 TODO)
- [ ] **소비처가 없는 컴포넌트 3개** — `PotiHeaderPageSearch` · `PotiHeaderPrimaryToggle` ·
      `ModalButtonType.SECONDARY`. 컴포넌트만 먼저 만들었고 화면 연결은 후속 이슈
- [ ] **분철 내역 화면 헤더 교체** — `PotiHeaderPrimaryToggle`은 만들어 뒀지만,
      적용 시 모드 전환 동작까지 함께 바뀌어야 해서 후속 이슈로 분리했습니다

## To Reviewers 📢

**1. 명암 반전**

기존 `흰 배경 + 회색 섹션`에서 `회색 배경 + 흰 섹션`으로 뒤집혔습니다.

헤더도 화면 배경과 이어져야 하는데 배경색이 `white`로 하드코딩되어 있어,
헤더 컴포넌트 4종에 `containerColor` 파라미터를 추가했습니다.
기본값이 흰색이라 나머지 호출부는 영향이 없고, 마이페이지·프로필에서만 회색을 넘깁니다.
(Figma도 컴포넌트 기본값은 흰색이고 해당 화면에서만 회색으로 오버라이드되어 있습니다)

**2. `HistorySummaryType.ALL`을 남겨뒀습니다**

`전체` 항목이 UI에서 빠졌지만 enum과 `HistorySummary.total`은 유지했습니다.
API 응답에 있고 분철 내역 진입 파라미터로도 쓰이기 때문입니다.
미사용이 된 `user_history_all` 문자열은 제거했습니다.

### 커밋 순서

**앞쪽 7개는 컴포넌트 단위로, 뒤쪽 3개는 화면 적용**으로 나눴습니다.

```
header-section 칩 형태로 변경          ← 컴포넌트
search-bar 컴포넌트 추가
header-page 검색 헤더 추가
header-primary 토글 헤더 추가
btn-modal secondary 타입 추가
btn-badge 색상 변경
history-vertical 구조 변경

마이페이지·프로필 내역 카드 2단 배치     ← 화면 적용
마이페이지·프로필 배경 명암 반전
바텀 내비게이션 inner shadow 적용
```

`header-section` 커밋만 호출부(`HistoryListScreen`)가 함께 들어가 있습니다.
칩 전환으로 화면 수정이 같이 필요해서 수정되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 검색창 UI(입력·검색·초기화)와 검색 전용 헤더를 추가했습니다.
  * 선택형 헤더(토글)와 보조 모달 버튼 스타일을 추가했습니다.
* **개선 사항**
  * 헤더 탭을 칩 형태로 변경하고 진행·종료 개수를 표시합니다.
  * 히스토리 요약 카드를 2열로 정리하고 선택적 클릭 동작을 지원합니다.
  * 마이페이지·프로필 레이아웃과 카드 디자인을 개선했습니다.
  * 이메일이 없는 프로필도 자연스럽게 표시됩니다.
* **디자인 및 문구**
  * 하단 바, 배지 버튼, 사용자 정보와 관련 안내 문구를 다듬었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->