### PR TITLE
[Feat/#183] 분철팟 검색 기능 구현

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
@@ -53,6 +53,7 @@ fun PotiHeaderPage(
         modifier = modifier,
         potiHeaderPageType = potiHeaderPageType,
         containerColor = containerColor,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Column(
             modifier = Modifier.weight(1f),
@@ -131,7 +132,9 @@ fun PotiHeaderPageSearch(
             value = value,
             onValueChange = onValueChange,
             onSearch = onSearch,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 12.dp),
             placeholder = placeholder,
             onClear = onClear,
             focusRequester = focusRequester,
@@ -154,6 +157,7 @@ private fun PotiHeaderPageBase(
     modifier: Modifier = Modifier,
     potiHeaderPageType: PotiHeaderPageType = PotiHeaderPageType.BACK,
     containerColor: Color = PotiTheme.colors.white,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
     content: @Composable RowScope.() -> Unit,
 ) {
     Row(
@@ -161,7 +165,7 @@ private fun PotiHeaderPageBase(
             .background(containerColor)
             .padding(horizontal = 4.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = horizontalArrangement,
     ) {
         PotiIconButton(
             iconRes = potiHeaderPageType.iconResId,

--- a/app/src/main/java/com/poti/android/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/RepositoryModule.kt
@@ -11,6 +11,7 @@ import com.poti.android.data.repository.PartyRepositoryImpl
 import com.poti.android.data.repository.PaymentRepositoryImpl
 import com.poti.android.data.repository.ReviewRepositoryImpl
 import com.poti.android.data.repository.S3RepositoryImpl
+import com.poti.android.data.repository.SearchRepositoryImpl
 import com.poti.android.data.repository.UserRepositoryImpl
 import com.poti.android.domain.repository.ArtistRepository
 import com.poti.android.domain.repository.AuthRepository
@@ -23,6 +24,7 @@ import com.poti.android.domain.repository.PartyRepository
 import com.poti.android.domain.repository.PaymentRepository
 import com.poti.android.domain.repository.ReviewRepository
 import com.poti.android.domain.repository.S3Repository
+import com.poti.android.domain.repository.SearchRepository
 import com.poti.android.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
@@ -52,6 +54,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindPartyRepository(partyRepositoryImpl: PartyRepositoryImpl): PartyRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSearchRepository(searchRepositoryImpl: SearchRepositoryImpl): SearchRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/poti/android/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/ServiceModule.kt
@@ -9,6 +9,7 @@ import com.poti.android.data.remote.service.ParticipationService
 import com.poti.android.data.remote.service.PartyService
 import com.poti.android.data.remote.service.PaymentService
 import com.poti.android.data.remote.service.ReviewService
+import com.poti.android.data.remote.service.SearchService
 import com.poti.android.data.remote.service.UserService
 import dagger.Module
 import dagger.Provides
@@ -56,6 +57,11 @@ object ServiceModule {
     @Singleton
     fun providePartyService(retrofit: Retrofit): PartyService =
         retrofit.create(PartyService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSearchService(retrofit: Retrofit): SearchService =
+        retrofit.create(SearchService::class.java)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/poti/android/data/mapper/home/GoodsCategoryMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/home/GoodsCategoryMapper.kt
@@ -11,7 +11,6 @@ fun GoodsCategoryResponseDto.toDomain(): ProductCategory =
         mainArtist = mainArtist,
         mainArtistId = mainArtistId,
         groupItems = groupItems?.map { it.toDomain() }.orEmpty(),
-        myGroupItems = myGroupItems?.map { it.toDomain() }.orEmpty(),
     )
 
 fun GroupItemDto.toDomain(): GroupItem =

--- a/app/src/main/java/com/poti/android/data/mapper/search/PartySearchMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/search/PartySearchMapper.kt
@@ -17,6 +17,6 @@ private fun PartySearchItemResponseDto.toDomain(): PartySearchItem =
         artistId = artistId,
         postImage = postImage.orEmpty(),
         postTitle = postTitle,
-        postCount = postCount.toInt(),
+        postCount = postCount,
         tag = tag,
     )

--- a/app/src/main/java/com/poti/android/data/mapper/search/PartySearchMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/search/PartySearchMapper.kt
@@ -8,7 +8,7 @@ import com.poti.android.domain.model.search.PartySearchResult
 fun PartySearchResponseDto.toDomain(): PartySearchResult =
     PartySearchResult(
         items = content.map { it.toDomain() },
-        hasNext = hasNext,
+        hasNext = false,
     )
 
 private fun PartySearchItemResponseDto.toDomain(): PartySearchItem =

--- a/app/src/main/java/com/poti/android/data/mapper/search/PartySearchMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/search/PartySearchMapper.kt
@@ -8,7 +8,7 @@ import com.poti.android.domain.model.search.PartySearchResult
 fun PartySearchResponseDto.toDomain(): PartySearchResult =
     PartySearchResult(
         items = content.map { it.toDomain() },
-        hasNext = false,
+        hasNext = hasNext,
     )
 
 private fun PartySearchItemResponseDto.toDomain(): PartySearchItem =

--- a/app/src/main/java/com/poti/android/data/mapper/search/PartySearchMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/search/PartySearchMapper.kt
@@ -1,0 +1,22 @@
+package com.poti.android.data.mapper.search
+
+import com.poti.android.data.remote.dto.response.search.PartySearchItemResponseDto
+import com.poti.android.data.remote.dto.response.search.PartySearchResponseDto
+import com.poti.android.domain.model.search.PartySearchItem
+import com.poti.android.domain.model.search.PartySearchResult
+
+fun PartySearchResponseDto.toDomain(): PartySearchResult =
+    PartySearchResult(
+        items = content.map { it.toDomain() },
+        hasNext = hasNext,
+    )
+
+private fun PartySearchItemResponseDto.toDomain(): PartySearchItem =
+    PartySearchItem(
+        artist = artist,
+        artistId = artistId,
+        postImage = postImage.orEmpty(),
+        postTitle = postTitle,
+        postCount = postCount.toInt(),
+        tag = tag,
+    )

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -132,7 +132,6 @@ object UiMockData {
                 tag = tags[index % tags.size],
             )
         },
-        myGroupItems = emptyList(),
     )
 
     val productPartyList = ProductPartyList(

--- a/app/src/main/java/com/poti/android/data/remote/datasource/SearchRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/SearchRemoteDataSource.kt
@@ -12,7 +12,6 @@ class SearchRemoteDataSource @Inject constructor(
         keyword: String,
         page: Int,
         size: Int,
-        sort: String?,
     ): BaseResponse<PartySearchResponseDto> =
-        searchService.searchParties(keyword, page, size, sort)
+        searchService.searchParties(keyword, page, size)
 }

--- a/app/src/main/java/com/poti/android/data/remote/datasource/SearchRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/SearchRemoteDataSource.kt
@@ -1,0 +1,18 @@
+package com.poti.android.data.remote.datasource
+
+import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.response.search.PartySearchResponseDto
+import com.poti.android.data.remote.service.SearchService
+import javax.inject.Inject
+
+class SearchRemoteDataSource @Inject constructor(
+    private val searchService: SearchService,
+) {
+    suspend fun searchParties(
+        keyword: String,
+        page: Int,
+        size: Int,
+        sort: String?,
+    ): BaseResponse<PartySearchResponseDto> =
+        searchService.searchParties(keyword, page, size, sort)
+}

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/home/GoodsCategoryResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/home/GoodsCategoryResponseDto.kt
@@ -13,8 +13,6 @@ data class GoodsCategoryResponseDto(
     val mainArtistId: Long?,
     @SerialName("groupItems")
     val groupItems: List<GroupItemDto>?,
-    @SerialName("myGroupItems")
-    val myGroupItems: List<GroupItemDto>?,
 )
 
 @Serializable

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/party/PartySearchResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/party/PartySearchResponseDto.kt
@@ -1,0 +1,28 @@
+package com.poti.android.data.remote.dto.response.party
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PartySearchResponseDto(
+    @SerialName("content")
+    val content: List<PartySearchItemResponseDto>,
+    @SerialName("hasNext")
+    val hasNext: Boolean,
+)
+
+@Serializable
+data class PartySearchItemResponseDto(
+    @SerialName("artist")
+    val artist: String,
+    @SerialName("artistId")
+    val artistId: Long,
+    @SerialName("postImage")
+    val postImage: String?,
+    @SerialName("postTitle")
+    val postTitle: String,
+    @SerialName("postCount")
+    val postCount: Long,
+    @SerialName("tag")
+    val tag: String?,
+)

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/search/PartySearchResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/search/PartySearchResponseDto.kt
@@ -1,4 +1,4 @@
-package com.poti.android.data.remote.dto.response.party
+package com.poti.android.data.remote.dto.response.search
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/search/PartySearchResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/search/PartySearchResponseDto.kt
@@ -7,8 +7,8 @@ import kotlinx.serialization.Serializable
 data class PartySearchResponseDto(
     @SerialName("content")
     val content: List<PartySearchItemResponseDto>,
-    @SerialName("hasNext")
-    val hasNext: Boolean,
+//    @SerialName("hasNext")
+//    val hasNext: Boolean,
 )
 
 @Serializable

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/search/PartySearchResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/search/PartySearchResponseDto.kt
@@ -7,8 +7,8 @@ import kotlinx.serialization.Serializable
 data class PartySearchResponseDto(
     @SerialName("content")
     val content: List<PartySearchItemResponseDto>,
-//    @SerialName("hasNext")
-//    val hasNext: Boolean,
+    @SerialName("hasNext")
+    val hasNext: Boolean,
 )
 
 @Serializable

--- a/app/src/main/java/com/poti/android/data/remote/service/SearchService.kt
+++ b/app/src/main/java/com/poti/android/data/remote/service/SearchService.kt
@@ -1,0 +1,16 @@
+package com.poti.android.data.remote.service
+
+import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.response.search.PartySearchResponseDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface SearchService {
+    @GET("/api/v1/search")
+    suspend fun searchParties(
+        @Query("keyword") keyword: String,
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+        @Query("sort") sort: String?,
+    ): BaseResponse<PartySearchResponseDto>
+}

--- a/app/src/main/java/com/poti/android/data/remote/service/SearchService.kt
+++ b/app/src/main/java/com/poti/android/data/remote/service/SearchService.kt
@@ -11,6 +11,5 @@ interface SearchService {
         @Query("keyword") keyword: String,
         @Query("page") page: Int,
         @Query("size") size: Int,
-        @Query("sort") sort: String?,
     ): BaseResponse<PartySearchResponseDto>
 }

--- a/app/src/main/java/com/poti/android/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/SearchRepositoryImpl.kt
@@ -19,7 +19,6 @@ class SearchRepositoryImpl @Inject constructor(
         keyword: String,
         page: Int,
         size: Int,
-        sort: String?,
     ): Result<PartySearchResult> = executeWithUiMock(
         mock = {
             val matchedItems = UiMockData.productCategory.groupItems
@@ -47,7 +46,7 @@ class SearchRepositoryImpl @Inject constructor(
         },
         real = {
             httpResponseHandler.safeApiCall {
-                searchRemoteDataSource.searchParties(keyword, page, size, sort)
+                searchRemoteDataSource.searchParties(keyword, page, size)
                     .handleApiResponse()
                     .getOrThrow()
                     .toDomain()

--- a/app/src/main/java/com/poti/android/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/SearchRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.poti.android.data.repository
+
+import com.poti.android.core.network.model.handleApiResponse
+import com.poti.android.core.network.util.HttpResponseHandler
+import com.poti.android.data.mapper.search.toDomain
+import com.poti.android.data.mock.UiMockData
+import com.poti.android.data.mock.executeWithUiMock
+import com.poti.android.data.remote.datasource.SearchRemoteDataSource
+import com.poti.android.domain.model.search.PartySearchItem
+import com.poti.android.domain.model.search.PartySearchResult
+import com.poti.android.domain.repository.SearchRepository
+import javax.inject.Inject
+
+class SearchRepositoryImpl @Inject constructor(
+    private val httpResponseHandler: HttpResponseHandler,
+    private val searchRemoteDataSource: SearchRemoteDataSource,
+) : SearchRepository {
+    override suspend fun searchParties(
+        keyword: String,
+        page: Int,
+        size: Int,
+        sort: String?,
+    ): Result<PartySearchResult> = executeWithUiMock(
+        mock = {
+            val matchedItems = UiMockData.productCategory.groupItems
+                .filter { item ->
+                    item.artist.contains(keyword, ignoreCase = true) ||
+                        item.postTitle.contains(keyword, ignoreCase = true)
+                }
+            val pageItems = matchedItems
+                .drop(page * size)
+                .take(size)
+
+            PartySearchResult(
+                items = pageItems.map { item ->
+                    PartySearchItem(
+                        artist = item.artist,
+                        artistId = item.artistId,
+                        postImage = item.postImage,
+                        postTitle = item.postTitle,
+                        postCount = item.postCount,
+                        tag = item.tag,
+                    )
+                },
+                hasNext = (page + 1) * size < matchedItems.size,
+            )
+        },
+        real = {
+            httpResponseHandler.safeApiCall {
+                searchRemoteDataSource.searchParties(keyword, page, size, sort)
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/poti/android/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/SearchRepositoryImpl.kt
@@ -37,7 +37,7 @@ class SearchRepositoryImpl @Inject constructor(
                         artistId = item.artistId,
                         postImage = item.postImage,
                         postTitle = item.postTitle,
-                        postCount = item.postCount,
+                        postCount = item.postCount.toLong(),
                         tag = item.tag,
                     )
                 },

--- a/app/src/main/java/com/poti/android/domain/model/party/ProductCategory.kt
+++ b/app/src/main/java/com/poti/android/domain/model/party/ProductCategory.kt
@@ -5,7 +5,6 @@ data class ProductCategory(
     val mainArtist: String?,
     val mainArtistId: Long?,
     val groupItems: List<GroupItem>,
-    val myGroupItems: List<GroupItem>,
 )
 
 data class GroupItem(

--- a/app/src/main/java/com/poti/android/domain/model/search/PartySearchResult.kt
+++ b/app/src/main/java/com/poti/android/domain/model/search/PartySearchResult.kt
@@ -1,0 +1,15 @@
+package com.poti.android.domain.model.search
+
+data class PartySearchResult(
+    val items: List<PartySearchItem>,
+    val hasNext: Boolean,
+)
+
+data class PartySearchItem(
+    val artist: String,
+    val artistId: Long,
+    val postImage: String,
+    val postTitle: String,
+    val postCount: Int,
+    val tag: String?,
+)

--- a/app/src/main/java/com/poti/android/domain/model/search/PartySearchResult.kt
+++ b/app/src/main/java/com/poti/android/domain/model/search/PartySearchResult.kt
@@ -10,6 +10,6 @@ data class PartySearchItem(
     val artistId: Long,
     val postImage: String,
     val postTitle: String,
-    val postCount: Int,
+    val postCount: Long,
     val tag: String?,
 )

--- a/app/src/main/java/com/poti/android/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/SearchRepository.kt
@@ -1,0 +1,12 @@
+package com.poti.android.domain.repository
+
+import com.poti.android.domain.model.search.PartySearchResult
+
+interface SearchRepository {
+    suspend fun searchParties(
+        keyword: String,
+        page: Int,
+        size: Int,
+        sort: String?,
+    ): Result<PartySearchResult>
+}

--- a/app/src/main/java/com/poti/android/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/SearchRepository.kt
@@ -7,6 +7,5 @@ interface SearchRepository {
         keyword: String,
         page: Int,
         size: Int,
-        sort: String?,
     ): Result<PartySearchResult>
 }

--- a/app/src/main/java/com/poti/android/domain/usecase/search/SearchPartyUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/search/SearchPartyUseCase.kt
@@ -1,0 +1,16 @@
+package com.poti.android.domain.usecase.search
+
+import com.poti.android.domain.model.search.PartySearchResult
+import com.poti.android.domain.repository.SearchRepository
+import javax.inject.Inject
+
+class SearchPartyUseCase @Inject constructor(
+    private val searchRepository: SearchRepository,
+) {
+    suspend operator fun invoke(
+        keyword: String,
+        page: Int,
+        size: Int,
+        sort: String? = null,
+    ): Result<PartySearchResult> = searchRepository.searchParties(keyword, page, size, sort)
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/search/SearchPartyUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/search/SearchPartyUseCase.kt
@@ -11,6 +11,5 @@ class SearchPartyUseCase @Inject constructor(
         keyword: String,
         page: Int,
         size: Int,
-        sort: String? = null,
-    ): Result<PartySearchResult> = searchRepository.searchParties(keyword, page, size, sort)
+    ): Result<PartySearchResult> = searchRepository.searchParties(keyword, page, size)
 }

--- a/app/src/main/java/com/poti/android/presentation/party/PartyNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/PartyNavigation.kt
@@ -10,6 +10,7 @@ import com.poti.android.presentation.party.detail.navigation.partyDetailNavGraph
 import com.poti.android.presentation.party.home.navigation.HomeRoute
 import com.poti.android.presentation.party.home.navigation.homeNavGraph
 import com.poti.android.presentation.party.product.navigation.productNavGraph
+import com.poti.android.presentation.party.search.navigation.searchNavGraph
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -38,6 +39,10 @@ fun NavGraphBuilder.partyNavGraph(
         partyCreateNavGraph(
             paddingValues = paddingValues,
             navController = navController,
+        )
+        searchNavGraph(
+            navController = navController,
+            paddingValues = paddingValues,
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/PartyNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/PartyNavigation.kt
@@ -42,7 +42,6 @@ fun NavGraphBuilder.partyNavGraph(
         )
         searchNavGraph(
             navController = navController,
-            paddingValues = paddingValues,
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
@@ -32,6 +32,7 @@ import com.poti.android.presentation.party.home.model.HomeUiIntent
 
 @Composable
 fun HomeRoute(
+    onNavigateToPartySearch: () -> Unit,
     onNavigateToPartyCreate: () -> Unit,
     onNavigateToGoodsPartyList: (Long, String) -> Unit,
     onNavigateToProductCategory: (Long?, Boolean) -> Unit,
@@ -52,6 +53,7 @@ fun HomeRoute(
     uiState.homeContentLoadState.onSuccess { homeContent ->
         HomeScreen(
             homeContent = homeContent,
+            onSearchClick = onNavigateToPartySearch,
             onFloatingClick = { viewModel.processIntent(HomeUiIntent.OnFloatingClick) },
             onMyArtistCategoryClick = { artistId -> viewModel.processIntent(HomeUiIntent.OnMyArtistCategoryClick(artistId)) },
             onOtherProductCategoryClick = { viewModel.processIntent(HomeUiIntent.OnOtherProductCategoryClick) },
@@ -64,6 +66,7 @@ fun HomeRoute(
 @Composable
 private fun HomeScreen(
     homeContent: HomeContent,
+    onSearchClick: () -> Unit,
     onFloatingClick: () -> Unit,
     onMyArtistCategoryClick: (Long?) -> Unit,
     onOtherProductCategoryClick: (Long?) -> Unit,
@@ -78,7 +81,7 @@ private fun HomeScreen(
         Column {
             PotiHeaderPrimary(
                 firstIconRes = R.drawable.ic_search,
-                onFirstIconClick = {},
+                onFirstIconClick = onSearchClick,
                 secondIconRes = R.drawable.ic_alarm,
                 onSecondIconClick = {},
             )
@@ -138,6 +141,7 @@ private fun HomeScreen(
 private fun HomeScreenPreview() {
     PotiTheme {
         HomeScreen(
+            onSearchClick = {},
             homeContent = UiMockData.homeContent,
             onFloatingClick = { },
             onMyArtistCategoryClick = { },

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
@@ -43,6 +43,7 @@ fun HomeRoute(
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
+            HomeUiEffect.NavigateToPartySearch -> onNavigateToPartySearch()
             HomeUiEffect.NavigateToPartyCreate -> onNavigateToPartyCreate()
             is HomeUiEffect.NavigateToGoodsPartyList -> onNavigateToGoodsPartyList(effect.artistId, effect.title)
             is HomeUiEffect.NavigateToMyArtistCategory -> onNavigateToProductCategory(effect.artistId, true)
@@ -53,7 +54,7 @@ fun HomeRoute(
     uiState.homeContentLoadState.onSuccess { homeContent ->
         HomeScreen(
             homeContent = homeContent,
-            onSearchClick = onNavigateToPartySearch,
+            onSearchClick = { viewModel.processIntent(HomeUiIntent.OnSearchClick) },
             onFloatingClick = { viewModel.processIntent(HomeUiIntent.OnFloatingClick) },
             onMyArtistCategoryClick = { artistId -> viewModel.processIntent(HomeUiIntent.OnMyArtistCategoryClick(artistId)) },
             onOtherProductCategoryClick = { viewModel.processIntent(HomeUiIntent.OnOtherProductCategoryClick) },

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
@@ -19,6 +19,7 @@ class HomeViewModel @Inject constructor(
     ) {
     override fun processIntent(intent: HomeUiIntent) {
         when (intent) {
+            HomeUiIntent.OnSearchClick -> sendEffect(NavigateToPartySearch)
             HomeUiIntent.OnFloatingClick -> sendEffect(NavigateToPartyCreate)
             is HomeUiIntent.OnMyArtistCategoryClick -> sendEffect(NavigateToMyArtistCategory(if (uiState.value.artistIdToNull) null else intent.artistId))
             is HomeUiIntent.OnProductCardClick -> sendEffect(NavigateToGoodsPartyList(intent.artistId, intent.title))

--- a/app/src/main/java/com/poti/android/presentation/party/home/component/GoodsLargeCard.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/component/GoodsLargeCard.kt
@@ -39,7 +39,7 @@ fun GoodsLargeCard(
     artist: String,
     artistId: Long,
     title: String,
-    partyCount: Int,
+    partyCount: Long,
     tag: String?,
     onClick: (Long, String) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/poti/android/presentation/party/home/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/model/Contracts.kt
@@ -12,6 +12,8 @@ data class HomeUiState(
 ) : UiState
 
 sealed interface HomeUiIntent : UiIntent {
+    data object OnSearchClick : HomeUiIntent
+
     data class OnMyArtistCategoryClick(val artistId: Long?) : HomeUiIntent
 
     data class OnProductCardClick(val artistId: Long, val title: String) : HomeUiIntent
@@ -24,6 +26,8 @@ sealed interface HomeUiIntent : UiIntent {
 }
 
 sealed interface HomeUiEffect : UiEffect {
+    data object NavigateToPartySearch : HomeUiEffect
+
     data object NavigateToPartyCreate : HomeUiEffect
 
     data class NavigateToMyArtistCategory(val artistId: Long?) : HomeUiEffect

--- a/app/src/main/java/com/poti/android/presentation/party/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/navigation/HomeNavigation.kt
@@ -11,6 +11,7 @@ import com.poti.android.presentation.party.create.navigation.navigateToPartyCrea
 import com.poti.android.presentation.party.home.HomeRoute
 import com.poti.android.presentation.party.product.navigation.navigateToProductCategory
 import com.poti.android.presentation.party.product.navigation.navigateToProductPartyList
+import com.poti.android.presentation.party.search.navigation.navigateToPartySearch
 import kotlinx.serialization.Serializable
 
 sealed interface HomeRoute : Route {
@@ -24,6 +25,7 @@ fun NavGraphBuilder.homeNavGraph(
 ) {
     composable<HomeRoute.Home> {
         HomeRoute(
+            onNavigateToPartySearch = navController::navigateToPartySearch,
             onNavigateToPartyCreate = navController::navigateToPartyCreate,
             onNavigateToGoodsPartyList = navController::navigateToProductPartyList,
             onNavigateToProductCategory = navController::navigateToProductCategory,

--- a/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListScreen.kt
@@ -1,10 +1,12 @@
 package com.poti.android.presentation.party.product.partylist
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -28,6 +30,7 @@ import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiFloatingButton
 import com.poti.android.core.designsystem.component.button.PotiSmallButton
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.party.PartySummary
 import com.poti.android.domain.model.party.ProductPartyList
 import com.poti.android.presentation.party.component.MemberSelectBottomSheet
@@ -141,7 +144,9 @@ private fun ProductPartyListScreen(
     }
 
     Box(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.white),
     ) {
         Column {
             PotiHeaderPage(

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
@@ -160,7 +160,7 @@ private fun ProductCategoryScreen(
                         imageUrl = groupItem.postImage,
                         artist = groupItem.artist,
                         title = groupItem.postTitle,
-                        partyCount = groupItem.postCount,
+                        partyCount = groupItem.postCount.toLong(),
                         tag = groupItem.tag,
                         onClick = { id, title -> onCardClick(groupItem.artistId, groupItem.postTitle) },
                         modifier = Modifier

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -18,7 +18,18 @@ import com.poti.android.presentation.party.home.component.GoodsLargeCard
 import com.poti.android.presentation.party.search.model.PartySearchUiState
 
 @Composable
-fun PartySearchRoute(modifier: Modifier = Modifier) {
+fun PartySearchRoute(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PartySearchScreen(
+        uiState = PartySearchUiState(),
+        onBackClick = onBackClick,
+        onCardClick = { _, _ -> },
+        onSearchKeywordChange = {},
+        onSearch = {},
+        modifier = modifier,
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -25,7 +25,6 @@ import com.poti.android.core.common.state.ApiState
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.display.PotiEmptyStateInline
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPageSearch
-import com.poti.android.data.mock.UiMockData
 import com.poti.android.domain.model.search.PartySearchItem
 import com.poti.android.domain.model.search.PartySearchResult
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
@@ -171,16 +170,24 @@ private fun PartySearchScreenPreview() {
     val uiState = PartySearchUiState(
         searchResultLoadState = ApiState.Success(
             PartySearchResult(
-                items = UiMockData.productCategory.groupItems.map { item ->
+                items = listOf(
                     PartySearchItem(
-                        artist = item.artist,
-                        artistId = item.artistId,
-                        postImage = item.postImage,
-                        postTitle = item.postTitle,
-                        postCount = item.postCount.toLong(),
-                        tag = item.tag,
-                    )
-                },
+                        artist = "아이브",
+                        artistId = 1L,
+                        postImage = "",
+                        postTitle = "IVE SWITCH",
+                        postCount = 12L,
+                        tag = "미공포",
+                    ),
+                    PartySearchItem(
+                        artist = "아이브",
+                        artistId = 1L,
+                        postImage = "",
+                        postTitle = "I'VE MINE",
+                        postCount = 8L,
+                        tag = null,
+                    ),
+                ),
                 hasNext = false,
             ),
         ),

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -7,26 +7,33 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPageSearch
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
+import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import com.poti.android.presentation.party.search.model.PartySearchUiState
 
 @Composable
 fun PartySearchRoute(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: PartySearchViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
     PartySearchScreen(
-        uiState = PartySearchUiState(),
+        uiState = uiState,
         onBackClick = onBackClick,
         onCardClick = { _, _ -> },
-        onSearchKeywordChange = {},
+        onSearchKeywordChange = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange(keyword)) },
         onSearch = {},
         modifier = modifier,
     )

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -1,0 +1,28 @@
+package com.poti.android.presentation.party.search
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun PartySearchRoute(modifier: Modifier = Modifier) {
+}
+
+@Composable
+fun PartySearchScreen(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        // TODO: 검색 컴포넌트 추가
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PartySearchScreenPreview() {
+    PartySearchScreen()
+}

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.state.ApiState
-import com.poti.android.domain.model.party.GroupItem
-import com.poti.android.domain.model.party.ProductCategory
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPageSearch
+import com.poti.android.data.mock.UiMockData
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
 import com.poti.android.presentation.party.search.model.PartySearchUiState
 
@@ -24,13 +24,21 @@ fun PartySearchRoute(modifier: Modifier = Modifier) {
 @Composable
 fun PartySearchScreen(
     uiState: PartySearchUiState,
-    modifier: Modifier = Modifier,
+    onBackClick: () -> Unit,
     onCardClick: (Long, String) -> Unit,
+    onSearchKeywordChange: (String) -> Unit,
+    onSearch: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier.fillMaxSize(),
     ) {
-        // TODO: 검색 컴포넌트 추가
+        PotiHeaderPageSearch(
+            onNavigationClick = onBackClick,
+            value = uiState.searchKeyword,
+            onValueChange = onSearchKeywordChange,
+            onSearch = onSearch,
+        )
 
         LazyColumn(
             modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
@@ -60,26 +68,14 @@ fun PartySearchScreen(
 private fun PartySearchScreenPreview() {
     val uiState = PartySearchUiState(
         productCategoryLoadState = ApiState.Success(
-            ProductCategory(
-                nickname = "",
-                mainArtist = "",
-                mainArtistId = 1,
-                groupItems = listOf(
-                    GroupItem(
-                        artist = "아티스트명",
-                        artistId = 1,
-                        postImage = "",
-                        postTitle = "상품 종류명",
-                        postCount = 2,
-                        tag = "인기",
-                    ),
-                ),
-                myGroupItems = listOf(),
-            ),
+            UiMockData.productCategory,
         ),
     )
     PartySearchScreen(
         uiState = uiState,
+        onBackClick = {},
+        onSearchKeywordChange = {},
+        onSearch = {},
         onCardClick = { _, _ -> },
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -13,12 +13,15 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.poti.android.R
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.core.designsystem.component.display.PotiEmptyStateInline
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPageSearch
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.domain.model.search.PartySearchItem
@@ -92,19 +95,27 @@ fun PartySearchScreen(
             modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
         ) {
             uiState.searchResultLoadState.onSuccess { searchResult ->
-                items(searchResult.items) { groupItem ->
-                    GoodsLargeCard(
-                        imageUrl = groupItem.postImage,
-                        artist = groupItem.artist,
-                        title = groupItem.postTitle,
-                        partyCount = groupItem.postCount,
-                        tag = groupItem.tag,
-                        onClick = onCardClick,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 16.dp),
-                        artistId = groupItem.artistId,
-                    )
+                if (searchResult.items.isEmpty()) {
+                    item {
+                        PotiEmptyStateInline(
+                            text = stringResource(R.string.search_message_empty_result),
+                        )
+                    }
+                } else {
+                    items(searchResult.items) { groupItem ->
+                        GoodsLargeCard(
+                            imageUrl = groupItem.postImage,
+                            artist = groupItem.artist,
+                            title = groupItem.postTitle,
+                            partyCount = groupItem.postCount,
+                            tag = groupItem.tag,
+                            onClick = onCardClick,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 16.dp),
+                            artistId = groupItem.artistId,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -30,6 +30,7 @@ import com.poti.android.presentation.party.search.model.PartySearchUiState
 @Composable
 fun PartySearchRoute(
     onBackClick: () -> Unit,
+    onNavigateToProductPartyList: (Long, String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PartySearchViewModel = hiltViewModel(),
 ) {
@@ -38,7 +39,7 @@ fun PartySearchRoute(
     PartySearchScreen(
         uiState = uiState,
         onBackClick = onBackClick,
-        onCardClick = { _, _ -> },
+        onCardClick = onNavigateToProductPartyList,
         onSearchKeywordChange = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange(keyword)) },
         onSearch = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearch(keyword)) },
         onLoadNextPage = { viewModel.processIntent(PartySearchUiIntent.OnLoadNextPage) },
@@ -98,7 +99,7 @@ fun PartySearchScreen(
                         title = groupItem.postTitle,
                         partyCount = groupItem.postCount,
                         tag = groupItem.tag,
-                        onClick = { id, title -> onCardClick(groupItem.artistId, groupItem.postTitle) },
+                        onClick = onCardClick,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(bottom = 16.dp),

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -164,7 +164,7 @@ private fun PartySearchScreenPreview() {
                         artistId = item.artistId,
                         postImage = item.postImage,
                         postTitle = item.postTitle,
-                        postCount = item.postCount,
+                        postCount = item.postCount.toLong(),
                         tag = item.tag,
                     )
                 },

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.display.PotiEmptyStateInline
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPageSearch
 import com.poti.android.data.mock.UiMockData
@@ -29,6 +30,7 @@ import com.poti.android.domain.model.search.PartySearchItem
 import com.poti.android.domain.model.search.PartySearchResult
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
 import com.poti.android.presentation.party.search.model.NextPageLoadState
+import com.poti.android.presentation.party.search.model.PartySearchUiEffect
 import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import com.poti.android.presentation.party.search.model.PartySearchUiState
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -44,10 +46,21 @@ fun PartySearchRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    HandleSideEffects(viewModel.sideEffect) { effect ->
+        when (effect) {
+            PartySearchUiEffect.NavigateBack -> onBackClick()
+            is PartySearchUiEffect.NavigateToProductPartyList -> {
+                onNavigateToProductPartyList(effect.artistId, effect.title)
+            }
+        }
+    }
+
     PartySearchScreen(
         uiState = uiState,
-        onBackClick = onBackClick,
-        onCardClick = onNavigateToProductPartyList,
+        onBackClick = { viewModel.processIntent(PartySearchUiIntent.OnBackClick) },
+        onCardClick = { artistId, title ->
+            viewModel.processIntent(PartySearchUiIntent.OnCardClick(artistId, title))
+        },
         onSearchKeywordChange = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange(keyword)) },
         onSearch = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearch(keyword)) },
         onLoadNextPage = { viewModel.processIntent(PartySearchUiIntent.OnLoadNextPage) },

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -1,9 +1,17 @@
 package com.poti.android.presentation.party.search
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -80,6 +88,9 @@ fun PartySearchScreen(
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
+    val navigationBarBottomPadding = WindowInsets.navigationBars
+        .asPaddingValues()
+        .calculateBottomPadding()
     val shouldLoadNextPage by remember(
         listState,
         uiState.hasNextPage,
@@ -123,7 +134,9 @@ fun PartySearchScreen(
     }
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.statusBars.only(WindowInsetsSides.Top)),
     ) {
         PotiHeaderPageSearch(
             onNavigationClick = onBackClick,
@@ -134,7 +147,15 @@ fun PartySearchScreen(
 
         LazyColumn(
             state = listState,
-            modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
+            contentPadding = PaddingValues(
+                top = 12.dp,
+                bottom = 12.dp + navigationBarBottomPadding,
+                start = 16.dp,
+                end = 16.dp,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
         ) {
             uiState.searchResultLoadState.onSuccess { searchResult ->
                 if (searchResult.items.isEmpty()) {

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,6 +30,9 @@ import com.poti.android.domain.model.search.PartySearchResult
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
 import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import com.poti.android.presentation.party.search.model.PartySearchUiState
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 
 @Composable
 fun PartySearchRoute(
@@ -46,6 +50,7 @@ fun PartySearchRoute(
         onSearchKeywordChange = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange(keyword)) },
         onSearch = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearch(keyword)) },
         onLoadNextPage = { viewModel.processIntent(PartySearchUiIntent.OnLoadNextPage) },
+        onRetryNextPage = { viewModel.processIntent(PartySearchUiIntent.OnRetryNextPage) },
         modifier = modifier,
     )
 }
@@ -58,10 +63,16 @@ fun PartySearchScreen(
     onSearchKeywordChange: (String) -> Unit,
     onSearch: (String) -> Unit,
     onLoadNextPage: () -> Unit,
+    onRetryNextPage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
-    val shouldLoadNextPage by remember(listState, uiState.hasNextPage, uiState.isPageLoading) {
+    val shouldLoadNextPage by remember(
+        listState,
+        uiState.hasNextPage,
+        uiState.isPageLoading,
+        uiState.isNextPageLoadFailed,
+    ) {
         derivedStateOf {
             val lastVisibleItemIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
                 ?: return@derivedStateOf false
@@ -69,6 +80,7 @@ fun PartySearchScreen(
 
             uiState.hasNextPage &&
                 !uiState.isPageLoading &&
+                !uiState.isNextPageLoadFailed &&
                 totalItemsCount > 0 &&
                 lastVisibleItemIndex >= totalItemsCount - 3
         }
@@ -78,6 +90,25 @@ fun PartySearchScreen(
         if (shouldLoadNextPage) {
             onLoadNextPage()
         }
+    }
+
+    LaunchedEffect(listState, uiState.isNextPageLoadFailed) {
+        if (!uiState.isNextPageLoadFailed) return@LaunchedEffect
+
+        snapshotFlow { listState.isScrollInProgress }
+            .distinctUntilChanged()
+            .drop(1)
+            .filter { isScrolling -> isScrolling }
+            .collect {
+                val lastVisibleItemIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+                    ?: return@collect
+                val totalItemsCount = listState.layoutInfo.totalItemsCount
+                val isNearEnd = totalItemsCount > 0 && lastVisibleItemIndex >= totalItemsCount - 3
+
+                if (isNearEnd) {
+                    onRetryNextPage()
+                }
+            }
     }
 
     Column(
@@ -148,6 +179,7 @@ private fun PartySearchScreenPreview() {
         onSearchKeywordChange = {},
         onSearch = {},
         onLoadNextPage = {},
+        onRetryNextPage = {},
         onCardClick = { _, _ -> },
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -6,8 +6,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -17,6 +21,8 @@ import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPageSearch
 import com.poti.android.data.mock.UiMockData
+import com.poti.android.domain.model.search.PartySearchItem
+import com.poti.android.domain.model.search.PartySearchResult
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
 import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import com.poti.android.presentation.party.search.model.PartySearchUiState
@@ -34,7 +40,8 @@ fun PartySearchRoute(
         onBackClick = onBackClick,
         onCardClick = { _, _ -> },
         onSearchKeywordChange = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange(keyword)) },
-        onSearch = {},
+        onSearch = { keyword -> viewModel.processIntent(PartySearchUiIntent.OnSearch(keyword)) },
+        onLoadNextPage = { viewModel.processIntent(PartySearchUiIntent.OnLoadNextPage) },
         modifier = modifier,
     )
 }
@@ -46,8 +53,29 @@ fun PartySearchScreen(
     onCardClick: (Long, String) -> Unit,
     onSearchKeywordChange: (String) -> Unit,
     onSearch: (String) -> Unit,
+    onLoadNextPage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val listState = rememberLazyListState()
+    val shouldLoadNextPage by remember(listState, uiState.hasNextPage, uiState.isPageLoading) {
+        derivedStateOf {
+            val lastVisibleItemIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+                ?: return@derivedStateOf false
+            val totalItemsCount = listState.layoutInfo.totalItemsCount
+
+            uiState.hasNextPage &&
+                !uiState.isPageLoading &&
+                totalItemsCount > 0 &&
+                lastVisibleItemIndex >= totalItemsCount - 3
+        }
+    }
+
+    LaunchedEffect(shouldLoadNextPage) {
+        if (shouldLoadNextPage) {
+            onLoadNextPage()
+        }
+    }
+
     Column(
         modifier = modifier.fillMaxSize(),
     ) {
@@ -59,10 +87,11 @@ fun PartySearchScreen(
         )
 
         LazyColumn(
+            state = listState,
             modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
         ) {
-            uiState.productCategoryLoadState.onSuccess { goodsCategory ->
-                items(goodsCategory.groupItems) { groupItem ->
+            uiState.searchResultLoadState.onSuccess { searchResult ->
+                items(searchResult.items) { groupItem ->
                     GoodsLargeCard(
                         imageUrl = groupItem.postImage,
                         artist = groupItem.artist,
@@ -85,8 +114,20 @@ fun PartySearchScreen(
 @Composable
 private fun PartySearchScreenPreview() {
     val uiState = PartySearchUiState(
-        productCategoryLoadState = ApiState.Success(
-            UiMockData.productCategory,
+        searchResultLoadState = ApiState.Success(
+            PartySearchResult(
+                items = UiMockData.productCategory.groupItems.map { item ->
+                    PartySearchItem(
+                        artist = item.artist,
+                        artistId = item.artistId,
+                        postImage = item.postImage,
+                        postTitle = item.postTitle,
+                        postCount = item.postCount,
+                        tag = item.tag,
+                    )
+                },
+                hasNext = false,
+            ),
         ),
     )
     PartySearchScreen(
@@ -94,6 +135,7 @@ private fun PartySearchScreenPreview() {
         onBackClick = {},
         onSearchKeywordChange = {},
         onSearch = {},
+        onLoadNextPage = {},
         onCardClick = { _, _ -> },
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -2,9 +2,20 @@ package com.poti.android.presentation.party.search
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.core.common.extension.onSuccess
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.model.party.GroupItem
+import com.poti.android.domain.model.party.ProductCategory
+import com.poti.android.presentation.party.home.component.GoodsLargeCard
+import com.poti.android.presentation.party.search.model.PartySearchUiState
 
 @Composable
 fun PartySearchRoute(modifier: Modifier = Modifier) {
@@ -12,17 +23,63 @@ fun PartySearchRoute(modifier: Modifier = Modifier) {
 
 @Composable
 fun PartySearchScreen(
+    uiState: PartySearchUiState,
     modifier: Modifier = Modifier,
+    onCardClick: (Long, String) -> Unit,
 ) {
     Column(
         modifier = modifier.fillMaxSize(),
     ) {
         // TODO: 검색 컴포넌트 추가
+
+        LazyColumn(
+            modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
+        ) {
+            uiState.productCategoryLoadState.onSuccess { goodsCategory ->
+                items(goodsCategory.groupItems) { groupItem ->
+                    GoodsLargeCard(
+                        imageUrl = groupItem.postImage,
+                        artist = groupItem.artist,
+                        title = groupItem.postTitle,
+                        partyCount = groupItem.postCount,
+                        tag = groupItem.tag,
+                        onClick = { id, title -> onCardClick(groupItem.artistId, groupItem.postTitle) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 16.dp),
+                        artistId = groupItem.artistId,
+                    )
+                }
+            }
+        }
     }
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun PartySearchScreenPreview() {
-    PartySearchScreen()
+    val uiState = PartySearchUiState(
+        productCategoryLoadState = ApiState.Success(
+            ProductCategory(
+                nickname = "",
+                mainArtist = "",
+                mainArtistId = 1,
+                groupItems = listOf(
+                    GroupItem(
+                        artist = "아티스트명",
+                        artistId = 1,
+                        postImage = "",
+                        postTitle = "상품 종류명",
+                        postCount = 2,
+                        tag = "인기",
+                    ),
+                ),
+                myGroupItems = listOf(),
+            ),
+        ),
+    )
+    PartySearchScreen(
+        uiState = uiState,
+        onCardClick = { _, _ -> },
+    )
 }

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchScreen.kt
@@ -28,6 +28,7 @@ import com.poti.android.data.mock.UiMockData
 import com.poti.android.domain.model.search.PartySearchItem
 import com.poti.android.domain.model.search.PartySearchResult
 import com.poti.android.presentation.party.home.component.GoodsLargeCard
+import com.poti.android.presentation.party.search.model.NextPageLoadState
 import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import com.poti.android.presentation.party.search.model.PartySearchUiState
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -70,8 +71,7 @@ fun PartySearchScreen(
     val shouldLoadNextPage by remember(
         listState,
         uiState.hasNextPage,
-        uiState.isPageLoading,
-        uiState.isNextPageLoadFailed,
+        uiState.nextPageLoadState,
     ) {
         derivedStateOf {
             val lastVisibleItemIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
@@ -79,8 +79,7 @@ fun PartySearchScreen(
             val totalItemsCount = listState.layoutInfo.totalItemsCount
 
             uiState.hasNextPage &&
-                !uiState.isPageLoading &&
-                !uiState.isNextPageLoadFailed &&
+                uiState.nextPageLoadState == NextPageLoadState.Idle &&
                 totalItemsCount > 0 &&
                 lastVisibleItemIndex >= totalItemsCount - 3
         }
@@ -92,8 +91,8 @@ fun PartySearchScreen(
         }
     }
 
-    LaunchedEffect(listState, uiState.isNextPageLoadFailed) {
-        if (!uiState.isNextPageLoadFailed) return@LaunchedEffect
+    LaunchedEffect(listState, uiState.nextPageLoadState) {
+        if (uiState.nextPageLoadState != NextPageLoadState.Failure) return@LaunchedEffect
 
         snapshotFlow { listState.isScrollInProgress }
             .distinctUntilChanged()

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
@@ -1,21 +1,143 @@
 package com.poti.android.presentation.party.search
 
+import androidx.lifecycle.viewModelScope
 import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.search.SearchPartyUseCase
 import com.poti.android.presentation.party.search.model.PartySearchUiEffect
 import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import com.poti.android.presentation.party.search.model.PartySearchUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val PARTY_SEARCH_PAGE_SIZE = 20
+private const val PARTY_SEARCH_DEBOUNCE_MILLIS = 400L
+
 @HiltViewModel
-class PartySearchViewModel @Inject constructor() : BaseViewModel<PartySearchUiState, PartySearchUiIntent, PartySearchUiEffect>(
-    initialState = PartySearchUiState(),
-) {
-    override fun processIntent(intent: PartySearchUiIntent) {
-        when (intent) {
-            is PartySearchUiIntent.OnSearchKeywordChange -> updateState {
-                copy(searchKeyword = intent.keyword)
+class PartySearchViewModel @Inject constructor(
+    private val searchPartyUseCase: SearchPartyUseCase,
+) :
+    BaseViewModel<PartySearchUiState, PartySearchUiIntent, PartySearchUiEffect>(
+            initialState = PartySearchUiState(),
+        ) {
+        private var searchJob: Job? = null
+
+        override fun processIntent(intent: PartySearchUiIntent) {
+            when (intent) {
+                is PartySearchUiIntent.OnSearchKeywordChange -> scheduleSearch(intent.keyword)
+                is PartySearchUiIntent.OnSearch -> scheduleSearch(intent.keyword, debounceMillis = 0L)
+                PartySearchUiIntent.OnLoadNextPage -> loadNextPage()
             }
         }
+
+        private fun scheduleSearch(
+            keyword: String,
+            debounceMillis: Long = PARTY_SEARCH_DEBOUNCE_MILLIS,
+        ) {
+            searchJob?.cancel()
+
+            val trimmedKeyword = keyword.trim()
+            if (trimmedKeyword.isEmpty()) {
+                resetSearch(keyword)
+                return
+            }
+
+            updateState {
+                copy(
+                    searchKeyword = keyword,
+                    searchResultLoadState = ApiState.Loading,
+                    isPageLoading = false,
+                    hasNextPage = false,
+                    nextPage = 0,
+                )
+            }
+
+            searchJob = viewModelScope.launch {
+                delay(debounceMillis)
+                requestSearch(
+                    keyword = trimmedKeyword,
+                    page = 0,
+                    reset = true,
+                )
+            }
+        }
+
+        private fun loadNextPage() {
+            val state = uiState.value
+            if (state.isPageLoading || !state.hasNextPage) return
+
+            val trimmedKeyword = state.searchKeyword.trim()
+            if (trimmedKeyword.isEmpty()) return
+
+            searchJob = viewModelScope.launch {
+                requestSearch(
+                    keyword = trimmedKeyword,
+                    page = state.nextPage,
+                    reset = false,
+                )
+            }
+        }
+
+        private fun resetSearch(keyword: String) {
+            updateState {
+                copy(
+                    searchKeyword = keyword,
+                    searchResultLoadState = ApiState.Init,
+                    isPageLoading = false,
+                    hasNextPage = false,
+                    nextPage = 0,
+                )
+            }
+        }
+
+        private suspend fun requestSearch(
+            keyword: String,
+            page: Int,
+            reset: Boolean,
+        ) {
+            updateState { copy(isPageLoading = true) }
+
+            searchPartyUseCase(
+                keyword = keyword,
+                page = page,
+                size = PARTY_SEARCH_PAGE_SIZE,
+            )
+                .onSuccess { result ->
+                    val currentItems = (uiState.value.searchResultLoadState as? ApiState.Success)
+                        ?.data
+                        ?.items
+                        .orEmpty()
+                    val updatedItems = if (reset) result.items else currentItems + result.items
+
+                    updateState {
+                        copy(
+                            searchResultLoadState = ApiState.Success(
+                                result.copy(
+                                    items = updatedItems.distinctBy { item ->
+                                        item.artistId to item.postTitle
+                                    },
+                                ),
+                            ),
+                            isPageLoading = false,
+                            hasNextPage = result.hasNext,
+                            nextPage = page + 1,
+                        )
+                    }
+                }
+                .onFailure { throwable ->
+                    updateState {
+                        copy(
+                            searchResultLoadState = if (reset) {
+                                ApiState.Failure(throwable.message ?: "Failed to search parties")
+                            } else {
+                                searchResultLoadState
+                            },
+                            isPageLoading = false,
+                        )
+                    }
+                }
+        }
     }
-}

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.usecase.search.SearchPartyUseCase
+import com.poti.android.presentation.party.search.model.NextPageLoadState
 import com.poti.android.presentation.party.search.model.PartySearchUiEffect
 import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import com.poti.android.presentation.party.search.model.PartySearchUiState
@@ -50,10 +51,9 @@ class PartySearchViewModel @Inject constructor(
                 copy(
                     searchKeyword = keyword,
                     searchResultLoadState = ApiState.Loading,
-                    isPageLoading = false,
+                    nextPageLoadState = NextPageLoadState.Idle,
                     hasNextPage = false,
                     nextPage = 0,
-                    isNextPageLoadFailed = false,
                 )
             }
 
@@ -69,7 +69,7 @@ class PartySearchViewModel @Inject constructor(
 
         private fun loadNextPage() {
             val state = uiState.value
-            if (state.isPageLoading || !state.hasNextPage || state.isNextPageLoadFailed) return
+            if (state.nextPageLoadState != NextPageLoadState.Idle || !state.hasNextPage) return
 
             val trimmedKeyword = state.searchKeyword.trim()
             if (trimmedKeyword.isEmpty()) return
@@ -84,9 +84,9 @@ class PartySearchViewModel @Inject constructor(
         }
 
         private fun retryNextPage() {
-            if (!uiState.value.isNextPageLoadFailed) return
+            if (uiState.value.nextPageLoadState != NextPageLoadState.Failure) return
 
-            updateState { copy(isNextPageLoadFailed = false) }
+            updateState { copy(nextPageLoadState = NextPageLoadState.Idle) }
             loadNextPage()
         }
 
@@ -95,10 +95,9 @@ class PartySearchViewModel @Inject constructor(
                 copy(
                     searchKeyword = keyword,
                     searchResultLoadState = ApiState.Init,
-                    isPageLoading = false,
+                    nextPageLoadState = NextPageLoadState.Idle,
                     hasNextPage = false,
                     nextPage = 0,
-                    isNextPageLoadFailed = false,
                 )
             }
         }
@@ -108,7 +107,9 @@ class PartySearchViewModel @Inject constructor(
             page: Int,
             reset: Boolean,
         ) {
-            updateState { copy(isPageLoading = true) }
+            if (!reset) {
+                updateState { copy(nextPageLoadState = NextPageLoadState.Loading) }
+            }
 
             searchPartyUseCase(
                 keyword = keyword,
@@ -131,10 +132,9 @@ class PartySearchViewModel @Inject constructor(
                                     },
                                 ),
                             ),
-                            isPageLoading = false,
+                            nextPageLoadState = NextPageLoadState.Idle,
                             hasNextPage = result.hasNext,
                             nextPage = page + 1,
-                            isNextPageLoadFailed = false,
                         )
                     }
                 }
@@ -146,8 +146,11 @@ class PartySearchViewModel @Inject constructor(
                             } else {
                                 searchResultLoadState
                             },
-                            isPageLoading = false,
-                            isNextPageLoadFailed = !reset,
+                            nextPageLoadState = if (reset) {
+                                NextPageLoadState.Idle
+                            } else {
+                                NextPageLoadState.Failure
+                            },
                         )
                     }
                 }

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
@@ -1,0 +1,21 @@
+package com.poti.android.presentation.party.search
+
+import com.poti.android.core.base.BaseViewModel
+import com.poti.android.presentation.party.search.model.PartySearchUiEffect
+import com.poti.android.presentation.party.search.model.PartySearchUiIntent
+import com.poti.android.presentation.party.search.model.PartySearchUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PartySearchViewModel @Inject constructor() : BaseViewModel<PartySearchUiState, PartySearchUiIntent, PartySearchUiEffect>(
+    initialState = PartySearchUiState(),
+) {
+    override fun processIntent(intent: PartySearchUiIntent) {
+        when (intent) {
+            is PartySearchUiIntent.OnSearchKeywordChange -> updateState {
+                copy(searchKeyword = intent.keyword)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
@@ -28,6 +28,13 @@ class PartySearchViewModel @Inject constructor(
 
         override fun processIntent(intent: PartySearchUiIntent) {
             when (intent) {
+                PartySearchUiIntent.OnBackClick -> sendEffect(PartySearchUiEffect.NavigateBack)
+                is PartySearchUiIntent.OnCardClick -> sendEffect(
+                    PartySearchUiEffect.NavigateToProductPartyList(
+                        artistId = intent.artistId,
+                        title = intent.title,
+                    ),
+                )
                 is PartySearchUiIntent.OnSearchKeywordChange -> scheduleSearch(intent.keyword)
                 is PartySearchUiIntent.OnSearch -> scheduleSearch(intent.keyword, debounceMillis = 0L)
                 PartySearchUiIntent.OnLoadNextPage -> loadNextPage()

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
@@ -81,6 +81,8 @@ class PartySearchViewModel @Inject constructor(
             val trimmedKeyword = state.searchKeyword.trim()
             if (trimmedKeyword.isEmpty()) return
 
+            updateState { copy(nextPageLoadState = NextPageLoadState.Loading) }
+
             searchJob = viewModelScope.launch {
                 requestSearch(
                     keyword = trimmedKeyword,
@@ -114,10 +116,6 @@ class PartySearchViewModel @Inject constructor(
             page: Int,
             reset: Boolean,
         ) {
-            if (!reset) {
-                updateState { copy(nextPageLoadState = NextPageLoadState.Loading) }
-            }
-
             searchPartyUseCase(
                 keyword = keyword,
                 page = page,

--- a/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/PartySearchViewModel.kt
@@ -30,6 +30,7 @@ class PartySearchViewModel @Inject constructor(
                 is PartySearchUiIntent.OnSearchKeywordChange -> scheduleSearch(intent.keyword)
                 is PartySearchUiIntent.OnSearch -> scheduleSearch(intent.keyword, debounceMillis = 0L)
                 PartySearchUiIntent.OnLoadNextPage -> loadNextPage()
+                PartySearchUiIntent.OnRetryNextPage -> retryNextPage()
             }
         }
 
@@ -52,6 +53,7 @@ class PartySearchViewModel @Inject constructor(
                     isPageLoading = false,
                     hasNextPage = false,
                     nextPage = 0,
+                    isNextPageLoadFailed = false,
                 )
             }
 
@@ -67,7 +69,7 @@ class PartySearchViewModel @Inject constructor(
 
         private fun loadNextPage() {
             val state = uiState.value
-            if (state.isPageLoading || !state.hasNextPage) return
+            if (state.isPageLoading || !state.hasNextPage || state.isNextPageLoadFailed) return
 
             val trimmedKeyword = state.searchKeyword.trim()
             if (trimmedKeyword.isEmpty()) return
@@ -81,6 +83,13 @@ class PartySearchViewModel @Inject constructor(
             }
         }
 
+        private fun retryNextPage() {
+            if (!uiState.value.isNextPageLoadFailed) return
+
+            updateState { copy(isNextPageLoadFailed = false) }
+            loadNextPage()
+        }
+
         private fun resetSearch(keyword: String) {
             updateState {
                 copy(
@@ -89,6 +98,7 @@ class PartySearchViewModel @Inject constructor(
                     isPageLoading = false,
                     hasNextPage = false,
                     nextPage = 0,
+                    isNextPageLoadFailed = false,
                 )
             }
         }
@@ -124,6 +134,7 @@ class PartySearchViewModel @Inject constructor(
                             isPageLoading = false,
                             hasNextPage = result.hasNext,
                             nextPage = page + 1,
+                            isNextPageLoadFailed = false,
                         )
                     }
                 }
@@ -136,6 +147,7 @@ class PartySearchViewModel @Inject constructor(
                                 searchResultLoadState
                             },
                             isPageLoading = false,
+                            isNextPageLoadFailed = !reset,
                         )
                     }
                 }

--- a/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
@@ -5,16 +5,23 @@ import com.poti.android.core.base.UiEffect
 import com.poti.android.core.base.UiIntent
 import com.poti.android.core.base.UiState
 import com.poti.android.core.common.state.ApiState
-import com.poti.android.domain.model.party.ProductCategory
+import com.poti.android.domain.model.search.PartySearchResult
 
 @Immutable
 data class PartySearchUiState(
     val searchKeyword: String = "",
-    val productCategoryLoadState: ApiState<ProductCategory> = ApiState.Init,
+    val searchResultLoadState: ApiState<PartySearchResult> = ApiState.Init,
+    val isPageLoading: Boolean = false,
+    val hasNextPage: Boolean = false,
+    val nextPage: Int = 0,
 ) : UiState {}
 
 sealed interface PartySearchUiIntent : UiIntent {
     data class OnSearchKeywordChange(val keyword: String) : PartySearchUiIntent
+
+    data class OnSearch(val keyword: String) : PartySearchUiIntent
+
+    data object OnLoadNextPage : PartySearchUiIntent
 }
 
 sealed interface PartySearchUiEffect : UiEffect {

--- a/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
@@ -11,11 +11,18 @@ import com.poti.android.domain.model.search.PartySearchResult
 data class PartySearchUiState(
     val searchKeyword: String = "",
     val searchResultLoadState: ApiState<PartySearchResult> = ApiState.Init,
-    val isPageLoading: Boolean = false,
+    val nextPageLoadState: NextPageLoadState = NextPageLoadState.Idle,
     val hasNextPage: Boolean = false,
     val nextPage: Int = 0,
-    val isNextPageLoadFailed: Boolean = false,
 ) : UiState {}
+
+sealed interface NextPageLoadState {
+    data object Idle : NextPageLoadState
+
+    data object Loading : NextPageLoadState
+
+    data object Failure : NextPageLoadState
+}
 
 sealed interface PartySearchUiIntent : UiIntent {
     data class OnSearchKeywordChange(val keyword: String) : PartySearchUiIntent

--- a/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
@@ -25,6 +25,10 @@ sealed interface NextPageLoadState {
 }
 
 sealed interface PartySearchUiIntent : UiIntent {
+    data object OnBackClick : PartySearchUiIntent
+
+    data class OnCardClick(val artistId: Long, val title: String) : PartySearchUiIntent
+
     data class OnSearchKeywordChange(val keyword: String) : PartySearchUiIntent
 
     data class OnSearch(val keyword: String) : PartySearchUiIntent
@@ -35,4 +39,10 @@ sealed interface PartySearchUiIntent : UiIntent {
 }
 
 sealed interface PartySearchUiEffect : UiEffect {
+    data object NavigateBack : PartySearchUiEffect
+
+    data class NavigateToProductPartyList(
+        val artistId: Long,
+        val title: String,
+    ) : PartySearchUiEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
@@ -10,11 +10,12 @@ import com.poti.android.domain.model.party.ProductCategory
 @Immutable
 data class PartySearchUiState(
     val searchKeyword: String = "",
-    val productCategoryLoadState: ApiState<ProductCategory> = ApiState.Loading,
+    val productCategoryLoadState: ApiState<ProductCategory> = ApiState.Init,
 ) : UiState {}
 
 sealed interface PartySearchUiIntent : UiIntent {
+    data class OnSearchKeywordChange(val keyword: String) : PartySearchUiIntent
 }
 
-sealed interface PartySearch : UiEffect {
+sealed interface PartySearchUiEffect : UiEffect {
 }

--- a/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
@@ -14,6 +14,7 @@ data class PartySearchUiState(
     val isPageLoading: Boolean = false,
     val hasNextPage: Boolean = false,
     val nextPage: Int = 0,
+    val isNextPageLoadFailed: Boolean = false,
 ) : UiState {}
 
 sealed interface PartySearchUiIntent : UiIntent {
@@ -22,6 +23,8 @@ sealed interface PartySearchUiIntent : UiIntent {
     data class OnSearch(val keyword: String) : PartySearchUiIntent
 
     data object OnLoadNextPage : PartySearchUiIntent
+
+    data object OnRetryNextPage : PartySearchUiIntent
 }
 
 sealed interface PartySearchUiEffect : UiEffect {

--- a/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
@@ -1,0 +1,20 @@
+package com.poti.android.presentation.party.search.model
+
+import androidx.compose.runtime.Immutable
+import com.poti.android.core.base.UiEffect
+import com.poti.android.core.base.UiIntent
+import com.poti.android.core.base.UiState
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.model.party.ProductCategory
+
+@Immutable
+data class PartySearchUiState(
+    val searchText: String = "",
+    val productCategoryLoadState: ApiState<ProductCategory> = ApiState.Loading,
+) : UiState {}
+
+sealed interface PartySearchUiIntent : UiIntent {
+}
+
+sealed interface PartySearch : UiEffect {
+}

--- a/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
@@ -9,7 +9,7 @@ import com.poti.android.domain.model.party.ProductCategory
 
 @Immutable
 data class PartySearchUiState(
-    val searchText: String = "",
+    val searchKeyword: String = "",
     val productCategoryLoadState: ApiState<ProductCategory> = ApiState.Loading,
 ) : UiState {}
 

--- a/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/model/Contracts.kt
@@ -14,7 +14,7 @@ data class PartySearchUiState(
     val nextPageLoadState: NextPageLoadState = NextPageLoadState.Idle,
     val hasNextPage: Boolean = false,
     val nextPage: Int = 0,
-) : UiState {}
+) : UiState
 
 sealed interface NextPageLoadState {
     data object Idle : NextPageLoadState

--- a/app/src/main/java/com/poti/android/presentation/party/search/navigation/SearchRoute.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/navigation/SearchRoute.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import com.poti.android.core.common.extension.slideComposable
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.party.product.navigation.navigateToProductPartyList
 import com.poti.android.presentation.party.search.PartySearchRoute
 import kotlinx.serialization.Serializable
 
@@ -26,6 +27,7 @@ fun NavGraphBuilder.searchNavGraph(
     slideComposable<SearchRoute.Search> {
         PartySearchRoute(
             onBackClick = navController::popBackStack,
+            onNavigateToProductPartyList = navController::navigateToProductPartyList,
             modifier = Modifier.padding(paddingValues),
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/party/search/navigation/SearchRoute.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/navigation/SearchRoute.kt
@@ -1,0 +1,32 @@
+package com.poti.android.presentation.party.search.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import com.poti.android.core.common.extension.slideComposable
+import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.party.search.PartySearchRoute
+import kotlinx.serialization.Serializable
+
+sealed interface SearchRoute : Route {
+    @Serializable
+    data object Search : SearchRoute
+}
+
+fun NavController.navigateToPartySearch() {
+    navigate(SearchRoute.Search)
+}
+
+fun NavGraphBuilder.searchNavGraph(
+    navController: NavController,
+    paddingValues: PaddingValues,
+) {
+    slideComposable<SearchRoute.Search> {
+        PartySearchRoute(
+            onBackClick = navController::popBackStack,
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/party/search/navigation/SearchRoute.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/search/navigation/SearchRoute.kt
@@ -1,8 +1,5 @@
 package com.poti.android.presentation.party.search.navigation
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
-import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import com.poti.android.core.common.extension.slideComposable
@@ -22,13 +19,11 @@ fun NavController.navigateToPartySearch() {
 
 fun NavGraphBuilder.searchNavGraph(
     navController: NavController,
-    paddingValues: PaddingValues,
 ) {
     slideComposable<SearchRoute.Search> {
         PartySearchRoute(
             onBackClick = navController::popBackStack,
             onNavigateToProductPartyList = navController::navigateToProductPartyList,
-            modifier = Modifier.padding(paddingValues),
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <!-- Field Component -->
     <string name="field_label_name">이름</string>
     <string name="search_bar_placeholder">검색어를 입력하세요</string>
+    <string name="search_message_empty_result">검색 결과가 없어요\n다른 키워드로 다시 검색해보세요</string>
 
 
     <!-- LoginScreen -->

--- a/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
@@ -1,0 +1,196 @@
+package com.poti.android.presentation.party.search
+
+import com.poti.android.MainDispatcherRule
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.model.search.PartySearchItem
+import com.poti.android.domain.model.search.PartySearchResult
+import com.poti.android.domain.repository.SearchRepository
+import com.poti.android.domain.usecase.search.SearchPartyUseCase
+import com.poti.android.presentation.party.search.model.PartySearchUiIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PartySearchViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var searchRepository: FakeSearchRepository
+    private lateinit var viewModel: PartySearchViewModel
+
+    @Before
+    fun setUp() {
+        searchRepository = FakeSearchRepository()
+        viewModel = PartySearchViewModel(SearchPartyUseCase(searchRepository))
+    }
+
+    @Test
+    fun `searches only the latest keyword after debounce`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            searchRepository.enqueue(Result.success(searchResult(item(1), hasNext = false)))
+
+            viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange("아"))
+            advanceTimeBy(399)
+            runCurrent()
+            assertTrue(searchRepository.requests.isEmpty())
+
+            viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange("아이브"))
+            advanceTimeBy(400)
+            runCurrent()
+
+            assertEquals(1, searchRepository.requests.size)
+            assertEquals("아이브", searchRepository.requests.single().keyword)
+        }
+
+    @Test
+    fun `clears results and cancels pending search when keyword becomes empty`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange("아이브"))
+            viewModel.processIntent(PartySearchUiIntent.OnSearchKeywordChange(""))
+            advanceUntilIdle()
+
+            assertTrue(searchRepository.requests.isEmpty())
+            assertEquals("", viewModel.uiState.value.searchKeyword)
+            assertEquals(ApiState.Init, viewModel.uiState.value.searchResultLoadState)
+            assertFalse(viewModel.uiState.value.hasNextPage)
+            assertEquals(0, viewModel.uiState.value.nextPage)
+        }
+
+    @Test
+    fun `search intent skips debounce and loads first page`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val firstItem = item(1)
+            searchRepository.enqueue(Result.success(searchResult(firstItem, hasNext = true)))
+
+            viewModel.processIntent(PartySearchUiIntent.OnSearch("  아이브  "))
+            advanceUntilIdle()
+
+            assertEquals(
+                SearchRequest(keyword = "아이브", page = 0, size = 20),
+                searchRepository.requests.single(),
+            )
+            val state = viewModel.uiState.value
+            val result = (state.searchResultLoadState as ApiState.Success).data
+            assertEquals(listOf(firstItem), result.items)
+            assertTrue(state.hasNextPage)
+            assertEquals(1, state.nextPage)
+        }
+
+    @Test
+    fun `appends next page and removes duplicate items`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val firstItem = item(1)
+            val secondItem = item(2)
+            searchRepository.enqueue(Result.success(searchResult(firstItem, hasNext = true)))
+            searchRepository.enqueue(Result.success(searchResult(firstItem, secondItem, hasNext = false)))
+
+            viewModel.processIntent(PartySearchUiIntent.OnSearch("아이브"))
+            advanceUntilIdle()
+            viewModel.processIntent(PartySearchUiIntent.OnLoadNextPage)
+            advanceUntilIdle()
+
+            assertEquals(listOf(0, 1), searchRepository.requests.map { it.page })
+            val state = viewModel.uiState.value
+            val result = (state.searchResultLoadState as ApiState.Success).data
+            assertEquals(listOf(firstItem, secondItem), result.items)
+            assertFalse(state.hasNextPage)
+            assertEquals(2, state.nextPage)
+        }
+
+    @Test
+    fun `keeps current results after page failure and retries the same page`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val firstItem = item(1)
+            val secondItem = item(2)
+            searchRepository.enqueue(Result.success(searchResult(firstItem, hasNext = true)))
+            searchRepository.enqueue(Result.failure(IllegalStateException("page failed")))
+            searchRepository.enqueue(Result.success(searchResult(secondItem, hasNext = false)))
+
+            viewModel.processIntent(PartySearchUiIntent.OnSearch("아이브"))
+            advanceUntilIdle()
+            viewModel.processIntent(PartySearchUiIntent.OnLoadNextPage)
+            advanceUntilIdle()
+
+            val failedState = viewModel.uiState.value
+            val failedResult = (failedState.searchResultLoadState as ApiState.Success).data
+            assertEquals(listOf(firstItem), failedResult.items)
+            assertTrue(failedState.isNextPageLoadFailed)
+            assertEquals(1, failedState.nextPage)
+
+            viewModel.processIntent(PartySearchUiIntent.OnRetryNextPage)
+            advanceUntilIdle()
+
+            val retriedState = viewModel.uiState.value
+            val retriedResult = (retriedState.searchResultLoadState as ApiState.Success).data
+            assertEquals(listOf(firstItem, secondItem), retriedResult.items)
+            assertEquals(listOf(0, 1, 1), searchRepository.requests.map { it.page })
+            assertFalse(retriedState.isNextPageLoadFailed)
+            assertFalse(retriedState.hasNextPage)
+            assertEquals(2, retriedState.nextPage)
+        }
+
+    @Test
+    fun `moves to failure when first page request fails`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            searchRepository.enqueue(Result.failure(IllegalStateException("search failed")))
+
+            viewModel.processIntent(PartySearchUiIntent.OnSearch("아이브"))
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            val failure = state.searchResultLoadState as ApiState.Failure
+            assertEquals("search failed", failure.message)
+            assertFalse(state.isNextPageLoadFailed)
+            assertFalse(state.isPageLoading)
+        }
+
+    private fun item(id: Long) = PartySearchItem(
+        artist = "artist-$id",
+        artistId = id,
+        postImage = "image-$id",
+        postTitle = "title-$id",
+        postCount = id.toInt(),
+        tag = null,
+    )
+
+    private fun searchResult(
+        vararg items: PartySearchItem,
+        hasNext: Boolean,
+    ) = PartySearchResult(
+        items = items.toList(),
+        hasNext = hasNext,
+    )
+
+    private class FakeSearchRepository : SearchRepository {
+        val requests = mutableListOf<SearchRequest>()
+        private val results = ArrayDeque<Result<PartySearchResult>>()
+
+        fun enqueue(result: Result<PartySearchResult>) {
+            results.addLast(result)
+        }
+
+        override suspend fun searchParties(
+            keyword: String,
+            page: Int,
+            size: Int,
+        ): Result<PartySearchResult> {
+            requests += SearchRequest(keyword, page, size)
+            return results.removeFirst()
+        }
+    }
+
+    private data class SearchRequest(
+        val keyword: String,
+        val page: Int,
+        val size: Int,
+    )
+}

--- a/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
@@ -7,8 +7,11 @@ import com.poti.android.domain.model.search.PartySearchResult
 import com.poti.android.domain.repository.SearchRepository
 import com.poti.android.domain.usecase.search.SearchPartyUseCase
 import com.poti.android.presentation.party.search.model.NextPageLoadState
+import com.poti.android.presentation.party.search.model.PartySearchUiEffect
 import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -151,6 +154,42 @@ class PartySearchViewModelTest {
             val failure = state.searchResultLoadState as ApiState.Failure
             assertEquals("search failed", failure.message)
             assertEquals(NextPageLoadState.Idle, state.nextPageLoadState)
+        }
+
+    @Test
+    fun `emits product party list navigation effect when card is clicked`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val effects = mutableListOf<PartySearchUiEffect>()
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.sideEffect.collect(effects::add)
+            }
+
+            viewModel.processIntent(
+                PartySearchUiIntent.OnCardClick(
+                    artistId = 1L,
+                    title = "앨범",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(PartySearchUiEffect.NavigateToProductPartyList(1L, "앨범")),
+                effects,
+            )
+        }
+
+    @Test
+    fun `emits back navigation effect when back is clicked`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val effects = mutableListOf<PartySearchUiEffect>()
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.sideEffect.collect(effects::add)
+            }
+
+            viewModel.processIntent(PartySearchUiIntent.OnBackClick)
+            advanceUntilIdle()
+
+            assertEquals(listOf(PartySearchUiEffect.NavigateBack), effects)
         }
 
     private fun item(id: Long) = PartySearchItem(

--- a/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
@@ -158,7 +158,7 @@ class PartySearchViewModelTest {
         artistId = id,
         postImage = "image-$id",
         postTitle = "title-$id",
-        postCount = id.toInt(),
+        postCount = id,
         tag = null,
     )
 

--- a/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
@@ -111,6 +111,22 @@ class PartySearchViewModelTest {
         }
 
     @Test
+    fun `requests next page only once when load intent is sent consecutively`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            searchRepository.enqueue(Result.success(searchResult(item(1), hasNext = true)))
+            searchRepository.enqueue(Result.success(searchResult(item(2), hasNext = false)))
+
+            viewModel.processIntent(PartySearchUiIntent.OnSearch("아이브"))
+            advanceUntilIdle()
+
+            viewModel.processIntent(PartySearchUiIntent.OnLoadNextPage)
+            viewModel.processIntent(PartySearchUiIntent.OnLoadNextPage)
+            advanceUntilIdle()
+
+            assertEquals(listOf(0, 1), searchRepository.requests.map { it.page })
+        }
+
+    @Test
     fun `keeps current results after page failure and retries the same page`() =
         runTest(mainDispatcherRule.testDispatcher) {
             val firstItem = item(1)

--- a/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/party/search/PartySearchViewModelTest.kt
@@ -6,6 +6,7 @@ import com.poti.android.domain.model.search.PartySearchItem
 import com.poti.android.domain.model.search.PartySearchResult
 import com.poti.android.domain.repository.SearchRepository
 import com.poti.android.domain.usecase.search.SearchPartyUseCase
+import com.poti.android.presentation.party.search.model.NextPageLoadState
 import com.poti.android.presentation.party.search.model.PartySearchUiIntent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
@@ -123,7 +124,7 @@ class PartySearchViewModelTest {
             val failedState = viewModel.uiState.value
             val failedResult = (failedState.searchResultLoadState as ApiState.Success).data
             assertEquals(listOf(firstItem), failedResult.items)
-            assertTrue(failedState.isNextPageLoadFailed)
+            assertEquals(NextPageLoadState.Failure, failedState.nextPageLoadState)
             assertEquals(1, failedState.nextPage)
 
             viewModel.processIntent(PartySearchUiIntent.OnRetryNextPage)
@@ -133,7 +134,7 @@ class PartySearchViewModelTest {
             val retriedResult = (retriedState.searchResultLoadState as ApiState.Success).data
             assertEquals(listOf(firstItem, secondItem), retriedResult.items)
             assertEquals(listOf(0, 1, 1), searchRepository.requests.map { it.page })
-            assertFalse(retriedState.isNextPageLoadFailed)
+            assertEquals(NextPageLoadState.Idle, retriedState.nextPageLoadState)
             assertFalse(retriedState.hasNextPage)
             assertEquals(2, retriedState.nextPage)
         }
@@ -149,8 +150,7 @@ class PartySearchViewModelTest {
             val state = viewModel.uiState.value
             val failure = state.searchResultLoadState as ApiState.Failure
             assertEquals("search failed", failure.message)
-            assertFalse(state.isNextPageLoadFailed)
-            assertFalse(state.isPageLoading)
+            assertEquals(NextPageLoadState.Idle, state.nextPageLoadState)
         }
 
     private fun item(id: Long) = PartySearchItem(


### PR DESCRIPTION
## Related issue 🛠️
- closed #183

## Work Description ✏️
- 홈 화면의 검색 아이콘에서 PartySearchScreen으로 이동하도록 네비게이션을 연결했습니다.
- /api/v1/search 기반 검색 기능을 SearchService, DataSource, Repository, UseCase로 분리했습니다.
- 검색어 입력 시 400ms debounce를 적용한 실시간 검색을 구현했습니다.
- Slice 기반 무한 스크롤과 다음 페이지 로딩 상태(Idle/Loading/Failure)를 추가했습니다.
- 다음 페이지 요청 실패 시 자동 반복 호출을 막고, 사용자가 다시 하단으로 스크롤하면 재시도하도록 처리했습니다.
- 검색 결과가 없을 때 PotiEmptyStateInline을 노출하도록 구현했습니다.
- 검색 결과 카드 클릭 시 ProductPartyListScreen으로 이동하도록 연결했습니다.
- ProductCategory 및 API DTO에서 사용하지 않는 myGroupItems를 제거하고, partyCount 타입을 Long으로 통일했습니다.
- PartySearchViewModel 단위 테스트를 추가했습니다.

## Screenshot 📸

https://github.com/user-attachments/assets/ae97b98d-a7ee-4874-9a5f-48a158b02af6



## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 최초 검색 상태는 ApiState, 다음 페이지 로딩 상태는 NextPageLoadState로 분리했습니다.
- 다음 페이지 실패 후에는 동일한 하단 위치에서 즉시 반복 요청하지 않고, 새로운 스크롤 입력이 들어올 때 재시도합니다.
- 검색 API 요청 파라미터는 keyword, page, size만 사용하며 sort는 전달하지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 파티 검색 화면을 추가했습니다.
  * 아티스트명과 게시물 제목으로 검색하고, 결과를 목록으로 확인할 수 있습니다.
  * 검색 결과의 추가 로드, 중복 제거, 실패 시 재시도를 지원합니다.
  * 검색 결과에서 상품 파티 목록으로 이동할 수 있습니다.
  * 홈 화면에서 검색 화면으로 바로 이동할 수 있습니다.

* **개선 사항**
  * 검색 결과가 없을 때 안내 메시지를 제공합니다.
  * 헤더 간격과 검색 영역 여백을 조정했습니다.
  * 상품 파티 목록 화면의 배경 표시를 개선했습니다.
  * 카테고리에서 불필요한 그룹 항목을 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->