### PR TITLE
[Refactor/#168] 토큰 재발급 및 인증 상태 처리 안정화

### DIFF
--- a/app/src/main/java/com/poti/android/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/NetworkModule.kt
@@ -59,10 +59,40 @@ object NetworkModule {
         addInterceptor(loggingInterceptor)
     }.build()
 
+    @ReissueClient
+    @Provides
+    @Singleton
+    fun provideReissueOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+    ): OkHttpClient = OkHttpClient.Builder().apply {
+        connectTimeout(10, TimeUnit.SECONDS)
+        writeTimeout(10, TimeUnit.SECONDS)
+        readTimeout(10, TimeUnit.SECONDS)
+        addInterceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("Accept", "*/*")
+                .build()
+            chain.proceed(request)
+        }
+        addInterceptor(loggingInterceptor)
+    }.build()
+
     @Provides
     @Singleton
     fun provideRetrofit(
         okHttpClient: OkHttpClient,
+        json: Json,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BuildConfig.BASE_URL)
+        .client(okHttpClient)
+        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .build()
+
+    @ReissueClient
+    @Provides
+    @Singleton
+    fun provideReissueRetrofit(
+        @ReissueClient okHttpClient: OkHttpClient,
         json: Json,
     ): Retrofit = Retrofit.Builder()
         .baseUrl(BuildConfig.BASE_URL)

--- a/app/src/main/java/com/poti/android/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/NetworkModule.kt
@@ -32,7 +32,7 @@ object NetworkModule {
     @Singleton
     fun provideLoggingInterceptor(): HttpLoggingInterceptor = HttpLoggingInterceptor().apply {
         level = if (BuildConfig.DEBUG) {
-            HttpLoggingInterceptor.Level.BODY
+            HttpLoggingInterceptor.Level.BASIC
         } else {
             HttpLoggingInterceptor.Level.NONE
         }

--- a/app/src/main/java/com/poti/android/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/NetworkModule.kt
@@ -65,9 +65,10 @@ object NetworkModule {
     fun provideReissueOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
     ): OkHttpClient = OkHttpClient.Builder().apply {
-        connectTimeout(10, TimeUnit.SECONDS)
-        writeTimeout(10, TimeUnit.SECONDS)
-        readTimeout(10, TimeUnit.SECONDS)
+        callTimeout(8, TimeUnit.SECONDS)
+        connectTimeout(3, TimeUnit.SECONDS)
+        writeTimeout(5, TimeUnit.SECONDS)
+        readTimeout(5, TimeUnit.SECONDS)
         addInterceptor { chain ->
             val request = chain.request().newBuilder()
                 .header("Accept", "*/*")

--- a/app/src/main/java/com/poti/android/data/di/ReissueClient.kt
+++ b/app/src/main/java/com/poti/android/data/di/ReissueClient.kt
@@ -1,0 +1,7 @@
+package com.poti.android.data.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ReissueClient

--- a/app/src/main/java/com/poti/android/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/ServiceModule.kt
@@ -30,6 +30,13 @@ object ServiceModule {
     fun provideAuthService(retrofit: Retrofit): AuthService =
         retrofit.create(AuthService::class.java)
 
+    @ReissueClient
+    @Provides
+    @Singleton
+    fun provideReissueAuthService(
+        @ReissueClient retrofit: Retrofit,
+    ): AuthService = retrofit.create(AuthService::class.java)
+
     @Provides
     @Singleton
     fun provideUserService(retrofit: Retrofit): UserService =

--- a/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
@@ -44,8 +44,12 @@ class AuthTokenStore @Inject constructor(
     val authState: Flow<AuthState> = combine(
         preferenceDataSource.authState,
         tokenState,
-    ) { authState, tokenState ->
-        authState.copy(isInitialized = tokenState.isInitialized)
+    ) { persistedAuthState, tokenState ->
+        AuthState(
+            accessToken = tokenState.tokenPair?.accessToken,
+            isOnboardingFinished = persistedAuthState.isOnboardingFinished,
+            isInitialized = tokenState.isInitialized,
+        )
     }
 
     val cachedTokenPair: TokenPair?

--- a/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -59,11 +60,13 @@ class AuthTokenStore @Inject constructor(
         }
     }
 
-    fun ensureInitializedBlocking() {
-        if (tokenState.value.isInitialized) return
+    fun ensureInitializedBlocking(): Boolean {
+        if (tokenState.value.isInitialized) return true
 
-        runBlocking {
-            awaitInitialized()
+        return runBlocking {
+            withTimeoutOrNull(INITIALIZATION_TIMEOUT_MILLIS) {
+                awaitInitialized()
+            } != null
         }
     }
 
@@ -73,23 +76,41 @@ class AuthTokenStore @Inject constructor(
         accessToken: String,
         refreshToken: String,
     ) {
-        _tokenState.value = AuthTokenState(
-            isInitialized = true,
-            tokenPair = TokenPair(
-                accessToken = accessToken,
-                refreshToken = refreshToken,
-            ),
-        )
-        preferenceDataSource.saveTokens(accessToken, refreshToken)
+        val tokenPair = TokenPair(accessToken, refreshToken)
+        updateCachedTokens(tokenPair)
+        persistTokens(tokenPair)
     }
 
     suspend fun clearTokens() {
-        _tokenState.value = AuthTokenState(isInitialized = true)
-        preferenceDataSource.clearTokens()
+        clearCachedTokens()
+        persistTokenClear()
     }
 
     suspend fun clearAll() {
         _tokenState.value = AuthTokenState(isInitialized = true)
         preferenceDataSource.clearAll()
+    }
+
+    fun updateCachedTokens(tokenPair: TokenPair) {
+        _tokenState.value = AuthTokenState(
+            isInitialized = true,
+            tokenPair = tokenPair,
+        )
+    }
+
+    fun clearCachedTokens() {
+        _tokenState.value = AuthTokenState(isInitialized = true)
+    }
+
+    suspend fun persistTokens(tokenPair: TokenPair) {
+        preferenceDataSource.saveTokens(tokenPair.accessToken, tokenPair.refreshToken)
+    }
+
+    suspend fun persistTokenClear() {
+        preferenceDataSource.clearTokens()
+    }
+
+    private companion object {
+        const val INITIALIZATION_TIMEOUT_MILLIS = 1_000L
     }
 }

--- a/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,6 +27,7 @@ data class TokenPair(
 data class AuthTokenState(
     val isInitialized: Boolean = false,
     val tokenPair: TokenPair? = null,
+    val generation: Long = 0L,
 )
 
 @Singleton
@@ -33,6 +36,8 @@ class AuthTokenStore @Inject constructor(
     @ApplicationScope private val externalScope: CoroutineScope,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
+    private val cacheLock = Any()
+    private val persistenceMutex = Mutex()
     private val _tokenState = MutableStateFlow(AuthTokenState())
     val tokenState: StateFlow<AuthTokenState> = _tokenState.asStateFlow()
 
@@ -52,10 +57,7 @@ class AuthTokenStore @Inject constructor(
     init {
         externalScope.launch(ioDispatcher) {
             preferenceDataSource.tokenPair.collect { tokenPair ->
-                _tokenState.value = AuthTokenState(
-                    isInitialized = true,
-                    tokenPair = tokenPair,
-                )
+                initializeFromStorage(tokenPair)
             }
         }
     }
@@ -77,37 +79,80 @@ class AuthTokenStore @Inject constructor(
         refreshToken: String,
     ) {
         val tokenPair = TokenPair(accessToken, refreshToken)
-        updateCachedTokens(tokenPair)
-        persistTokens(tokenPair)
+        val generation = updateCachedTokens(tokenPair)
+        persistTokensIfCurrent(tokenPair, generation)
     }
 
     suspend fun clearTokens() {
-        clearCachedTokens()
-        persistTokenClear()
+        val generation = clearCachedTokens()
+        persistTokenClearIfCurrent(generation)
     }
 
     suspend fun clearAll() {
-        _tokenState.value = AuthTokenState(isInitialized = true)
-        preferenceDataSource.clearAll()
+        val generation = clearCachedTokens()
+        persistenceMutex.withLock {
+            if (isCurrentClearedGeneration(generation)) {
+                preferenceDataSource.clearAll()
+            }
+        }
     }
 
-    fun updateCachedTokens(tokenPair: TokenPair) {
+    fun updateCachedTokens(tokenPair: TokenPair): Long = synchronized(cacheLock) {
+        val generation = tokenState.value.generation + 1
         _tokenState.value = AuthTokenState(
             isInitialized = true,
             tokenPair = tokenPair,
+            generation = generation,
         )
+        generation
     }
 
-    fun clearCachedTokens() {
-        _tokenState.value = AuthTokenState(isInitialized = true)
+    fun clearCachedTokens(): Long = synchronized(cacheLock) {
+        val generation = tokenState.value.generation + 1
+        _tokenState.value = AuthTokenState(
+            isInitialized = true,
+            generation = generation,
+        )
+        generation
     }
 
-    suspend fun persistTokens(tokenPair: TokenPair) {
+    suspend fun persistTokensIfCurrent(
+        tokenPair: TokenPair,
+        generation: Long,
+    ): Boolean = persistenceMutex.withLock {
+        if (!isCurrentGeneration(tokenPair, generation)) return@withLock false
+
         preferenceDataSource.saveTokens(tokenPair.accessToken, tokenPair.refreshToken)
+        true
     }
 
-    suspend fun persistTokenClear() {
+    suspend fun persistTokenClearIfCurrent(generation: Long): Boolean = persistenceMutex.withLock {
+        if (!isCurrentClearedGeneration(generation)) return@withLock false
+
         preferenceDataSource.clearTokens()
+        true
+    }
+
+    private fun initializeFromStorage(tokenPair: TokenPair?) {
+        synchronized(cacheLock) {
+            if (tokenState.value.isInitialized) return
+
+            _tokenState.value = AuthTokenState(
+                isInitialized = true,
+                tokenPair = tokenPair,
+            )
+        }
+    }
+
+    private fun isCurrentGeneration(
+        tokenPair: TokenPair,
+        generation: Long,
+    ): Boolean = synchronized(cacheLock) {
+        tokenState.value.generation == generation && tokenState.value.tokenPair == tokenPair
+    }
+
+    private fun isCurrentClearedGeneration(generation: Long): Boolean = synchronized(cacheLock) {
+        tokenState.value.generation == generation && tokenState.value.tokenPair == null
     }
 
     private companion object {

--- a/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
@@ -1,0 +1,95 @@
+package com.poti.android.data.local.datasource
+
+import com.poti.android.di.ApplicationScope
+import com.poti.android.di.IoDispatcher
+import com.poti.android.domain.model.auth.AuthState
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class TokenPair(
+    val accessToken: String,
+    val refreshToken: String,
+)
+
+data class AuthTokenState(
+    val isInitialized: Boolean = false,
+    val tokenPair: TokenPair? = null,
+)
+
+@Singleton
+class AuthTokenStore @Inject constructor(
+    private val preferenceDataSource: PreferenceDataSource,
+    @ApplicationScope private val externalScope: CoroutineScope,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+    private val _tokenState = MutableStateFlow(AuthTokenState())
+    val tokenState: StateFlow<AuthTokenState> = _tokenState.asStateFlow()
+
+    val authState: Flow<AuthState> = combine(
+        preferenceDataSource.authState,
+        tokenState,
+    ) { authState, tokenState ->
+        authState.copy(isInitialized = tokenState.isInitialized)
+    }
+
+    val cachedTokenPair: TokenPair?
+        get() = tokenState.value.tokenPair
+
+    val cachedAccessToken: String?
+        get() = cachedTokenPair?.accessToken
+
+    init {
+        externalScope.launch(ioDispatcher) {
+            preferenceDataSource.tokenPair.collect { tokenPair ->
+                _tokenState.value = AuthTokenState(
+                    isInitialized = true,
+                    tokenPair = tokenPair,
+                )
+            }
+        }
+    }
+
+    fun ensureInitializedBlocking() {
+        if (tokenState.value.isInitialized) return
+
+        runBlocking {
+            awaitInitialized()
+        }
+    }
+
+    suspend fun awaitInitialized(): AuthTokenState = tokenState.first { it.isInitialized }
+
+    suspend fun saveTokens(
+        accessToken: String,
+        refreshToken: String,
+    ) {
+        _tokenState.value = AuthTokenState(
+            isInitialized = true,
+            tokenPair = TokenPair(
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+            ),
+        )
+        preferenceDataSource.saveTokens(accessToken, refreshToken)
+    }
+
+    suspend fun clearTokens() {
+        _tokenState.value = AuthTokenState(isInitialized = true)
+        preferenceDataSource.clearTokens()
+    }
+
+    suspend fun clearAll() {
+        _tokenState.value = AuthTokenState(isInitialized = true)
+        preferenceDataSource.clearAll()
+    }
+}

--- a/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
@@ -95,7 +95,7 @@ class AuthTokenStore @Inject constructor(
     suspend fun clearAll() {
         val generation = clearCachedTokens()
         persistenceMutex.withLock {
-            if (isCurrentClearedGeneration(generation)) {
+            if (isLogoutGenerationCurrent(generation)) {
                 preferenceDataSource.clearAll()
             }
         }
@@ -131,7 +131,7 @@ class AuthTokenStore @Inject constructor(
     }
 
     suspend fun persistTokenClearIfCurrent(generation: Long): Boolean = persistenceMutex.withLock {
-        if (!isCurrentClearedGeneration(generation)) return@withLock false
+        if (!isLogoutGenerationCurrent(generation)) return@withLock false
 
         preferenceDataSource.clearTokens()
         true
@@ -155,7 +155,7 @@ class AuthTokenStore @Inject constructor(
         tokenState.value.generation == generation && tokenState.value.tokenPair == tokenPair
     }
 
-    private fun isCurrentClearedGeneration(generation: Long): Boolean = synchronized(cacheLock) {
+    fun isLogoutGenerationCurrent(generation: Long): Boolean = synchronized(cacheLock) {
         tokenState.value.generation == generation && tokenState.value.tokenPair == null
     }
 

--- a/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/AuthTokenStore.kt
@@ -9,13 +9,16 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -41,8 +44,14 @@ class AuthTokenStore @Inject constructor(
     private val _tokenState = MutableStateFlow(AuthTokenState())
     val tokenState: StateFlow<AuthTokenState> = _tokenState.asStateFlow()
 
+    private val safePersistedAuthState = preferenceDataSource.authState.catch { error ->
+        Timber.Forest.tag("AuthTokenStore")
+            .e(error, "Failed to read persisted auth state. Continue as logged out.")
+        emit(AuthState(accessToken = null, isOnboardingFinished = false))
+    }
+
     val authState: Flow<AuthState> = combine(
-        preferenceDataSource.authState,
+        safePersistedAuthState,
         tokenState,
     ) { persistedAuthState, tokenState ->
         AuthState(
@@ -60,9 +69,14 @@ class AuthTokenStore @Inject constructor(
 
     init {
         externalScope.launch(ioDispatcher) {
-            preferenceDataSource.tokenPair.collect { tokenPair ->
-                initializeFromStorage(tokenPair)
-            }
+            val tokenPair = preferenceDataSource.tokenPair
+                .catch { error ->
+                    Timber.Forest.tag("AuthTokenStore")
+                        .e(error, "Failed to read persisted token pair. Continue without tokens.")
+                    emit(null)
+                }
+                .firstOrNull()
+            initializeFromStorage(tokenPair)
         }
     }
 

--- a/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
@@ -17,6 +17,11 @@ import timber.log.Timber
 import javax.inject.Inject
 import kotlin.collections.set
 
+data class TokenPair(
+    val accessToken: String,
+    val refreshToken: String,
+)
+
 class PreferenceDataSource @Inject constructor(
     private val dataStore: DataStore<Preferences>,
     @ApplicationScope private val externalScope: CoroutineScope,
@@ -46,12 +51,28 @@ class PreferenceDataSource @Inject constructor(
     val cachedRefreshToken: String?
         get() = _cachedRefreshToken
 
+    @Volatile
+    private var _cachedTokenPair: TokenPair? = null
+    val cachedTokenPair: TokenPair?
+        get() = _cachedTokenPair
+
     init {
         externalScope.launch(ioDispatcher) {
-            accessToken.collect { _cachedAccessToken = it }
-        }
-        externalScope.launch(ioDispatcher) {
-            refreshToken.collect { _cachedRefreshToken = it }
+            dataStore.data.collect { prefs ->
+                val accessToken = prefs[ACCESS_TOKEN_KEY]
+                val refreshToken = prefs[REFRESH_TOKEN_KEY]
+
+                _cachedAccessToken = accessToken
+                _cachedRefreshToken = refreshToken
+                _cachedTokenPair = if (accessToken != null && refreshToken != null) {
+                    TokenPair(
+                        accessToken = accessToken,
+                        refreshToken = refreshToken,
+                    )
+                } else {
+                    null
+                }
+            }
         }
     }
 
@@ -70,6 +91,10 @@ class PreferenceDataSource @Inject constructor(
     ) {
         _cachedAccessToken = accessToken
         _cachedRefreshToken = refreshToken
+        _cachedTokenPair = TokenPair(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+        )
 
         dataStore.edit { prefs ->
             Timber.d("saveTokens 호출됨 - Access: ${accessToken.take(5)}... Refresh: ${refreshToken.take(5)}...")
@@ -92,6 +117,7 @@ class PreferenceDataSource @Inject constructor(
     suspend fun clearTokens() {
         _cachedAccessToken = null
         _cachedRefreshToken = null
+        _cachedTokenPair = null
 
         dataStore.edit { prefs ->
             prefs.remove(ACCESS_TOKEN_KEY)
@@ -102,6 +128,7 @@ class PreferenceDataSource @Inject constructor(
     suspend fun clearAll() {
         _cachedAccessToken = null
         _cachedRefreshToken = null
+        _cachedTokenPair = null
 
         dataStore.edit { prefs ->
             prefs.clear()

--- a/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
@@ -19,14 +19,6 @@ class PreferenceDataSource @Inject constructor(
         private val IS_ONBOARDING_FINISHED_KEY = booleanPreferencesKey("IS_ONBOARDING_FINISHED")
     }
 
-    val accessToken: Flow<String?> = dataStore.data.map { prefs ->
-        prefs[ACCESS_TOKEN_KEY]
-    }
-
-    val refreshToken: Flow<String?> = dataStore.data.map { prefs ->
-        prefs[REFRESH_TOKEN_KEY]
-    }
-
     val tokenPair: Flow<TokenPair?> = dataStore.data.map { prefs ->
         val accessToken = prefs[ACCESS_TOKEN_KEY]
         val refreshToken = prefs[REFRESH_TOKEN_KEY]
@@ -39,14 +31,6 @@ class PreferenceDataSource @Inject constructor(
         } else {
             null
         }
-    }
-
-    suspend fun saveAccessToken(accessToken: String) = dataStore.edit { prefs ->
-        prefs[ACCESS_TOKEN_KEY] = accessToken
-    }
-
-    suspend fun saveRefreshToken(refreshToken: String) = dataStore.edit { prefs ->
-        prefs[REFRESH_TOKEN_KEY] = refreshToken
     }
 
     suspend fun saveTokens(

--- a/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
@@ -90,6 +90,9 @@ class PreferenceDataSource @Inject constructor(
     }
 
     suspend fun clearTokens() {
+        _cachedAccessToken = null
+        _cachedRefreshToken = null
+
         dataStore.edit { prefs ->
             prefs.remove(ACCESS_TOKEN_KEY)
             prefs.remove(REFRESH_TOKEN_KEY)

--- a/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
@@ -5,27 +5,14 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import com.poti.android.di.ApplicationScope
-import com.poti.android.di.IoDispatcher
 import com.poti.android.domain.model.auth.AuthState
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
-import kotlin.collections.set
-
-data class TokenPair(
-    val accessToken: String,
-    val refreshToken: String,
-)
 
 class PreferenceDataSource @Inject constructor(
     private val dataStore: DataStore<Preferences>,
-    @ApplicationScope private val externalScope: CoroutineScope,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     companion object {
         private val ACCESS_TOKEN_KEY = stringPreferencesKey("ACCESS_TOKEN")
@@ -41,38 +28,17 @@ class PreferenceDataSource @Inject constructor(
         prefs[REFRESH_TOKEN_KEY]
     }
 
-    @Volatile
-    private var _cachedAccessToken: String? = null
-    val cachedAccessToken: String?
-        get() = _cachedAccessToken
+    val tokenPair: Flow<TokenPair?> = dataStore.data.map { prefs ->
+        val accessToken = prefs[ACCESS_TOKEN_KEY]
+        val refreshToken = prefs[REFRESH_TOKEN_KEY]
 
-    @Volatile
-    private var _cachedRefreshToken: String? = null
-    val cachedRefreshToken: String?
-        get() = _cachedRefreshToken
-
-    @Volatile
-    private var _cachedTokenPair: TokenPair? = null
-    val cachedTokenPair: TokenPair?
-        get() = _cachedTokenPair
-
-    init {
-        externalScope.launch(ioDispatcher) {
-            dataStore.data.collect { prefs ->
-                val accessToken = prefs[ACCESS_TOKEN_KEY]
-                val refreshToken = prefs[REFRESH_TOKEN_KEY]
-
-                _cachedAccessToken = accessToken
-                _cachedRefreshToken = refreshToken
-                _cachedTokenPair = if (accessToken != null && refreshToken != null) {
-                    TokenPair(
-                        accessToken = accessToken,
-                        refreshToken = refreshToken,
-                    )
-                } else {
-                    null
-                }
-            }
+        if (accessToken != null && refreshToken != null) {
+            TokenPair(
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+            )
+        } else {
+            null
         }
     }
 
@@ -89,13 +55,6 @@ class PreferenceDataSource @Inject constructor(
         accessToken: String,
         refreshToken: String,
     ) {
-        _cachedAccessToken = accessToken
-        _cachedRefreshToken = refreshToken
-        _cachedTokenPair = TokenPair(
-            accessToken = accessToken,
-            refreshToken = refreshToken,
-        )
-
         dataStore.edit { prefs ->
             Timber.d("saveTokens 호출됨 - Access: ${accessToken.take(5)}... Refresh: ${refreshToken.take(5)}...")
             prefs[ACCESS_TOKEN_KEY] = accessToken
@@ -115,10 +74,6 @@ class PreferenceDataSource @Inject constructor(
     }
 
     suspend fun clearTokens() {
-        _cachedAccessToken = null
-        _cachedRefreshToken = null
-        _cachedTokenPair = null
-
         dataStore.edit { prefs ->
             prefs.remove(ACCESS_TOKEN_KEY)
             prefs.remove(REFRESH_TOKEN_KEY)
@@ -126,10 +81,6 @@ class PreferenceDataSource @Inject constructor(
     }
 
     suspend fun clearAll() {
-        _cachedAccessToken = null
-        _cachedRefreshToken = null
-        _cachedTokenPair = null
-
         dataStore.edit { prefs ->
             prefs.clear()
         }

--- a/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/local/datasource/PreferenceDataSource.kt
@@ -8,7 +8,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.poti.android.domain.model.auth.AuthState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import timber.log.Timber
 import javax.inject.Inject
 
 class PreferenceDataSource @Inject constructor(
@@ -47,7 +46,6 @@ class PreferenceDataSource @Inject constructor(
     }
 
     suspend fun saveRefreshToken(refreshToken: String) = dataStore.edit { prefs ->
-        Timber.d("saveRefreshToken 호출됨")
         prefs[REFRESH_TOKEN_KEY] = refreshToken
     }
 
@@ -56,7 +54,6 @@ class PreferenceDataSource @Inject constructor(
         refreshToken: String,
     ) {
         dataStore.edit { prefs ->
-            Timber.d("saveTokens 호출됨 - Access: ${accessToken.take(5)}... Refresh: ${refreshToken.take(5)}...")
             prefs[ACCESS_TOKEN_KEY] = accessToken
             prefs[REFRESH_TOKEN_KEY] = refreshToken
         }

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -53,7 +53,7 @@ class AuthInterceptor @Inject constructor(
 
     private companion object {
         val apiBaseUrl: HttpUrl = BuildConfig.BASE_URL.toHttpUrl()
-        const val AUTH_LOGIN_PATH = "/auth/login"
-        const val AUTH_REISSUE_PATH = "/auth/reissue"
+        const val AUTH_LOGIN_PATH = "/api/v1/auth/login"
+        const val AUTH_REISSUE_PATH = "/api/v1/auth/reissue"
     }
 }

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -1,5 +1,6 @@
 package com.poti.android.data.network
 
+import android.os.Looper
 import com.poti.android.BuildConfig
 import com.poti.android.data.local.datasource.AuthTokenStore
 import okhttp3.Interceptor
@@ -11,6 +12,10 @@ class AuthInterceptor @Inject constructor(
     private val authTokenStore: AuthTokenStore,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
+        check(Looper.myLooper() != Looper.getMainLooper()) {
+            "AuthInterceptor must not run on the main thread. Use an asynchronous API call."
+        }
+
         val originalRequest = chain.request()
         val url = originalRequest.url.toString()
         Timber.d("요청 URL: $url")
@@ -25,12 +30,17 @@ class AuthInterceptor @Inject constructor(
 
         val builder = originalRequest.newBuilder()
 
-        authTokenStore.ensureInitializedBlocking()
+        if (!authTokenStore.ensureInitializedBlocking()) {
+            Timber.Forest.tag("AuthInterceptor")
+                .w("Token store initialization timed out. Proceeding without Authorization header.")
+            return chain.proceed(builder.build())
+        }
+
         val accessToken = authTokenStore.cachedAccessToken
 
         if (!accessToken.isNullOrBlank()) {
             Timber.Forest.tag("AuthInterceptor").d("Adding Authorization Header")
-            builder.addHeader("Authorization", "Bearer $accessToken")
+            builder.header("Authorization", "Bearer $accessToken")
         }
 
         return chain.proceed(builder.build())

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -17,7 +17,7 @@ class AuthInterceptor @Inject constructor(
         val requestPath = originalRequest.url.encodedPath
         Timber.d("요청 경로: $requestPath")
 
-        if (isExcludedAuthPath(requestPath)) {
+        if (AuthRequestPolicy.isExcludedAuthPath(requestPath)) {
             return chain.proceed(originalRequest)
         }
 
@@ -37,14 +37,11 @@ class AuthInterceptor @Inject constructor(
 
         if (!accessToken.isNullOrBlank()) {
             Timber.Forest.tag("AuthInterceptor").d("Adding Authorization Header")
-            builder.header("Authorization", "Bearer $accessToken")
+            builder.header(AuthRequestPolicy.AUTHORIZATION_HEADER, "${AuthRequestPolicy.BEARER_PREFIX}$accessToken")
         }
 
         return chain.proceed(builder.build())
     }
-
-    private fun isExcludedAuthPath(path: String): Boolean =
-        path == AUTH_LOGIN_PATH || path == AUTH_REISSUE_PATH
 
     private fun isApiOrigin(requestUrl: HttpUrl): Boolean =
         requestUrl.scheme == apiBaseUrl.scheme &&
@@ -53,7 +50,5 @@ class AuthInterceptor @Inject constructor(
 
     private companion object {
         val apiBaseUrl: HttpUrl = BuildConfig.BASE_URL.toHttpUrl()
-        const val AUTH_LOGIN_PATH = "/api/v1/auth/login"
-        const val AUTH_REISSUE_PATH = "/api/v1/auth/reissue"
     }
 }

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -15,7 +15,7 @@ class AuthInterceptor @Inject constructor(
         val url = originalRequest.url.toString()
         Timber.d("요청 URL: $url")
 
-        if (url.contains("/auth/login") || url.contains("/auth/reissue")) {
+        if (isExcludedAuthPath(originalRequest.url.encodedPath)) {
             return chain.proceed(originalRequest)
         }
 
@@ -39,5 +39,13 @@ class AuthInterceptor @Inject constructor(
         }
 
         return chain.proceed(builder.build())
+    }
+
+    private fun isExcludedAuthPath(path: String): Boolean =
+        path == AUTH_LOGIN_PATH || path == AUTH_REISSUE_PATH
+
+    private companion object {
+        const val AUTH_LOGIN_PATH = "/auth/login"
+        const val AUTH_REISSUE_PATH = "/auth/reissue"
     }
 }

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -1,14 +1,14 @@
 package com.poti.android.data.network
 
 import com.poti.android.BuildConfig
-import com.poti.android.data.local.datasource.PreferenceDataSource
+import com.poti.android.data.local.datasource.AuthTokenStore
 import okhttp3.Interceptor
 import okhttp3.Response
 import timber.log.Timber
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
-    private val preferenceDataSource: PreferenceDataSource,
+    private val authTokenStore: AuthTokenStore,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
@@ -25,7 +25,8 @@ class AuthInterceptor @Inject constructor(
 
         val builder = originalRequest.newBuilder()
 
-        val accessToken = preferenceDataSource.cachedAccessToken
+        authTokenStore.ensureInitializedBlocking()
+        val accessToken = authTokenStore.cachedAccessToken
 
         if (!accessToken.isNullOrBlank()) {
             Timber.Forest.tag("AuthInterceptor").d("Adding Authorization Header")

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -1,6 +1,5 @@
 package com.poti.android.data.network
 
-import android.os.Looper
 import com.poti.android.BuildConfig
 import com.poti.android.data.local.datasource.AuthTokenStore
 import okhttp3.Interceptor
@@ -12,10 +11,6 @@ class AuthInterceptor @Inject constructor(
     private val authTokenStore: AuthTokenStore,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        check(Looper.myLooper() != Looper.getMainLooper()) {
-            "AuthInterceptor must not run on the main thread. Use an asynchronous API call."
-        }
-
         val originalRequest = chain.request()
         val url = originalRequest.url.toString()
         Timber.d("요청 URL: $url")

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -15,7 +15,7 @@ class AuthInterceptor @Inject constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
         val requestPath = originalRequest.url.encodedPath
-        Timber.d("요청 경로: $requestPath")
+        Timber.Forest.tag("AuthInterceptor").d("Request path: $requestPath")
 
         if (AuthRequestPolicy.isExcludedAuthPath(requestPath)) {
             return chain.proceed(originalRequest)

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -14,10 +14,10 @@ class AuthInterceptor @Inject constructor(
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
-        val url = originalRequest.url.toString()
-        Timber.d("요청 URL: $url")
+        val requestPath = originalRequest.url.encodedPath
+        Timber.d("요청 경로: $requestPath")
 
-        if (isExcludedAuthPath(originalRequest.url.encodedPath)) {
+        if (isExcludedAuthPath(requestPath)) {
             return chain.proceed(originalRequest)
         }
 

--- a/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthInterceptor.kt
@@ -2,6 +2,8 @@ package com.poti.android.data.network
 
 import com.poti.android.BuildConfig
 import com.poti.android.data.local.datasource.AuthTokenStore
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
 import timber.log.Timber
@@ -19,7 +21,7 @@ class AuthInterceptor @Inject constructor(
             return chain.proceed(originalRequest)
         }
 
-        if (!url.contains(BuildConfig.BASE_URL)) {
+        if (!isApiOrigin(originalRequest.url)) {
             return chain.proceed(originalRequest)
         }
 
@@ -44,7 +46,13 @@ class AuthInterceptor @Inject constructor(
     private fun isExcludedAuthPath(path: String): Boolean =
         path == AUTH_LOGIN_PATH || path == AUTH_REISSUE_PATH
 
+    private fun isApiOrigin(requestUrl: HttpUrl): Boolean =
+        requestUrl.scheme == apiBaseUrl.scheme &&
+            requestUrl.host == apiBaseUrl.host &&
+            requestUrl.port == apiBaseUrl.port
+
     private companion object {
+        val apiBaseUrl: HttpUrl = BuildConfig.BASE_URL.toHttpUrl()
         const val AUTH_LOGIN_PATH = "/auth/login"
         const val AUTH_REISSUE_PATH = "/auth/reissue"
     }

--- a/app/src/main/java/com/poti/android/data/network/AuthRequestPolicy.kt
+++ b/app/src/main/java/com/poti/android/data/network/AuthRequestPolicy.kt
@@ -1,0 +1,11 @@
+package com.poti.android.data.network
+
+internal object AuthRequestPolicy {
+    const val LOGIN_PATH = "/api/v1/auth/login"
+    const val REISSUE_PATH = "/api/v1/auth/reissue"
+    const val AUTHORIZATION_HEADER = "Authorization"
+    const val BEARER_PREFIX = "Bearer "
+
+    fun isExcludedAuthPath(path: String): Boolean =
+        path == LOGIN_PATH || path == REISSUE_PATH
+}

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -79,8 +79,8 @@ class TokenAuthenticator @Inject constructor(
                 HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> {
                     Timber.Forest.tag("TokenAuthenticator")
                         .e("Refresh token is expired or invalid. code=${refreshResponse.code()}. Logout.")
-                    authTokenStore.clearCachedTokens()
-                    return@synchronized RefreshResult.Logout
+                    val generation = authTokenStore.clearCachedTokens()
+                    return@synchronized RefreshResult.Logout(generation)
                 }
 
                 in HTTP_SERVER_ERROR_START..HTTP_SERVER_ERROR_END -> {
@@ -106,19 +106,19 @@ class TokenAuthenticator @Inject constructor(
             Timber.Forest.tag("TokenAuthenticator").d("Token reissue SUCCESS! Saving new tokens.")
 
             val newTokenPair = TokenPair(reissueData.accessToken, reissueData.refreshToken)
-            authTokenStore.updateCachedTokens(newTokenPair)
-            RefreshResult.PersistAndRetry(newTokenPair)
+            val generation = authTokenStore.updateCachedTokens(newTokenPair)
+            RefreshResult.PersistAndRetry(newTokenPair, generation)
         }
 
         return when (refreshResult) {
             is RefreshResult.Retry -> newRequestWithAccessToken(response.request, refreshResult.accessToken)
             is RefreshResult.PersistAndRetry -> {
-                persistTokensBlocking(refreshResult.tokenPair)
+                persistTokensBlocking(refreshResult.tokenPair, refreshResult.generation)
                 newRequestWithAccessToken(response.request, refreshResult.tokenPair.accessToken)
             }
 
-            RefreshResult.Logout -> {
-                handleLogout()
+            is RefreshResult.Logout -> {
+                handleLogout(refreshResult.generation)
                 null
             }
 
@@ -137,12 +137,12 @@ class TokenAuthenticator @Inject constructor(
             .build()
     }
 
-    private fun handleLogout() {
+    private fun handleLogout(generation: Long) {
         Timber.Forest.tag("TokenAuthenticator").w("Executing Logout logic (Clear DataStore).")
         runCatching {
             runBlocking {
                 withTimeout(DATASTORE_PERSIST_TIMEOUT_MILLIS) {
-                    authTokenStore.persistTokenClear()
+                    authTokenStore.persistTokenClearIfCurrent(generation)
                 }
             }
         }.onFailure { error ->
@@ -153,11 +153,14 @@ class TokenAuthenticator @Inject constructor(
         authSessionManager.triggerLogout()
     }
 
-    private fun persistTokensBlocking(tokenPair: TokenPair) {
+    private fun persistTokensBlocking(
+        tokenPair: TokenPair,
+        generation: Long,
+    ) {
         runCatching {
             runBlocking {
                 withTimeout(DATASTORE_PERSIST_TIMEOUT_MILLIS) {
-                    authTokenStore.persistTokens(tokenPair)
+                    authTokenStore.persistTokensIfCurrent(tokenPair, generation)
                 }
             }
         }.onFailure { error ->
@@ -187,9 +190,12 @@ class TokenAuthenticator @Inject constructor(
     private sealed interface RefreshResult {
         data class Retry(val accessToken: String) : RefreshResult
 
-        data class PersistAndRetry(val tokenPair: TokenPair) : RefreshResult
+        data class PersistAndRetry(
+            val tokenPair: TokenPair,
+            val generation: Long,
+        ) : RefreshResult
 
-        data object Logout : RefreshResult
+        data class Logout(val generation: Long) : RefreshResult
 
         data object Stop : RefreshResult
     }

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -140,7 +140,7 @@ class TokenAuthenticator @Inject constructor(
 
     private fun handleLogout(generation: Long) {
         Timber.Forest.tag("TokenAuthenticator").w("Executing Logout logic (Clear DataStore).")
-        runCatching {
+        val tokensCleared = runCatching {
             runBlocking {
                 withTimeout(DATASTORE_PERSIST_TIMEOUT_MILLIS) {
                     authTokenStore.persistTokenClearIfCurrent(generation)
@@ -149,7 +149,14 @@ class TokenAuthenticator @Inject constructor(
         }.onFailure { error ->
             Timber.Forest.tag("TokenAuthenticator")
                 .e(error, "Failed to persist token clear. Continue logout with cleared in-memory tokens.")
+        }.getOrNull()
+
+        if (tokensCleared == false || !authTokenStore.isLogoutGenerationCurrent(generation)) {
+            Timber.Forest.tag("TokenAuthenticator")
+                .d("Skip logout event because a newer auth state is already active.")
+            return
         }
+
         Timber.Forest.tag("TokenAuthenticator").d("Restarting MainActivity to navigate to Login.")
         authSessionManager.triggerLogout()
     }

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -46,8 +46,13 @@ class TokenAuthenticator @Inject constructor(
             val freshTokenPair = preferenceDataSource.cachedTokenPair
 
             if (freshTokenPair != currentTokenPair) {
+                if (freshTokenPair == null) {
+                    Timber.tag("TokenAuthenticator").w("Token was cleared while waiting. Stop retry.")
+                    return null
+                }
+
                 Timber.tag("TokenAuthenticator").d("Token already refreshed! Retrying.")
-                return newRequestWithAccessToken(response.request, freshTokenPair?.accessToken)
+                return newRequestWithAccessToken(response.request, freshTokenPair.accessToken)
             }
 
             val currentRefreshToken = currentTokenPair?.refreshToken

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -28,6 +28,7 @@ class TokenAuthenticator @Inject constructor(
         response: Response,
     ): Request? {
         val requestUrl = response.request.url.toString()
+        val requestPath = response.request.url.encodedPath
         Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! URL: $requestUrl")
 
         if (response.authRetryCount() > MAX_AUTH_RETRY_COUNT) {
@@ -36,7 +37,7 @@ class TokenAuthenticator @Inject constructor(
             return null
         }
 
-        if (isExcludedAuthUrl(requestUrl)) {
+        if (isExcludedAuthPath(requestPath)) {
             Timber.Forest.tag("TokenAuthenticator")
                 .d("Skip token reissue for auth endpoint. URL: $requestUrl")
             return null
@@ -169,8 +170,8 @@ class TokenAuthenticator @Inject constructor(
         }
     }
 
-    private fun isExcludedAuthUrl(requestUrl: String): Boolean =
-        requestUrl.contains(AUTH_LOGIN_PATH) || requestUrl.contains(AUTH_REISSUE_PATH)
+    private fun isExcludedAuthPath(path: String): Boolean =
+        path == AUTH_LOGIN_PATH || path == AUTH_REISSUE_PATH
 
     private fun Request.accessTokenFromAuthorizationHeader(): String? =
         header(AUTHORIZATION_HEADER)?.removePrefix(BEARER_PREFIX)?.takeIf { it.isNotBlank() }

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -76,7 +76,7 @@ class TokenAuthenticator @Inject constructor(
             }
 
             when (refreshResponse.code()) {
-                HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> {
+                HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED, HTTP_FORBIDDEN, HTTP_NOT_FOUND -> {
                     Timber.Forest.tag("TokenAuthenticator")
                         .e("Refresh token is expired or invalid. code=${refreshResponse.code()}. Logout.")
                     val generation = authTokenStore.clearCachedTokens()
@@ -208,8 +208,10 @@ class TokenAuthenticator @Inject constructor(
 
     private companion object {
         const val MAX_AUTH_RETRY_COUNT = 1
+        const val HTTP_BAD_REQUEST = 400
         const val HTTP_UNAUTHORIZED = 401
         const val HTTP_FORBIDDEN = 403
+        const val HTTP_NOT_FOUND = 404
         const val HTTP_SERVER_ERROR_START = 500
         const val HTTP_SERVER_ERROR_END = 599
         const val DATASTORE_PERSIST_TIMEOUT_MILLIS = 1_000L

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -28,6 +28,12 @@ class TokenAuthenticator @Inject constructor(
         val requestUrl = response.request.url.toString()
         Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! URL: $requestUrl")
 
+        if (response.authRetryCount() > MAX_AUTH_RETRY_COUNT) {
+            Timber.Forest.tag("TokenAuthenticator")
+                .w("Stop token reissue because auth retry limit exceeded. URL: $requestUrl")
+            return null
+        }
+
         if (isExcludedAuthUrl(requestUrl)) {
             Timber.Forest.tag("TokenAuthenticator")
                 .d("Skip token reissue for auth endpoint. URL: $requestUrl")
@@ -133,9 +139,22 @@ class TokenAuthenticator @Inject constructor(
     private fun isExcludedAuthUrl(requestUrl: String): Boolean =
         requestUrl.contains(AUTH_LOGIN_PATH) || requestUrl.contains(AUTH_REISSUE_PATH)
 
+    private fun Response.authRetryCount(): Int {
+        var count = 1
+        var priorResponse = priorResponse
+
+        while (priorResponse != null) {
+            count++
+            priorResponse = priorResponse.priorResponse
+        }
+
+        return count
+    }
+
     private companion object {
         const val AUTH_LOGIN_PATH = "/auth/login"
         const val AUTH_REISSUE_PATH = "/auth/reissue"
+        const val MAX_AUTH_RETRY_COUNT = 1
         const val HTTP_UNAUTHORIZED = 401
         const val HTTP_FORBIDDEN = 403
         const val HTTP_SERVER_ERROR_START = 500

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -40,17 +40,17 @@ class TokenAuthenticator @Inject constructor(
             return null
         }
 
-        val currentAccessToken = preferenceDataSource.cachedAccessToken
-        val currentRefreshToken = preferenceDataSource.cachedRefreshToken
+        val currentTokenPair = preferenceDataSource.cachedTokenPair
 
         synchronized(lock) {
-            val freshAccessToken = preferenceDataSource.cachedAccessToken
+            val freshTokenPair = preferenceDataSource.cachedTokenPair
 
-            if (freshAccessToken != currentAccessToken) {
+            if (freshTokenPair != currentTokenPair) {
                 Timber.tag("TokenAuthenticator").d("Token already refreshed! Retrying.")
-                return newRequestWithAccessToken(response.request, freshAccessToken)
+                return newRequestWithAccessToken(response.request, freshTokenPair?.accessToken)
             }
 
+            val currentRefreshToken = currentTokenPair?.refreshToken
             if (currentRefreshToken.isNullOrBlank()) {
                 Timber.Forest.tag("TokenAuthenticator").e("RefreshToken is empty. Logout.")
                 handleLogout()

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -28,9 +28,9 @@ class TokenAuthenticator @Inject constructor(
         val requestUrl = response.request.url.toString()
         Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! URL: $requestUrl")
 
-        if (requestUrl.contains("/auth/reissue")) {
-            Timber.Forest.tag("TokenAuthenticator").e("Reissue request returned 401. Logout.")
-            handleLogout()
+        if (isExcludedAuthUrl(requestUrl)) {
+            Timber.Forest.tag("TokenAuthenticator")
+                .d("Skip token reissue for auth endpoint. URL: $requestUrl")
             return null
         }
 
@@ -130,7 +130,12 @@ class TokenAuthenticator @Inject constructor(
         }
     }
 
+    private fun isExcludedAuthUrl(requestUrl: String): Boolean =
+        requestUrl.contains(AUTH_LOGIN_PATH) || requestUrl.contains(AUTH_REISSUE_PATH)
+
     private companion object {
+        const val AUTH_LOGIN_PATH = "/auth/login"
+        const val AUTH_REISSUE_PATH = "/auth/reissue"
         const val HTTP_UNAUTHORIZED = 401
         const val HTTP_FORBIDDEN = 403
         const val HTTP_SERVER_ERROR_START = 500

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -10,6 +10,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
 import timber.log.Timber
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -28,7 +29,7 @@ class TokenAuthenticator @Inject constructor(
         Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! URL: $requestUrl")
 
         if (requestUrl.contains("/auth/reissue")) {
-            Timber.Forest.tag("TokenAuthenticator").e("Refresh Token expired. Giving up.")
+            Timber.Forest.tag("TokenAuthenticator").e("Reissue request returned 401. Logout.")
             handleLogout()
             return null
         }
@@ -53,29 +54,57 @@ class TokenAuthenticator @Inject constructor(
             Timber.Forest.tag("TokenAuthenticator").d("Requesting token reissue...")
             val refreshResponse = try {
                 authRemoteDataSource.get().reissue(ReissueRequestDto(currentRefreshToken)).execute()
+            } catch (e: IOException) {
+                Timber.Forest.tag("TokenAuthenticator")
+                    .w(e, "Reissue API call failed due to network error. Keep session.")
+                return null
             } catch (e: Exception) {
-                Timber.Forest.tag("TokenAuthenticator").e(e, "Reissue API call failed (Exception). Logout.")
-                handleLogout()
+                Timber.Forest.tag("TokenAuthenticator")
+                    .e(e, "Reissue API call failed unexpectedly. Keep session.")
                 return null
             }
 
-            if (refreshResponse.isSuccessful) {
-                refreshResponse.body()?.data?.let { reissueData ->
-                    Timber.Forest.tag("TokenAuthenticator").d("Token reissue SUCCESS! Saving new tokens.")
+            when (refreshResponse.code()) {
+                HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> {
+                    Timber.Forest.tag("TokenAuthenticator")
+                        .e("Refresh token is expired or invalid. code=${refreshResponse.code()}. Logout.")
+                    handleLogout()
+                    return null
+                }
 
-                    val newAccessToken = reissueData.accessToken
-                    val newRefreshToken = reissueData.refreshToken
-
-                    runBlocking {
-                        preferenceDataSource.saveTokens(newAccessToken, newRefreshToken)
-                    }
-
-                    return newRequestWithAccessToken(response.request, newAccessToken)
+                in HTTP_SERVER_ERROR_START..HTTP_SERVER_ERROR_END -> {
+                    Timber.Forest.tag("TokenAuthenticator")
+                        .w("Reissue API returned server error. code=${refreshResponse.code()}. Keep session.")
+                    return null
                 }
             }
+
+            if (!refreshResponse.isSuccessful) {
+                Timber.Forest.tag("TokenAuthenticator")
+                    .w("Reissue API returned non-success response. code=${refreshResponse.code()}. Keep session.")
+                return null
+            }
+
+            val reissueData = refreshResponse.body()?.data
+            if (reissueData == null) {
+                Timber.Forest.tag("TokenAuthenticator")
+                    .e("Reissue API returned success but body/data is null. Keep session.")
+                return null
+            }
+
+            Timber.Forest.tag("TokenAuthenticator").d("Token reissue SUCCESS! Saving new tokens.")
+
+            val newAccessToken = reissueData.accessToken
+            val newRefreshToken = reissueData.refreshToken
+
+            runBlocking {
+                preferenceDataSource.saveTokens(newAccessToken, newRefreshToken)
+            }
+
+            return newRequestWithAccessToken(response.request, newAccessToken)
         }
 
-        handleLogout()
+        Timber.Forest.tag("TokenAuthenticator").w("Token reissue was not completed. Keep session.")
         return null
     }
 
@@ -99,5 +128,12 @@ class TokenAuthenticator @Inject constructor(
             Timber.Forest.tag("TokenAuthenticator").d("Restarting MainActivity to navigate to Login.")
             authSessionManager.triggerLogout()
         }
+    }
+
+    private companion object {
+        const val HTTP_UNAUTHORIZED = 401
+        const val HTTP_FORBIDDEN = 403
+        const val HTTP_SERVER_ERROR_START = 500
+        const val HTTP_SERVER_ERROR_END = 599
     }
 }

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -202,8 +202,8 @@ class TokenAuthenticator @Inject constructor(
     }
 
     private companion object {
-        const val AUTH_LOGIN_PATH = "/auth/login"
-        const val AUTH_REISSUE_PATH = "/auth/reissue"
+        const val AUTH_LOGIN_PATH = "/api/v1/auth/login"
+        const val AUTH_REISSUE_PATH = "/api/v1/auth/reissue"
         const val AUTHORIZATION_HEADER = "Authorization"
         const val BEARER_PREFIX = "Bearer "
         const val MAX_AUTH_RETRY_COUNT = 1

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -1,6 +1,6 @@
 package com.poti.android.data.network
 
-import com.poti.android.data.local.datasource.PreferenceDataSource
+import com.poti.android.data.local.datasource.AuthTokenStore
 import com.poti.android.data.remote.datasource.AuthRemoteDataSource
 import com.poti.android.data.remote.dto.request.auth.ReissueRequestDto
 import com.poti.android.domain.manager.AuthSessionManager
@@ -15,7 +15,7 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 class TokenAuthenticator @Inject constructor(
-    private val preferenceDataSource: PreferenceDataSource,
+    private val authTokenStore: AuthTokenStore,
     private val authRemoteDataSource: Provider<AuthRemoteDataSource>,
     private val authSessionManager: AuthSessionManager,
 ) : Authenticator {
@@ -41,9 +41,10 @@ class TokenAuthenticator @Inject constructor(
         }
 
         val requestAccessToken = response.request.accessTokenFromAuthorizationHeader()
+        authTokenStore.ensureInitializedBlocking()
 
         synchronized(lock) {
-            val latestTokenPair = preferenceDataSource.cachedTokenPair
+            val latestTokenPair = authTokenStore.cachedTokenPair
 
             if (latestTokenPair == null) {
                 Timber.tag("TokenAuthenticator").w("Token is empty or was cleared. Stop retry.")
@@ -102,7 +103,7 @@ class TokenAuthenticator @Inject constructor(
             val newRefreshToken = reissueData.refreshToken
 
             runBlocking {
-                preferenceDataSource.saveTokens(newAccessToken, newRefreshToken)
+                authTokenStore.saveTokens(newAccessToken, newRefreshToken)
             }
 
             return newRequestWithAccessToken(response.request, newAccessToken)
@@ -128,7 +129,7 @@ class TokenAuthenticator @Inject constructor(
     private fun handleLogout() {
         Timber.Forest.tag("TokenAuthenticator").w("Executing Logout logic (Clear DataStore).")
         runBlocking {
-            preferenceDataSource.clearTokens()
+            authTokenStore.clearTokens()
             Timber.Forest.tag("TokenAuthenticator").d("Restarting MainActivity to navigate to Login.")
             authSessionManager.triggerLogout()
         }

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -28,7 +28,7 @@ class TokenAuthenticator @Inject constructor(
         response: Response,
     ): Request? {
         val requestPath = response.request.url.encodedPath
-        Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! Path: $requestPath")
+        Timber.Forest.tag("TokenAuthenticator").w("401 Unauthorized detected. Path: $requestPath")
 
         if (response.authRetryCount() > MAX_AUTH_RETRY_COUNT) {
             Timber.Forest.tag("TokenAuthenticator")

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -27,19 +27,18 @@ class TokenAuthenticator @Inject constructor(
         route: Route?,
         response: Response,
     ): Request? {
-        val requestUrl = response.request.url.toString()
         val requestPath = response.request.url.encodedPath
-        Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! URL: $requestUrl")
+        Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! Path: $requestPath")
 
         if (response.authRetryCount() > MAX_AUTH_RETRY_COUNT) {
             Timber.Forest.tag("TokenAuthenticator")
-                .w("Stop token reissue because auth retry limit exceeded. URL: $requestUrl")
+                .w("Stop token reissue because auth retry limit exceeded. Path: $requestPath")
             return null
         }
 
         if (isExcludedAuthPath(requestPath)) {
             Timber.Forest.tag("TokenAuthenticator")
-                .d("Skip token reissue for auth endpoint. URL: $requestUrl")
+                .d("Skip token reissue for auth endpoint. Path: $requestPath")
             return null
         }
 

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -36,7 +36,7 @@ class TokenAuthenticator @Inject constructor(
             return null
         }
 
-        if (isExcludedAuthPath(requestPath)) {
+        if (AuthRequestPolicy.isExcludedAuthPath(requestPath)) {
             Timber.Forest.tag("TokenAuthenticator")
                 .d("Skip token reissue for auth endpoint. Path: $requestPath")
             return null
@@ -133,7 +133,7 @@ class TokenAuthenticator @Inject constructor(
         Timber.Forest.tag("TokenAuthenticator").d("Rebuilding request with new Bearer token.")
 
         return request.newBuilder()
-            .header(AUTHORIZATION_HEADER, "$BEARER_PREFIX$newAccessToken")
+            .header(AuthRequestPolicy.AUTHORIZATION_HEADER, "${AuthRequestPolicy.BEARER_PREFIX}$newAccessToken")
             .build()
     }
 
@@ -176,11 +176,10 @@ class TokenAuthenticator @Inject constructor(
         }
     }
 
-    private fun isExcludedAuthPath(path: String): Boolean =
-        path == AUTH_LOGIN_PATH || path == AUTH_REISSUE_PATH
-
     private fun Request.accessTokenFromAuthorizationHeader(): String? =
-        header(AUTHORIZATION_HEADER)?.removePrefix(BEARER_PREFIX)?.takeIf { it.isNotBlank() }
+        header(AuthRequestPolicy.AUTHORIZATION_HEADER)
+            ?.removePrefix(AuthRequestPolicy.BEARER_PREFIX)
+            ?.takeIf { it.isNotBlank() }
 
     private fun Response.authRetryCount(): Int {
         var count = 1
@@ -208,10 +207,6 @@ class TokenAuthenticator @Inject constructor(
     }
 
     private companion object {
-        const val AUTH_LOGIN_PATH = "/api/v1/auth/login"
-        const val AUTH_REISSUE_PATH = "/api/v1/auth/reissue"
-        const val AUTHORIZATION_HEADER = "Authorization"
-        const val BEARER_PREFIX = "Bearer "
         const val MAX_AUTH_RETRY_COUNT = 1
         const val HTTP_UNAUTHORIZED = 401
         const val HTTP_FORBIDDEN = 403

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -1,10 +1,13 @@
 package com.poti.android.data.network
 
+import android.os.Looper
 import com.poti.android.data.local.datasource.AuthTokenStore
+import com.poti.android.data.local.datasource.TokenPair
 import com.poti.android.data.remote.datasource.AuthRemoteDataSource
 import com.poti.android.data.remote.dto.request.auth.ReissueRequestDto
 import com.poti.android.domain.manager.AuthSessionManager
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
@@ -25,6 +28,10 @@ class TokenAuthenticator @Inject constructor(
         route: Route?,
         response: Response,
     ): Request? {
+        check(Looper.myLooper() != Looper.getMainLooper()) {
+            "TokenAuthenticator must not run on the main thread. Use an asynchronous API call."
+        }
+
         val requestUrl = response.request.url.toString()
         Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! URL: $requestUrl")
 
@@ -41,19 +48,23 @@ class TokenAuthenticator @Inject constructor(
         }
 
         val requestAccessToken = response.request.accessTokenFromAuthorizationHeader()
-        authTokenStore.ensureInitializedBlocking()
+        if (!authTokenStore.ensureInitializedBlocking()) {
+            Timber.Forest.tag("TokenAuthenticator")
+                .w("Token store initialization timed out. Stop token reissue.")
+            return null
+        }
 
-        synchronized(lock) {
+        val refreshResult = synchronized(lock) {
             val latestTokenPair = authTokenStore.cachedTokenPair
 
             if (latestTokenPair == null) {
                 Timber.tag("TokenAuthenticator").w("Token is empty or was cleared. Stop retry.")
-                return null
+                return@synchronized RefreshResult.Stop
             }
 
             if (requestAccessToken != latestTokenPair.accessToken) {
                 Timber.tag("TokenAuthenticator").d("Token already refreshed! Retrying.")
-                return newRequestWithAccessToken(response.request, latestTokenPair.accessToken)
+                return@synchronized RefreshResult.Retry(latestTokenPair.accessToken)
             }
 
             Timber.Forest.tag("TokenAuthenticator").d("Requesting token reissue...")
@@ -62,63 +73,68 @@ class TokenAuthenticator @Inject constructor(
             } catch (e: IOException) {
                 Timber.Forest.tag("TokenAuthenticator")
                     .w(e, "Reissue API call failed due to network error. Keep session.")
-                return null
+                return@synchronized RefreshResult.Stop
             } catch (e: Exception) {
                 Timber.Forest.tag("TokenAuthenticator")
                     .e(e, "Reissue API call failed unexpectedly. Keep session.")
-                return null
+                return@synchronized RefreshResult.Stop
             }
 
             when (refreshResponse.code()) {
                 HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> {
                     Timber.Forest.tag("TokenAuthenticator")
                         .e("Refresh token is expired or invalid. code=${refreshResponse.code()}. Logout.")
-                    handleLogout()
-                    return null
+                    authTokenStore.clearCachedTokens()
+                    return@synchronized RefreshResult.Logout
                 }
 
                 in HTTP_SERVER_ERROR_START..HTTP_SERVER_ERROR_END -> {
                     Timber.Forest.tag("TokenAuthenticator")
                         .w("Reissue API returned server error. code=${refreshResponse.code()}. Keep session.")
-                    return null
+                    return@synchronized RefreshResult.Stop
                 }
             }
 
             if (!refreshResponse.isSuccessful) {
                 Timber.Forest.tag("TokenAuthenticator")
                     .w("Reissue API returned non-success response. code=${refreshResponse.code()}. Keep session.")
-                return null
+                return@synchronized RefreshResult.Stop
             }
 
             val reissueData = refreshResponse.body()?.data
             if (reissueData == null) {
                 Timber.Forest.tag("TokenAuthenticator")
                     .e("Reissue API returned success but body/data is null. Keep session.")
-                return null
+                return@synchronized RefreshResult.Stop
             }
 
             Timber.Forest.tag("TokenAuthenticator").d("Token reissue SUCCESS! Saving new tokens.")
 
-            val newAccessToken = reissueData.accessToken
-            val newRefreshToken = reissueData.refreshToken
-
-            runBlocking {
-                authTokenStore.saveTokens(newAccessToken, newRefreshToken)
-            }
-
-            return newRequestWithAccessToken(response.request, newAccessToken)
+            val newTokenPair = TokenPair(reissueData.accessToken, reissueData.refreshToken)
+            authTokenStore.updateCachedTokens(newTokenPair)
+            RefreshResult.PersistAndRetry(newTokenPair)
         }
 
-        Timber.Forest.tag("TokenAuthenticator").w("Token reissue was not completed. Keep session.")
-        return null
+        return when (refreshResult) {
+            is RefreshResult.Retry -> newRequestWithAccessToken(response.request, refreshResult.accessToken)
+            is RefreshResult.PersistAndRetry -> {
+                persistTokensBlocking(refreshResult.tokenPair)
+                newRequestWithAccessToken(response.request, refreshResult.tokenPair.accessToken)
+            }
+
+            RefreshResult.Logout -> {
+                handleLogout()
+                null
+            }
+
+            RefreshResult.Stop -> null
+        }
     }
 
     private fun newRequestWithAccessToken(
         request: Request,
-        newAccessToken: String?,
+        newAccessToken: String,
     ): Request {
-        if (newAccessToken == null) return request
-
         Timber.Forest.tag("TokenAuthenticator").d("Rebuilding request with new Bearer token.")
 
         return request.newBuilder()
@@ -128,10 +144,30 @@ class TokenAuthenticator @Inject constructor(
 
     private fun handleLogout() {
         Timber.Forest.tag("TokenAuthenticator").w("Executing Logout logic (Clear DataStore).")
-        runBlocking {
-            authTokenStore.clearTokens()
-            Timber.Forest.tag("TokenAuthenticator").d("Restarting MainActivity to navigate to Login.")
-            authSessionManager.triggerLogout()
+        runCatching {
+            runBlocking {
+                withTimeout(DATASTORE_PERSIST_TIMEOUT_MILLIS) {
+                    authTokenStore.persistTokenClear()
+                }
+            }
+        }.onFailure { error ->
+            Timber.Forest.tag("TokenAuthenticator")
+                .e(error, "Failed to persist token clear. Continue logout with cleared in-memory tokens.")
+        }
+        Timber.Forest.tag("TokenAuthenticator").d("Restarting MainActivity to navigate to Login.")
+        authSessionManager.triggerLogout()
+    }
+
+    private fun persistTokensBlocking(tokenPair: TokenPair) {
+        runCatching {
+            runBlocking {
+                withTimeout(DATASTORE_PERSIST_TIMEOUT_MILLIS) {
+                    authTokenStore.persistTokens(tokenPair)
+                }
+            }
+        }.onFailure { error ->
+            Timber.Forest.tag("TokenAuthenticator")
+                .e(error, "Failed to persist refreshed tokens. Keep the updated in-memory token pair.")
         }
     }
 
@@ -153,6 +189,16 @@ class TokenAuthenticator @Inject constructor(
         return count
     }
 
+    private sealed interface RefreshResult {
+        data class Retry(val accessToken: String) : RefreshResult
+
+        data class PersistAndRetry(val tokenPair: TokenPair) : RefreshResult
+
+        data object Logout : RefreshResult
+
+        data object Stop : RefreshResult
+    }
+
     private companion object {
         const val AUTH_LOGIN_PATH = "/auth/login"
         const val AUTH_REISSUE_PATH = "/auth/reissue"
@@ -163,5 +209,6 @@ class TokenAuthenticator @Inject constructor(
         const val HTTP_FORBIDDEN = 403
         const val HTTP_SERVER_ERROR_START = 500
         const val HTTP_SERVER_ERROR_END = 599
+        const val DATASTORE_PERSIST_TIMEOUT_MILLIS = 1_000L
     }
 }

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -1,6 +1,5 @@
 package com.poti.android.data.network
 
-import android.os.Looper
 import com.poti.android.data.local.datasource.AuthTokenStore
 import com.poti.android.data.local.datasource.TokenPair
 import com.poti.android.data.remote.datasource.AuthRemoteDataSource
@@ -28,10 +27,6 @@ class TokenAuthenticator @Inject constructor(
         route: Route?,
         response: Response,
     ): Request? {
-        check(Looper.myLooper() != Looper.getMainLooper()) {
-            "TokenAuthenticator must not run on the main thread. Use an asynchronous API call."
-        }
-
         val requestUrl = response.request.url.toString()
         Timber.Forest.tag("TokenAuthenticator").e("401 Unauthorized detected! URL: $requestUrl")
 

--- a/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/poti/android/data/network/TokenAuthenticator.kt
@@ -40,31 +40,24 @@ class TokenAuthenticator @Inject constructor(
             return null
         }
 
-        val currentTokenPair = preferenceDataSource.cachedTokenPair
+        val requestAccessToken = response.request.accessTokenFromAuthorizationHeader()
 
         synchronized(lock) {
-            val freshTokenPair = preferenceDataSource.cachedTokenPair
+            val latestTokenPair = preferenceDataSource.cachedTokenPair
 
-            if (freshTokenPair != currentTokenPair) {
-                if (freshTokenPair == null) {
-                    Timber.tag("TokenAuthenticator").w("Token was cleared while waiting. Stop retry.")
-                    return null
-                }
-
-                Timber.tag("TokenAuthenticator").d("Token already refreshed! Retrying.")
-                return newRequestWithAccessToken(response.request, freshTokenPair.accessToken)
+            if (latestTokenPair == null) {
+                Timber.tag("TokenAuthenticator").w("Token is empty or was cleared. Stop retry.")
+                return null
             }
 
-            val currentRefreshToken = currentTokenPair?.refreshToken
-            if (currentRefreshToken.isNullOrBlank()) {
-                Timber.Forest.tag("TokenAuthenticator").e("RefreshToken is empty. Logout.")
-                handleLogout()
-                return null
+            if (requestAccessToken != latestTokenPair.accessToken) {
+                Timber.tag("TokenAuthenticator").d("Token already refreshed! Retrying.")
+                return newRequestWithAccessToken(response.request, latestTokenPair.accessToken)
             }
 
             Timber.Forest.tag("TokenAuthenticator").d("Requesting token reissue...")
             val refreshResponse = try {
-                authRemoteDataSource.get().reissue(ReissueRequestDto(currentRefreshToken)).execute()
+                authRemoteDataSource.get().reissue(ReissueRequestDto(latestTokenPair.refreshToken)).execute()
             } catch (e: IOException) {
                 Timber.Forest.tag("TokenAuthenticator")
                     .w(e, "Reissue API call failed due to network error. Keep session.")
@@ -128,7 +121,7 @@ class TokenAuthenticator @Inject constructor(
         Timber.Forest.tag("TokenAuthenticator").d("Rebuilding request with new Bearer token.")
 
         return request.newBuilder()
-            .header("Authorization", "Bearer $newAccessToken")
+            .header(AUTHORIZATION_HEADER, "$BEARER_PREFIX$newAccessToken")
             .build()
     }
 
@@ -143,6 +136,9 @@ class TokenAuthenticator @Inject constructor(
 
     private fun isExcludedAuthUrl(requestUrl: String): Boolean =
         requestUrl.contains(AUTH_LOGIN_PATH) || requestUrl.contains(AUTH_REISSUE_PATH)
+
+    private fun Request.accessTokenFromAuthorizationHeader(): String? =
+        header(AUTHORIZATION_HEADER)?.removePrefix(BEARER_PREFIX)?.takeIf { it.isNotBlank() }
 
     private fun Response.authRetryCount(): Int {
         var count = 1
@@ -159,6 +155,8 @@ class TokenAuthenticator @Inject constructor(
     private companion object {
         const val AUTH_LOGIN_PATH = "/auth/login"
         const val AUTH_REISSUE_PATH = "/auth/reissue"
+        const val AUTHORIZATION_HEADER = "Authorization"
+        const val BEARER_PREFIX = "Bearer "
         const val MAX_AUTH_RETRY_COUNT = 1
         const val HTTP_UNAUTHORIZED = 401
         const val HTTP_FORBIDDEN = 403

--- a/app/src/main/java/com/poti/android/data/remote/datasource/AuthRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/AuthRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.poti.android.data.remote.datasource
 
 import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.di.ReissueClient
 import com.poti.android.data.remote.dto.request.auth.LoginRequestDto
 import com.poti.android.data.remote.dto.request.auth.ReissueRequestDto
 import com.poti.android.data.remote.dto.response.auth.LoginResponseDto
@@ -11,12 +12,13 @@ import javax.inject.Inject
 
 class AuthRemoteDataSource @Inject constructor(
     private val authService: AuthService,
+    @param:ReissueClient private val reissueAuthService: AuthService,
 ) {
     suspend fun login(loginRequest: LoginRequestDto): BaseResponse<LoginResponseDto> =
         authService.login(loginRequest = loginRequest)
 
     fun reissue(reissueRequest: ReissueRequestDto): Call<BaseResponse<ReissueResponseDto>> =
-        authService.reissue(reissueRequest = reissueRequest)
+        reissueAuthService.reissue(reissueRequest = reissueRequest)
 
     suspend fun withdrawal(): BaseResponse<Unit> =
         authService.withdrawal()

--- a/app/src/main/java/com/poti/android/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/AuthRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.poti.android.data.repository
 
 import com.poti.android.core.network.model.handleApiResponse
 import com.poti.android.core.network.util.HttpResponseHandler
+import com.poti.android.data.local.datasource.AuthTokenStore
 import com.poti.android.data.local.datasource.PreferenceDataSource
 import com.poti.android.data.mapper.auth.toDomain
 import com.poti.android.data.mock.UiMockData
@@ -20,9 +21,10 @@ class AuthRepositoryImpl @Inject constructor(
     private val httpResponseHandler: HttpResponseHandler,
     private val authRemoteDataSource: AuthRemoteDataSource,
     private val preferenceDataSource: PreferenceDataSource,
+    private val authTokenStore: AuthTokenStore,
     private val authSessionManager: AuthSessionManager,
 ) : AuthRepository {
-    override fun observeAuthState(): Flow<AuthState> = preferenceDataSource.authState
+    override fun observeAuthState(): Flow<AuthState> = authTokenStore.authState
 
     override suspend fun login(
         socialType: SocialType,
@@ -30,7 +32,7 @@ class AuthRepositoryImpl @Inject constructor(
     ): Result<UserAuth> = executeWithUiMock(
         mock = {
             UiMockData.userAuth.also {
-                preferenceDataSource.saveTokens(it.accessToken, it.refreshToken)
+                authTokenStore.saveTokens(it.accessToken, it.refreshToken)
                 preferenceDataSource.saveOnboardingState(!it.isNewUser)
             }
         },
@@ -44,7 +46,7 @@ class AuthRepositoryImpl @Inject constructor(
                     .handleApiResponse()
                     .getOrThrow()
                     .apply {
-                        preferenceDataSource.saveTokens(accessToken, refreshToken)
+                        authTokenStore.saveTokens(accessToken, refreshToken)
                         preferenceDataSource.saveOnboardingState(!isNewUser)
                     }
                     .toDomain()
@@ -67,13 +69,13 @@ class AuthRepositoryImpl @Inject constructor(
 
     override suspend fun withdrawal(): Result<Unit> = executeWithUiMock(
         mock = {
-            preferenceDataSource.clearAll()
+            authTokenStore.clearAll()
             authSessionManager.triggerLogout()
         },
         real = {
             httpResponseHandler.safeApiCall {
                 authRemoteDataSource.withdrawal()
-                preferenceDataSource.clearAll()
+                authTokenStore.clearAll()
                 authSessionManager.triggerLogout()
             }
         },

--- a/app/src/main/java/com/poti/android/domain/model/auth/AuthState.kt
+++ b/app/src/main/java/com/poti/android/domain/model/auth/AuthState.kt
@@ -3,4 +3,5 @@ package com.poti.android.domain.model.auth
 data class AuthState(
     val accessToken: String?,
     val isOnboardingFinished: Boolean,
+    val isInitialized: Boolean = false,
 )

--- a/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
@@ -18,6 +18,7 @@ class MainViewModel @Inject constructor(
     val startDestination = observeAuthStateUseCase()
         .map { authState ->
             when {
+                !authState.isInitialized -> null
                 !authState.accessToken.isNullOrBlank() && authState.isOnboardingFinished -> PartyGraph
                 else -> AuthRoute.Login
             }

--- a/app/src/test/java/com/poti/android/data/local/datasource/AuthTokenStoreTest.kt
+++ b/app/src/test/java/com/poti/android/data/local/datasource/AuthTokenStoreTest.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -23,6 +25,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AuthTokenStoreTest {
@@ -104,5 +107,30 @@ class AuthTokenStoreTest {
         assertEquals(storedTokenPair.accessToken, observedAuthStates.last().accessToken)
         assertTrue(observedAuthStates.last().isOnboardingFinished)
         assertTrue(observedAuthStates.last().isInitialized)
+    }
+
+    @Test
+    fun `initializes as logged out when DataStore reads fail`() = runTest(testDispatcher) {
+        val failingPreferenceDataSource: PreferenceDataSource = mock(PreferenceDataSource::class.java)
+        `when`(failingPreferenceDataSource.tokenPair).thenReturn(
+            flow { throw IOException("Unable to read token preferences") },
+        )
+        `when`(failingPreferenceDataSource.authState).thenReturn(
+            flow { throw IOException("Unable to read auth preferences") },
+        )
+        val failingTokenStore = AuthTokenStore(
+            preferenceDataSource = failingPreferenceDataSource,
+            externalScope = CoroutineScope(SupervisorJob() + testDispatcher),
+            ioDispatcher = testDispatcher,
+        )
+
+        advanceUntilIdle()
+        val authState = failingTokenStore.authState.first()
+
+        assertTrue(failingTokenStore.tokenState.value.isInitialized)
+        assertNull(failingTokenStore.cachedTokenPair)
+        assertNull(authState.accessToken)
+        assertFalse(authState.isOnboardingFinished)
+        assertTrue(authState.isInitialized)
     }
 }

--- a/app/src/test/java/com/poti/android/data/local/datasource/AuthTokenStoreTest.kt
+++ b/app/src/test/java/com/poti/android/data/local/datasource/AuthTokenStoreTest.kt
@@ -1,0 +1,58 @@
+package com.poti.android.data.local.datasource
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class AuthTokenStoreTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private val preferenceDataSource: PreferenceDataSource = mock(PreferenceDataSource::class.java)
+
+    private lateinit var authTokenStore: AuthTokenStore
+
+    @Before
+    fun setUp() {
+        `when`(preferenceDataSource.tokenPair).thenReturn(emptyFlow())
+        authTokenStore = AuthTokenStore(
+            preferenceDataSource = preferenceDataSource,
+            externalScope = CoroutineScope(SupervisorJob() + testDispatcher),
+            ioDispatcher = testDispatcher,
+        )
+    }
+
+    @Test
+    fun `does not persist refreshed tokens after logout clears a newer token generation`() = runTest(testDispatcher) {
+        val refreshedTokenPair = TokenPair(
+            accessToken = "new-access-token",
+            refreshToken = "new-refresh-token",
+        )
+        val refreshGeneration = authTokenStore.updateCachedTokens(refreshedTokenPair)
+
+        val logoutGeneration = authTokenStore.clearCachedTokens()
+        val refreshedTokensPersisted = authTokenStore.persistTokensIfCurrent(
+            tokenPair = refreshedTokenPair,
+            generation = refreshGeneration,
+        )
+        val clearedTokensPersisted = authTokenStore.persistTokenClearIfCurrent(logoutGeneration)
+
+        assertFalse(refreshedTokensPersisted)
+        assertTrue(clearedTokensPersisted)
+        assertNull(authTokenStore.cachedTokenPair)
+        verify(preferenceDataSource, never()).saveTokens(
+            refreshedTokenPair.accessToken,
+            refreshedTokenPair.refreshToken,
+        )
+        verify(preferenceDataSource).clearTokens()
+    }
+}

--- a/app/src/test/java/com/poti/android/data/local/datasource/AuthTokenStoreTest.kt
+++ b/app/src/test/java/com/poti/android/data/local/datasource/AuthTokenStoreTest.kt
@@ -1,10 +1,19 @@
 package com.poti.android.data.local.datasource
 
+import com.poti.android.domain.model.auth.AuthState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -15,6 +24,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AuthTokenStoreTest {
     private val testDispatcher = StandardTestDispatcher()
     private val preferenceDataSource: PreferenceDataSource = mock(PreferenceDataSource::class.java)
@@ -54,5 +64,45 @@ class AuthTokenStoreTest {
             refreshedTokenPair.refreshToken,
         )
         verify(preferenceDataSource).clearTokens()
+    }
+
+    @Test
+    fun `starts uninitialized then exposes loaded token pair consistently through cache and auth state`() = runTest(testDispatcher) {
+        val storedTokenPair = TokenPair(
+            accessToken = "stored-access-token",
+            refreshToken = "stored-refresh-token",
+        )
+        val tokenPairFlow = MutableSharedFlow<TokenPair?>()
+        val persistedAuthState = MutableStateFlow(
+            AuthState(
+                accessToken = "stale-persisted-access-token",
+                isOnboardingFinished = true,
+            ),
+        )
+        val initializingPreferenceDataSource: PreferenceDataSource = mock(PreferenceDataSource::class.java)
+        `when`(initializingPreferenceDataSource.tokenPair).thenReturn(tokenPairFlow)
+        `when`(initializingPreferenceDataSource.authState).thenReturn(persistedAuthState)
+        val initializingTokenStore = AuthTokenStore(
+            preferenceDataSource = initializingPreferenceDataSource,
+            externalScope = CoroutineScope(SupervisorJob() + testDispatcher),
+            ioDispatcher = testDispatcher,
+        )
+        val observedAuthStates = mutableListOf<AuthState>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            initializingTokenStore.authState.collect(observedAuthStates::add)
+        }
+
+        assertFalse(initializingTokenStore.tokenState.value.isInitialized)
+        assertNull(initializingTokenStore.cachedTokenPair)
+
+        runCurrent()
+        tokenPairFlow.emit(storedTokenPair)
+        advanceUntilIdle()
+
+        assertTrue(initializingTokenStore.tokenState.value.isInitialized)
+        assertEquals(storedTokenPair, initializingTokenStore.cachedTokenPair)
+        assertEquals(storedTokenPair.accessToken, observedAuthStates.last().accessToken)
+        assertTrue(observedAuthStates.last().isOnboardingFinished)
+        assertTrue(observedAuthStates.last().isInitialized)
     }
 }

--- a/app/src/test/java/com/poti/android/data/network/AuthInterceptorTest.kt
+++ b/app/src/test/java/com/poti/android/data/network/AuthInterceptorTest.kt
@@ -1,0 +1,81 @@
+package com.poti.android.data.network
+
+import com.poti.android.BuildConfig
+import com.poti.android.data.local.datasource.AuthTokenStore
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+
+class AuthInterceptorTest {
+    private val authTokenStore: AuthTokenStore = mock(AuthTokenStore::class.java)
+    private val apiBaseUrl = BuildConfig.BASE_URL.toHttpUrl()
+
+    private lateinit var authInterceptor: AuthInterceptor
+
+    @Before
+    fun setUp() {
+        authInterceptor = AuthInterceptor(authTokenStore)
+        `when`(authTokenStore.ensureInitializedBlocking()).thenReturn(true)
+        `when`(authTokenStore.cachedAccessToken).thenReturn(ACCESS_TOKEN)
+    }
+
+    @Test
+    fun `adds Authorization header only for API origin`() {
+        val proceededRequest = intercept(apiUrl("/api/v1/party"))
+
+        assertEquals("Bearer $ACCESS_TOKEN", proceededRequest.header(AUTHORIZATION_HEADER))
+        verify(authTokenStore).ensureInitializedBlocking()
+    }
+
+    @Test
+    fun `does not add Authorization header for external origin`() {
+        val proceededRequest = intercept("https://external.example.com/api/v1/party")
+
+        assertNull(proceededRequest.header(AUTHORIZATION_HEADER))
+        verifyNoInteractions(authTokenStore)
+    }
+
+    @Test
+    fun `does not add Authorization header for excluded authentication endpoints`() {
+        val loginRequest = intercept(apiUrl("/api/v1/auth/login"))
+        val reissueRequest = intercept(apiUrl("/api/v1/auth/reissue"))
+
+        assertNull(loginRequest.header(AUTHORIZATION_HEADER))
+        assertNull(reissueRequest.header(AUTHORIZATION_HEADER))
+        verifyNoInteractions(authTokenStore)
+    }
+
+    private fun intercept(requestUrl: String): Request {
+        val originalRequest = Request.Builder().url(requestUrl).build()
+        val chain: Interceptor.Chain = mock(Interceptor.Chain::class.java)
+        `when`(chain.request()).thenReturn(originalRequest)
+        `when`(chain.proceed(any(Request::class.java) ?: originalRequest)).thenReturn(mock(Response::class.java))
+
+        authInterceptor.intercept(chain)
+
+        val requestCaptor = ArgumentCaptor.forClass(Request::class.java)
+        verify(chain).proceed(requestCaptor.capture() ?: originalRequest)
+        return requestCaptor.value
+    }
+
+    private fun apiUrl(path: String): String = apiBaseUrl.newBuilder()
+        .encodedPath(path)
+        .build()
+        .toString()
+
+    private companion object {
+        const val AUTHORIZATION_HEADER = "Authorization"
+        const val ACCESS_TOKEN = "access-token"
+    }
+}

--- a/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
@@ -11,14 +11,18 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import retrofit2.Call
+import java.io.IOException
 import javax.inject.Provider
 import retrofit2.Response as RetrofitResponse
 
@@ -65,6 +69,60 @@ class TokenAuthenticatorTest {
         }
     }
 
+    @Test
+    fun `logs out when reissue returns 401`() {
+        assertInvalidRefreshTokenLogsOut(HTTP_UNAUTHORIZED)
+    }
+
+    @Test
+    fun `logs out when reissue returns 403`() {
+        assertInvalidRefreshTokenLogsOut(HTTP_FORBIDDEN)
+    }
+
+    @Test
+    fun `keeps session when reissue returns server error`() {
+        stubReissueResponse(RetrofitResponse.error(HTTP_INTERNAL_SERVER_ERROR, "Server error".toResponseBody()))
+
+        val retriedRequest = tokenAuthenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(retriedRequest)
+        verify(authTokenStore, never()).clearCachedTokens()
+        verify(authSessionManager, never()).triggerLogout()
+    }
+
+    @Test
+    fun `keeps session when reissue throws IOException`() {
+        val reissueCall = mockReissueCall()
+        `when`(reissueCall.execute()).thenThrow(IOException("Network unavailable"))
+        `when`(authRemoteDataSource.reissue(ReissueRequestDto(OLD_REFRESH_TOKEN)))
+            .thenReturn(reissueCall)
+
+        val retriedRequest = tokenAuthenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(retriedRequest)
+        verify(authTokenStore, never()).clearCachedTokens()
+        verify(authSessionManager, never()).triggerLogout()
+    }
+
+    @Test
+    fun `keeps session when reissue returns success with null body data`() {
+        stubReissueResponse(
+            RetrofitResponse.success(
+                BaseResponse(
+                    code = 200,
+                    message = "Success",
+                    data = null,
+                ),
+            ),
+        )
+
+        val retriedRequest = tokenAuthenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(retriedRequest)
+        verify(authTokenStore, never()).clearCachedTokens()
+        verify(authSessionManager, never()).triggerLogout()
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun reissueCallReturningNewTokens(): Call<BaseResponse<ReissueResponseDto>> {
         val reissueCall = mock(Call::class.java) as Call<BaseResponse<ReissueResponseDto>>
@@ -82,6 +140,31 @@ class TokenAuthenticatorTest {
         )
         return reissueCall
     }
+
+    private fun assertInvalidRefreshTokenLogsOut(responseCode: Int) {
+        `when`(authTokenStore.clearCachedTokens()).thenReturn(TOKEN_GENERATION)
+        stubReissueResponse(RetrofitResponse.error(responseCode, "Invalid refresh token".toResponseBody()))
+
+        val retriedRequest = tokenAuthenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(retriedRequest)
+        verify(authTokenStore).clearCachedTokens()
+        runBlocking {
+            verify(authTokenStore).persistTokenClearIfCurrent(TOKEN_GENERATION)
+        }
+        verify(authSessionManager).triggerLogout()
+    }
+
+    private fun stubReissueResponse(response: RetrofitResponse<BaseResponse<ReissueResponseDto>>) {
+        val reissueCall = mockReissueCall()
+        `when`(reissueCall.execute()).thenReturn(response)
+        `when`(authRemoteDataSource.reissue(ReissueRequestDto(OLD_REFRESH_TOKEN)))
+            .thenReturn(reissueCall)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun mockReissueCall(): Call<BaseResponse<ReissueResponseDto>> =
+        mock(Call::class.java) as Call<BaseResponse<ReissueResponseDto>>
 
     private fun unauthorizedResponse(): Response = Response.Builder()
         .request(
@@ -102,6 +185,9 @@ class TokenAuthenticatorTest {
         const val NEW_ACCESS_TOKEN = "new-access-token"
         const val NEW_REFRESH_TOKEN = "new-refresh-token"
         const val TOKEN_GENERATION = 1L
+        const val HTTP_UNAUTHORIZED = 401
+        const val HTTP_FORBIDDEN = 403
+        const val HTTP_INTERNAL_SERVER_ERROR = 500
 
         val OLD_TOKEN_PAIR = TokenPair(
             accessToken = OLD_ACCESS_TOKEN,

--- a/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
@@ -1,0 +1,115 @@
+package com.poti.android.data.network
+
+import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.local.datasource.AuthTokenStore
+import com.poti.android.data.local.datasource.TokenPair
+import com.poti.android.data.remote.datasource.AuthRemoteDataSource
+import com.poti.android.data.remote.dto.request.auth.ReissueRequestDto
+import com.poti.android.data.remote.dto.response.auth.ReissueResponseDto
+import com.poti.android.domain.manager.AuthSessionManager
+import kotlinx.coroutines.runBlocking
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import retrofit2.Call
+import javax.inject.Provider
+import retrofit2.Response as RetrofitResponse
+
+class TokenAuthenticatorTest {
+    private val authTokenStore: AuthTokenStore = mock(AuthTokenStore::class.java)
+    private val authRemoteDataSource: AuthRemoteDataSource = mock(AuthRemoteDataSource::class.java)
+    private val authSessionManager: AuthSessionManager = mock(AuthSessionManager::class.java)
+
+    private lateinit var tokenAuthenticator: TokenAuthenticator
+
+    @Before
+    fun setUp() {
+        tokenAuthenticator = TokenAuthenticator(
+            authTokenStore = authTokenStore,
+            authRemoteDataSource = Provider { authRemoteDataSource },
+            authSessionManager = authSessionManager,
+        )
+
+        `when`(authTokenStore.ensureInitializedBlocking()).thenReturn(true)
+        `when`(authTokenStore.cachedTokenPair).thenReturn(OLD_TOKEN_PAIR)
+        `when`(authTokenStore.updateCachedTokens(NEW_TOKEN_PAIR)).thenReturn(TOKEN_GENERATION)
+    }
+
+    @Test
+    fun `reissues token and retries request with new access token when original request returns 401`() {
+        val reissueCall = reissueCallReturningNewTokens()
+        `when`(authRemoteDataSource.reissue(ReissueRequestDto(OLD_REFRESH_TOKEN)))
+            .thenReturn(reissueCall)
+
+        val retriedRequest = tokenAuthenticator.authenticate(
+            route = null,
+            response = unauthorizedResponse(),
+        )
+
+        assertNotNull(retriedRequest)
+        assertEquals(
+            "Bearer $NEW_ACCESS_TOKEN",
+            retriedRequest?.header(AUTHORIZATION_HEADER),
+        )
+        verify(authRemoteDataSource).reissue(ReissueRequestDto(OLD_REFRESH_TOKEN))
+        verify(authTokenStore).updateCachedTokens(NEW_TOKEN_PAIR)
+        runBlocking {
+            verify(authTokenStore).persistTokensIfCurrent(NEW_TOKEN_PAIR, TOKEN_GENERATION)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun reissueCallReturningNewTokens(): Call<BaseResponse<ReissueResponseDto>> {
+        val reissueCall = mock(Call::class.java) as Call<BaseResponse<ReissueResponseDto>>
+        `when`(reissueCall.execute()).thenReturn(
+            RetrofitResponse.success(
+                BaseResponse(
+                    code = 200,
+                    message = "Success",
+                    data = ReissueResponseDto(
+                        accessToken = NEW_ACCESS_TOKEN,
+                        refreshToken = NEW_REFRESH_TOKEN,
+                    ),
+                ),
+            ),
+        )
+        return reissueCall
+    }
+
+    private fun unauthorizedResponse(): Response = Response.Builder()
+        .request(
+            Request.Builder()
+                .url("https://api.example.com/api/v1/party")
+                .header(AUTHORIZATION_HEADER, "Bearer $OLD_ACCESS_TOKEN")
+                .build(),
+        )
+        .protocol(Protocol.HTTP_1_1)
+        .code(401)
+        .message("Unauthorized")
+        .build()
+
+    private companion object {
+        const val AUTHORIZATION_HEADER = "Authorization"
+        const val OLD_ACCESS_TOKEN = "old-access-token"
+        const val OLD_REFRESH_TOKEN = "old-refresh-token"
+        const val NEW_ACCESS_TOKEN = "new-access-token"
+        const val NEW_REFRESH_TOKEN = "new-refresh-token"
+        const val TOKEN_GENERATION = 1L
+
+        val OLD_TOKEN_PAIR = TokenPair(
+            accessToken = OLD_ACCESS_TOKEN,
+            refreshToken = OLD_REFRESH_TOKEN,
+        )
+        val NEW_TOKEN_PAIR = TokenPair(
+            accessToken = NEW_ACCESS_TOKEN,
+            refreshToken = NEW_REFRESH_TOKEN,
+        )
+    }
+}

--- a/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
@@ -139,7 +139,7 @@ class TokenAuthenticatorTest {
     fun `does not reissue login endpoint`() {
         val retriedRequest = tokenAuthenticator.authenticate(
             route = null,
-            response = unauthorizedResponse(requestUrl = "$API_ORIGIN/auth/login?source=test"),
+            response = unauthorizedResponse(requestUrl = "$API_ORIGIN/api/v1/auth/login?source=test"),
         )
 
         assertNull(retriedRequest)
@@ -150,7 +150,7 @@ class TokenAuthenticatorTest {
     fun `does not reissue reissue endpoint`() {
         val retriedRequest = tokenAuthenticator.authenticate(
             route = null,
-            response = unauthorizedResponse(requestUrl = "$API_ORIGIN/auth/reissue"),
+            response = unauthorizedResponse(requestUrl = "$API_ORIGIN/api/v1/auth/reissue"),
         )
 
         assertNull(retriedRequest)

--- a/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
@@ -71,6 +71,16 @@ class TokenAuthenticatorTest {
     }
 
     @Test
+    fun `logs out when reissue returns 400`() {
+        assertInvalidRefreshTokenLogsOut(HTTP_BAD_REQUEST)
+    }
+
+    @Test
+    fun `logs out when reissue returns 404`() {
+        assertInvalidRefreshTokenLogsOut(HTTP_NOT_FOUND)
+    }
+
+    @Test
     fun `logs out when reissue returns 401`() {
         assertInvalidRefreshTokenLogsOut(HTTP_UNAUTHORIZED)
     }
@@ -248,6 +258,8 @@ class TokenAuthenticatorTest {
         const val NEW_ACCESS_TOKEN = "new-access-token"
         const val NEW_REFRESH_TOKEN = "new-refresh-token"
         const val TOKEN_GENERATION = 1L
+        const val HTTP_BAD_REQUEST = 400
+        const val HTTP_NOT_FOUND = 404
         const val HTTP_UNAUTHORIZED = 401
         const val HTTP_FORBIDDEN = 403
         const val HTTP_INTERNAL_SERVER_ERROR = 500

--- a/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import retrofit2.Call
 import java.io.IOException
@@ -123,6 +124,39 @@ class TokenAuthenticatorTest {
         verify(authSessionManager, never()).triggerLogout()
     }
 
+    @Test
+    fun `does not reissue when response already has an authentication retry`() {
+        val retriedRequest = tokenAuthenticator.authenticate(
+            route = null,
+            response = unauthorizedResponse(previousResponse = unauthorizedResponse()),
+        )
+
+        assertNull(retriedRequest)
+        verifyNoInteractions(authRemoteDataSource)
+    }
+
+    @Test
+    fun `does not reissue login endpoint`() {
+        val retriedRequest = tokenAuthenticator.authenticate(
+            route = null,
+            response = unauthorizedResponse(requestUrl = "$API_ORIGIN/auth/login?source=test"),
+        )
+
+        assertNull(retriedRequest)
+        verifyNoInteractions(authRemoteDataSource)
+    }
+
+    @Test
+    fun `does not reissue reissue endpoint`() {
+        val retriedRequest = tokenAuthenticator.authenticate(
+            route = null,
+            response = unauthorizedResponse(requestUrl = "$API_ORIGIN/auth/reissue"),
+        )
+
+        assertNull(retriedRequest)
+        verifyNoInteractions(authRemoteDataSource)
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun reissueCallReturningNewTokens(): Call<BaseResponse<ReissueResponseDto>> {
         val reissueCall = mock(Call::class.java) as Call<BaseResponse<ReissueResponseDto>>
@@ -166,20 +200,28 @@ class TokenAuthenticatorTest {
     private fun mockReissueCall(): Call<BaseResponse<ReissueResponseDto>> =
         mock(Call::class.java) as Call<BaseResponse<ReissueResponseDto>>
 
-    private fun unauthorizedResponse(): Response = Response.Builder()
+    private fun unauthorizedResponse(
+        requestUrl: String = PARTY_URL,
+        previousResponse: Response? = null,
+    ): Response = Response.Builder()
         .request(
             Request.Builder()
-                .url("https://api.example.com/api/v1/party")
+                .url(requestUrl)
                 .header(AUTHORIZATION_HEADER, "Bearer $OLD_ACCESS_TOKEN")
                 .build(),
         )
         .protocol(Protocol.HTTP_1_1)
         .code(401)
         .message("Unauthorized")
+        .apply {
+            previousResponse?.let { priorResponse(it) }
+        }
         .build()
 
     private companion object {
         const val AUTHORIZATION_HEADER = "Authorization"
+        const val API_ORIGIN = "https://api.example.com"
+        const val PARTY_URL = "$API_ORIGIN/api/v1/party"
         const val OLD_ACCESS_TOKEN = "old-access-token"
         const val OLD_REFRESH_TOKEN = "old-refresh-token"
         const val NEW_ACCESS_TOKEN = "new-access-token"

--- a/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
@@ -175,8 +175,29 @@ class TokenAuthenticatorTest {
         return reissueCall
     }
 
+    @Test
+    fun `does not trigger logout when a newer auth generation is active`() {
+        `when`(authTokenStore.clearCachedTokens()).thenReturn(TOKEN_GENERATION)
+        runBlocking {
+            `when`(authTokenStore.persistTokenClearIfCurrent(TOKEN_GENERATION)).thenReturn(true)
+        }
+        `when`(authTokenStore.isLogoutGenerationCurrent(TOKEN_GENERATION)).thenReturn(false)
+        stubReissueResponse(
+            RetrofitResponse.error(HTTP_UNAUTHORIZED, "Invalid refresh token".toResponseBody()),
+        )
+
+        val retriedRequest = tokenAuthenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(retriedRequest)
+        verify(authSessionManager, never()).triggerLogout()
+    }
+
     private fun assertInvalidRefreshTokenLogsOut(responseCode: Int) {
         `when`(authTokenStore.clearCachedTokens()).thenReturn(TOKEN_GENERATION)
+        runBlocking {
+            `when`(authTokenStore.persistTokenClearIfCurrent(TOKEN_GENERATION)).thenReturn(true)
+        }
+        `when`(authTokenStore.isLogoutGenerationCurrent(TOKEN_GENERATION)).thenReturn(true)
         stubReissueResponse(RetrofitResponse.error(responseCode, "Invalid refresh token".toResponseBody()))
 
         val retriedRequest = tokenAuthenticator.authenticate(null, unauthorizedResponse())


### PR DESCRIPTION
## Related issue 🛠️

- closed #168

## Work Description ✏️

- refresh token 재발급 실패를 상태별로 분리했습니다.
  - 401/403: 토큰 삭제 및 로그아웃
  - 5xx, timeout, IOException, 200/null body: 세션 유지 및 요청 실패 처리
- 재발급 전용 OkHttpClient/Retrofit을 분리하고 timeout을 설정했습니다.
- 재시도 횟수를 1회로 제한하고, 로그인·재발급 경로는 Authenticator/Interceptor 대상에서 제외했습니다.
- access/refresh token을 `TokenPair`로 원자적으로 관리하고, 앱 시작 시 토큰 캐시 초기화 상태를 보장했습니다.
- 재발급 저장과 로그아웃이 경합할 때 generation 기반으로 오래된 토큰 저장 및 오래된 로그아웃 이벤트를 차단했습니다.
- Authorization 헤더를 API origin에만 추가하고, HTTP BODY 로그 및 토큰 로그를 제거했습니다.
- 재발급 성공/실패, 재시도 제한, 인증 URL 제외, 캐시 초기화, 로그아웃 경쟁, 헤더 추가 동작 테스트를 추가했습니다.

## Screenshot 📸

- N/A

## Uncompleted Tasks 😅

- N/A

## To Reviewers 📢

- 실제 인증 경로(`/api/v1/auth/login`, `/api/v1/auth/reissue`) 기준으로 제외 경로를 수정했습니다.
- 재발급 실패 후 새 로그인 세션이 생성된 경우, 이전 로그아웃 이벤트가 새 세션을 끊지 않도록 generation을 확인합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 로그인 상태 초기화가 완료될 때까지 화면 전환을 안정적으로 처리합니다.
  * 액세스 토큰 관리와 인증 상태 반영을 개선했습니다.
  * 토큰 만료 시 자동 재발급 및 안전한 요청 재시도를 지원합니다.
  * 인증 요청과 일반 API 요청을 분리하고, 디버그 환경의 네트워크 로그 노출을 줄였습니다.

* **테스트**
  * 토큰 저장, 초기화, 로그아웃 및 재발급 성공·실패 시나리오를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->