### PR TITLE
Feat/#173 new component

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiCircleIconButton.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiCircleIconButton.kt
@@ -1,0 +1,57 @@
+package com.poti.android.core.designsystem.component.button
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.common.extension.noRippleClickable
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.designsystem.theme.PotiTheme.colors
+
+/**
+ * Poti 원형 아이콘 버튼
+ *
+ * @param onClick 버튼을 눌렀을 때 호출되는 콜백
+ * @param modifier 컴포넌트에 적용할 modifier
+ */
+@Composable
+fun PotiCircleIconButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(colors.black)
+            .noRippleClickable(onClick)
+            .padding(6.dp),
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_edit),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = colors.white,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PotiCircleIconButtonPreview() {
+    PotiTheme {
+        Column(modifier = Modifier.padding(16.dp)) {
+            PotiCircleIconButton(onClick = {})
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiMenuButton.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiMenuButton.kt
@@ -3,7 +3,6 @@ package com.poti.android.core.designsystem.component.button
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -34,14 +33,14 @@ import com.poti.android.core.designsystem.theme.PotiTheme.typography
 /**
  * Poti 설정 화면용 리스트 행 버튼
  *
- * 배경과 클릭 영역이 컴포넌트 전체를 차지하므로, 눌린 배경을 좌우 끝까지 채우려면
- * 호출부에서 `Modifier.fillMaxWidth()`를 넘깁니다.
+ * 컴포넌트는 눌린 배경과 클릭 영역 전체를 차지하며,
+ * 화면에서 컴포넌트까지의 배치 여백은 부모에서 적용합니다.
  *
  * @param text 좌측에 표시할 라벨
  * @param onClick 항목을 눌렀을 때 호출되는 콜백
  * @param modifier 컴포넌트에 적용할 modifier
  * @param trailingText 우측에 표시할 보조 텍스트, null이면 화살표 아이콘을 표시합니다
- * @param contentPadding 배경 안쪽 콘텐츠에 적용할 여백
+ * @param contentPadding 콘텐츠에 적용할 여백
  */
 @Composable
 fun PotiMenuButton(
@@ -49,13 +48,35 @@ fun PotiMenuButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     trailingText: String? = null,
-    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+    contentPadding: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
 
+    PotiMenuButtonContent(
+        text = text,
+        isPressed = isPressed,
+        modifier = modifier,
+        interactionSource = interactionSource,
+        onClick = onClick,
+        trailingText = trailingText,
+        contentPadding = contentPadding,
+    )
+}
+
+@Composable
+private fun PotiMenuButtonContent(
+    text: String,
+    isPressed: Boolean,
+    interactionSource: MutableInteractionSource,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailingText: String? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+) {
     Row(
         modifier = modifier
+            .fillMaxWidth()
             .heightIn(min = 56.dp)
             .clip(RoundedCornerShape(16.dp))
             .background(if (isPressed) colors.gray100 else Color.Transparent)
@@ -64,11 +85,11 @@ fun PotiMenuButton(
                 onClick = onClick,
             )
             .padding(contentPadding),
-        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = text,
+            modifier = Modifier.weight(1f),
             style = typography.body16sb,
             color = colors.black,
         )
@@ -90,27 +111,43 @@ fun PotiMenuButton(
     }
 }
 
-@Preview(showBackground = true, widthDp = 360)
+@Preview(showBackground = true, widthDp = 375)
 @Composable
 private fun PotiMenuButtonPreview() {
+    val interactionSource = remember { MutableInteractionSource() }
+
     PotiTheme {
-        Column {
+        Column(
+            modifier = Modifier.padding(horizontal = 8.dp),
+        ) {
             PotiMenuButton(
                 text = "내 계정",
                 onClick = {},
-                modifier = Modifier.fillMaxWidth(),
             )
 
             PotiMenuButton(
                 text = "내 프로필 관리",
                 onClick = {},
-                modifier = Modifier.fillMaxWidth(),
             )
 
             PotiMenuButton(
                 text = "버전 정보",
                 onClick = {},
-                modifier = Modifier.fillMaxWidth(),
+                trailingText = "1.0.0",
+            )
+
+            PotiMenuButtonContent(
+                text = "내 계정",
+                isPressed = true,
+                interactionSource = interactionSource,
+                onClick = {},
+            )
+
+            PotiMenuButtonContent(
+                text = "버전 정보",
+                isPressed = true,
+                interactionSource = interactionSource,
+                onClick = {},
                 trailingText = "1.0.0",
             )
         }

--- a/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiMenuButton.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiMenuButton.kt
@@ -1,0 +1,118 @@
+package com.poti.android.core.designsystem.component.button
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.common.extension.noRippleClickable
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.designsystem.theme.PotiTheme.colors
+import com.poti.android.core.designsystem.theme.PotiTheme.typography
+
+/**
+ * Poti 설정 화면용 리스트 행 버튼
+ *
+ * 배경과 클릭 영역이 컴포넌트 전체를 차지하므로, 눌린 배경을 좌우 끝까지 채우려면
+ * 호출부에서 `Modifier.fillMaxWidth()`를 넘깁니다.
+ *
+ * @param text 좌측에 표시할 라벨
+ * @param onClick 항목을 눌렀을 때 호출되는 콜백
+ * @param modifier 컴포넌트에 적용할 modifier
+ * @param trailingText 우측에 표시할 보조 텍스트, null이면 화살표 아이콘을 표시합니다
+ * @param contentPadding 배경 안쪽 콘텐츠에 적용할 여백
+ */
+@Composable
+fun PotiMenuButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailingText: String? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    Row(
+        modifier = modifier
+            .heightIn(min = 56.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(if (isPressed) colors.gray100 else Color.Transparent)
+            .noRippleClickable(
+                interactionSource = interactionSource,
+                onClick = onClick,
+            )
+            .padding(contentPadding),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = typography.body16sb,
+            color = colors.black,
+        )
+
+        if (trailingText != null) {
+            Text(
+                text = trailingText,
+                style = typography.body16sb,
+                color = colors.gray800,
+            )
+        } else {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_right_lg),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+                tint = colors.gray700,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+private fun PotiMenuButtonPreview() {
+    PotiTheme {
+        Column {
+            PotiMenuButton(
+                text = "내 계정",
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            PotiMenuButton(
+                text = "내 프로필 관리",
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            PotiMenuButton(
+                text = "버전 정보",
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+                trailingText = "1.0.0",
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiMenuToggle.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiMenuToggle.kt
@@ -44,7 +44,6 @@ fun PotiMenuToggle(
         modifier = modifier
             .heightIn(min = 80.dp)
             .padding(contentPadding),
-        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(

--- a/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiMenuToggle.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiMenuToggle.kt
@@ -1,0 +1,105 @@
+package com.poti.android.core.designsystem.component.button
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.designsystem.theme.PotiTheme.colors
+import com.poti.android.core.designsystem.theme.PotiTheme.typography
+
+/**
+ * Poti 설정 화면용 제목 + 설명 토글 행
+ *
+ * @param title 좌측 상단 제목
+ * @param description 제목 아래 설명
+ * @param checked 토글 on/off 여부
+ * @param onCheckedChange 토글을 눌렀을 때 변경될 상태와 함께 호출되는 콜백
+ * @param modifier 컴포넌트에 적용할 modifier
+ * @param contentPadding 콘텐츠에 적용할 여백
+ */
+@Composable
+fun PotiMenuToggle(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(start = 16.dp, end = 16.dp, top = 15.dp, bottom = 16.dp),
+) {
+    Row(
+        modifier = modifier
+            .heightIn(min = 80.dp)
+            .padding(contentPadding),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = title,
+                style = typography.body16sb,
+                color = colors.black,
+            )
+            Text(
+                text = description,
+                style = typography.body14m,
+                color = colors.gray800,
+            )
+        }
+
+        PotiToggle(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 375)
+@Composable
+private fun PotiMenuTogglePreview() {
+    var checked by remember { mutableStateOf(true) }
+
+    PotiTheme {
+        Column {
+            PotiMenuToggle(
+                title = "거래 알림",
+                description = "분철 모집/참여 거래 알림",
+                checked = true,
+                onCheckedChange = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            PotiMenuToggle(
+                title = "거래 알림",
+                description = "분철 모집/참여 거래 알림",
+                checked = false,
+                onCheckedChange = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            PotiMenuToggle(
+                title = "거래 알림",
+                description = "분철 모집/참여 거래 알림",
+                checked = checked,
+                onCheckedChange = { checked = it },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiToggle.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiToggle.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -51,11 +51,11 @@ fun PotiToggle(
             .height(26.dp)
             .clip(RoundedCornerShape(50.dp))
             .background(trackColor)
-            .selectable(
-                selected = checked,
+            .toggleable(
+                value = checked,
                 interactionSource = null,
                 indication = null,
-                onClick = { onCheckedChange(!checked) },
+                onValueChange = onCheckedChange,
             )
             .padding(3.dp),
         contentAlignment = Alignment.CenterStart,

--- a/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiToggle.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/button/PotiToggle.kt
@@ -1,0 +1,90 @@
+package com.poti.android.core.designsystem.component.button
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.designsystem.theme.PotiTheme.colors
+
+/**
+ * Poti 토글 스위치 UI
+ *
+ * @param checked 토글 on/off 여부
+ * @param onCheckedChange 토글을 눌렀을 때 변경될 상태와 함께 호출되는 콜백
+ * @param modifier 컴포넌트에 적용할 modifier
+ */
+@Composable
+fun PotiToggle(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val trackColor = if (checked) colors.poti600 else colors.gray500
+    val thumbOffset by animateDpAsState(
+        targetValue = if (checked) 20.dp else 0.dp,
+        label = "thumbOffset",
+    )
+
+    Box(
+        modifier = modifier
+            .width(46.dp)
+            .height(26.dp)
+            .clip(RoundedCornerShape(50.dp))
+            .background(trackColor)
+            .selectable(
+                selected = checked,
+                interactionSource = null,
+                indication = null,
+                onClick = { onCheckedChange(!checked) },
+            )
+            .padding(3.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Box(
+            modifier = Modifier
+                .offset(x = thumbOffset)
+                .size(20.dp)
+                .clip(CircleShape)
+                .background(colors.white),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PotiTogglePreview() {
+    var checked by remember { mutableStateOf(true) }
+
+    PotiTheme {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            PotiToggle(checked = true, onCheckedChange = {})
+
+            PotiToggle(checked = false, onCheckedChange = {})
+
+            PotiToggle(checked = checked, onCheckedChange = { checked = it })
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiCheckBoxItem.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiCheckBoxItem.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.core.designsystem.theme.PotiTheme
@@ -40,12 +41,13 @@ fun PotiCheckBoxItem(
     Row(
         modifier = modifier
             .alpha(if (enabled) 1f else 0.4f)
-            .selectable(
-                selected = selected,
+            .toggleable(
+                value = selected,
                 enabled = enabled,
+                role = Role.Checkbox,
                 interactionSource = null,
                 indication = null,
-                onClick = { onCheckedChange(!selected) },
+                onValueChange = onCheckedChange,
             ),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiCheckBoxItem.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiCheckBoxItem.kt
@@ -1,0 +1,83 @@
+package com.poti.android.core.designsystem.component.display
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.designsystem.theme.PotiTheme.colors
+import com.poti.android.core.designsystem.theme.PotiTheme.typography
+
+/**
+ * Poti 체크박스 + 라벨 UI
+ *
+ * @param text 체크박스 우측에 표시할 라벨
+ * @param selected 체크박스 선택 여부
+ * @param onCheckedChange 항목을 눌렀을 때 변경될 상태와 함께 호출되는 콜백
+ * @param modifier 컴포넌트에 적용할 modifier
+ * @param enabled 활성화 여부, 비활성 시 흐리게 표시되며 클릭되지 않습니다
+ */
+@Composable
+fun PotiCheckBoxItem(
+    text: String,
+    selected: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    Row(
+        modifier = modifier
+            .alpha(if (enabled) 1f else 0.4f)
+            .selectable(
+                selected = selected,
+                enabled = enabled,
+                interactionSource = null,
+                indication = null,
+                onClick = { onCheckedChange(!selected) },
+            ),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        PotiCheckBox(selected = selected)
+        Text(
+            text = text,
+            style = typography.body14m,
+            color = colors.gray900,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PotiCheckBoxItemPreview() {
+    var selected by remember { mutableStateOf(false) }
+
+    PotiTheme {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            PotiCheckBoxItem(text = "버튼", selected = false, onCheckedChange = {})
+
+            PotiCheckBoxItem(text = "버튼", selected = true, onCheckedChange = {})
+
+            PotiCheckBoxItem(text = "버튼", selected = false, onCheckedChange = {}, enabled = false)
+
+            PotiCheckBoxItem(text = "버튼", selected = true, onCheckedChange = {}, enabled = false)
+
+            PotiCheckBoxItem(text = "버튼", selected = selected, onCheckedChange = { selected = it })
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiNoticeItem.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiNoticeItem.kt
@@ -46,7 +46,6 @@ fun PotiNoticeItem(
             .background(if (isRead) colors.white else colors.gray100)
             .noRippleClickable(onClick)
             .padding(contentPadding),
-        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(
             modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiNoticeItem.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiNoticeItem.kt
@@ -1,0 +1,105 @@
+package com.poti.android.core.designsystem.component.display
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.core.common.extension.noRippleClickable
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.designsystem.theme.PotiTheme.colors
+import com.poti.android.core.designsystem.theme.PotiTheme.typography
+
+/**
+ * Poti 알림 목록 아이템
+ *
+ * @param title 알림 제목
+ * @param content 알림 본문
+ * @param time 우측에 표시할 시간
+ * @param isRead 읽음 여부, 읽지 않은 알림은 배경을 강조합니다
+ * @param onClick 알림을 눌렀을 때 호출되는 콜백
+ * @param modifier 컴포넌트에 적용할 modifier
+ * @param contentPadding 콘텐츠에 적용할 여백
+ */
+@Composable
+fun PotiNoticeItem(
+    title: String,
+    content: String,
+    time: String,
+    isRead: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(16.dp),
+) {
+    Row(
+        modifier = modifier
+            .heightIn(min = 81.dp)
+            .background(if (isRead) colors.white else colors.gray100)
+            .noRippleClickable(onClick)
+            .padding(contentPadding),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = title,
+                style = typography.body16sb,
+                color = colors.black,
+            )
+            Text(
+                text = content,
+                style = typography.body14m,
+                color = colors.gray800,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        Text(
+            text = time,
+            style = typography.caption12m,
+            color = colors.gray700,
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+private fun PotiNoticeItemPreview() {
+    PotiTheme {
+        Column {
+            PotiNoticeItem(
+                title = "배송 시작",
+                content = "아이브 메이크스타 거래건 배송이 시작되었어요",
+                time = "3시간 전",
+                isRead = true,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            PotiDivider(
+                styleType = PotiDividerStyle.SMALL,
+            )
+
+            PotiNoticeItem(
+                title = "배송 시작",
+                content = "아이브 메이크스타 거래건 배송이 시작되었어요",
+                time = "3시간 전",
+                isRead = false,
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠️
- closed #173

## Work Description ✏️

Figma 신규 컴포넌트 6종을 추가했습니다.

| 컴포넌트 | 설명 |
| --- | --- |
| `PotiToggle` | on/off 스위치 |
| `PotiCheckBoxItem` | 체크박스 + 라벨, 4상태 |
| `PotiMenuButton` | 설정 리스트 행, 아이콘 / 보조 텍스트 2 variant |
| `PotiMenuToggle` | 제목 + 설명 + 토글 |
| `PotiNoticeItem` | 알림 목록 아이템, 읽음/새 알림 |
| `PotiCircleIconButton` | 원형 아이콘 버튼 |

## Screenshot 📸

| Preview 1 | Preview 2 | 
| --- | --- |
| <img width="273" height="480" alt="스크린샷 2026-08-11 오후 6 50 31" src="https://github.com/user-attachments/assets/7b012ce1-f6f7-455a-a60b-5e5a0d7d424e" /> | <img width="244" height="546" alt="스크린샷 2026-08-11 오후 6 54 17" src="https://github.com/user-attachments/assets/73d5fde5-5234-44c3-a6c3-25addc95ad1f" /> |
| <img width="382" height="218" alt="스크린샷 2026-08-11 오후 6 54 35" src="https://github.com/user-attachments/assets/2fd34853-545b-4ccc-b799-2cf6971d65ff" /> | <img width="393" height="282" alt="스크린샷 2026-08-11 오후 6 54 54" src="https://github.com/user-attachments/assets/fdde5d38-c255-4b86-9a1d-ef1c08d80072" /> |
| <img width="428" height="223" alt="스크린샷 2026-08-11 오후 6 55 13" src="https://github.com/user-attachments/assets/6539c2c5-4a41-4aca-91c8-d3f29f473452" /> | <img width="249" height="272" alt="스크린샷 2026-08-11 오후 7 00 29" src="https://github.com/user-attachments/assets/e19d5c1a-319b-4492-9d67-28974374e838" /> |


## Uncompleted Tasks 😅

- [ ] 화면 연결 - 설정, 알림 화면 구현 시 후속 작업에서 진행

## To Reviewers 📢

**`PotiMenuButton`의 pressed 배경**은 Figma 상 행 밖으로 번지는 구조(359×56 vs 343×48)라, 컴포넌트가 좌우 여백을 스스로 소유하고 콘텐츠를 `contentPadding`으로 들여쓰는 방식으로 구현했습니다. 부모가 추가 padding을 주면 full-bleed 가 깨집니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 원형 아이콘 버튼, 메뉴 버튼, 토글 및 메뉴 토글 UI를 추가했습니다.
  * 선택·비활성 상태를 지원하는 체크박스 항목을 추가했습니다.
  * 읽음 상태에 따라 표시가 달라지는 알림 항목을 추가했습니다.
  * 각 컴포넌트의 다양한 상태를 확인할 수 있는 미리보기를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->