### PR TITLE
[Feat/#180] 참여자 안내 모달 추가 및 안내 모달 공통화

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/modal/PotiNoticeModal.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/modal/PotiNoticeModal.kt
@@ -1,4 +1,4 @@
-package com.poti.android.presentation.party.create.component
+package com.poti.android.core.designsystem.component.modal
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -31,8 +31,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringArrayResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -41,13 +39,17 @@ import com.poti.android.R
 import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.designsystem.component.button.ModalButtonType
 import com.poti.android.core.designsystem.component.button.PotiModalButton
-import com.poti.android.core.designsystem.component.modal.PotiModal
 import com.poti.android.core.designsystem.theme.PotiTheme
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun CreateCompleteModal(
+fun PotiNoticeModal(
+    title: String,
+    subtitle: String,
+    notices: ImmutableList<String>,
+    agreement: String,
+    confirmButtonText: String,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
     modifier: Modifier = Modifier,
@@ -56,7 +58,12 @@ fun CreateCompleteModal(
         onDismissRequest = onDismiss,
         modifier = modifier.padding(horizontal = 28.dp),
     ) {
-        CreateCompleteModalContent(
+        PotiNoticeModalContent(
+            title = title,
+            subtitle = subtitle,
+            notices = notices,
+            agreement = agreement,
+            confirmButtonText = confirmButtonText,
             onDismiss = onDismiss,
             onConfirm = onConfirm,
         )
@@ -64,60 +71,44 @@ fun CreateCompleteModal(
 }
 
 @Composable
-private fun CreateCompleteModalContent(
+private fun PotiNoticeModalContent(
+    title: String,
+    subtitle: String,
+    notices: ImmutableList<String>,
+    agreement: String,
+    confirmButtonText: String,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier,
-    ) {
-        CreateCompleteModalHeader(onDismiss = onDismiss)
+    Column(modifier = modifier) {
+        NoticeModalHeader(
+            title = title,
+            onDismiss = onDismiss,
+        )
 
         Spacer(Modifier.height(5.dp))
 
-        Text(
-            text = stringResource(R.string.create_complete_modal_subtitle),
+        NoticeTextBox(
+            text = subtitle,
             color = PotiTheme.colors.poti800,
-            style = PotiTheme.typography.body14m,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp)
-                .background(
-                    color = PotiTheme.colors.gray100,
-                    shape = RoundedCornerShape(8.dp),
-                )
-                .padding(vertical = 8.dp),
         )
 
         Spacer(Modifier.height(12.dp))
 
-        CreateCompleteModalNoticeList(
-            notices = rememberCreateCompleteModalNotices(),
-        )
+        NoticeList(notices = notices)
 
         Spacer(Modifier.height(12.dp))
 
-        Text(
-            text = stringResource(R.string.create_complete_modal_agreement),
+        NoticeTextBox(
+            text = agreement,
             color = PotiTheme.colors.gray900,
-            style = PotiTheme.typography.body14m,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp)
-                .background(
-                    color = PotiTheme.colors.gray100,
-                    shape = RoundedCornerShape(8.dp),
-                )
-                .padding(vertical = 8.dp),
         )
 
         Spacer(Modifier.height(12.dp))
 
         PotiModalButton(
-            text = stringResource(R.string.create_complete_modal_confirm),
+            text = confirmButtonText,
             onClick = onConfirm,
             modifier = Modifier
                 .fillMaxWidth()
@@ -130,7 +121,8 @@ private fun CreateCompleteModalContent(
 }
 
 @Composable
-private fun CreateCompleteModalHeader(
+private fun NoticeModalHeader(
+    title: String,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -142,7 +134,7 @@ private fun CreateCompleteModalHeader(
             .padding(start = 16.dp, end = 4.dp, top = 4.dp),
     ) {
         Text(
-            text = stringResource(R.string.create_notice_title),
+            text = title,
             color = PotiTheme.colors.black,
             style = PotiTheme.typography.title18sb,
         )
@@ -159,22 +151,36 @@ private fun CreateCompleteModalHeader(
 }
 
 @Composable
-private fun rememberCreateCompleteModalNotices(): ImmutableList<String> {
-    val noticesArray = stringArrayResource(R.array.create_complete_modal_notices)
-    return remember(noticesArray) { noticesArray.toPersistentList() }
+private fun NoticeTextBox(
+    text: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        color = color,
+        style = PotiTheme.typography.body14m,
+        textAlign = TextAlign.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp)
+            .background(
+                color = PotiTheme.colors.gray100,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .padding(vertical = 8.dp),
+    )
 }
 
 @Composable
-private fun CreateCompleteModalNoticeList(
+private fun NoticeList(
     notices: ImmutableList<String>,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
     val showBottomGradient by remember { derivedStateOf { scrollState.canScrollForward } }
 
-    Box(
-        modifier = modifier.heightIn(max = 280.dp),
-    ) {
+    Box(modifier = modifier.heightIn(max = 280.dp)) {
         Column(
             verticalArrangement = Arrangement.spacedBy(4.dp),
             modifier = Modifier
@@ -182,9 +188,7 @@ private fun CreateCompleteModalNoticeList(
                 .verticalScroll(scrollState),
         ) {
             notices.forEach { notice ->
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_bullet),
                         contentDescription = null,
@@ -245,13 +249,21 @@ private fun CreateCompleteModalNoticeList(
 
 @Preview
 @Composable
-private fun CreateCompleteModalContentPreview() {
+private fun PotiNoticeModalContentPreview() {
     PotiTheme {
         Surface(
             shape = RoundedCornerShape(12.dp),
             color = PotiTheme.colors.white,
         ) {
-            CreateCompleteModalContent(
+            PotiNoticeModalContent(
+                title = "모집자 안내 사항",
+                subtitle = "모집 전 꼭 확인해 주세요!",
+                notices = persistentListOf(
+                    "모집 시작 후에는 모집 정보를 수정할 수 없습니다.",
+                    "참여자가 있으면 모집글을 삭제할 수 없습니다.",
+                ),
+                agreement = "위 내용을 확인하였으며,\n안내 사항을 준수하겠습니다.",
+                confirmButtonText = "확인",
                 onDismiss = {},
                 onConfirm = {},
             )

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.ImeAction
@@ -36,13 +37,13 @@ import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.display.PotiErrorMessage
 import com.poti.android.core.designsystem.component.field.PotiLongTextField
 import com.poti.android.core.designsystem.component.field.PotiShortTextField
+import com.poti.android.core.designsystem.component.modal.PotiNoticeModal
 import com.poti.android.core.designsystem.component.modal.PotiSmallModal
 import com.poti.android.core.designsystem.component.navigation.PotiBottomButton
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.artist.MemberPriceOption
 import com.poti.android.presentation.party.component.MemberSelectBottomSheet
-import com.poti.android.presentation.party.create.component.CreateCompleteModal
 import com.poti.android.presentation.party.create.component.CreateDeliverySetting
 import com.poti.android.presentation.party.create.component.CreateDropdownField
 import com.poti.android.presentation.party.create.component.CreateMemberSetting
@@ -80,6 +81,7 @@ import com.poti.android.presentation.party.create.model.CreateUiIntent.ScrollCom
 import com.poti.android.presentation.party.create.model.CreateUiState
 import com.poti.android.presentation.party.create.model.DeliveryOptionUiModel
 import com.poti.android.presentation.party.create.util.DateTransformation
+import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 fun PartyCreateRoute(
@@ -139,7 +141,12 @@ fun PartyCreateRoute(
             onConfirmBtnClick = { viewModel.processIntent(OnCloseDialog) },
         )
 
-        CreateModalType.CREATE_COMPLETE -> CreateCompleteModal(
+        CreateModalType.CREATE_COMPLETE -> PotiNoticeModal(
+            title = stringResource(R.string.create_notice_title),
+            subtitle = stringResource(R.string.create_complete_modal_subtitle),
+            notices = stringArrayResource(R.array.create_complete_modal_notices).toPersistentList(),
+            agreement = stringResource(R.string.create_complete_modal_agreement),
+            confirmButtonText = stringResource(R.string.create_complete_modal_confirm),
             onDismiss = { viewModel.processIntent(OnCloseCreateModal) },
             onConfirm = { viewModel.processIntent(OnCreateConfirm) },
         )

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateScreen.kt
@@ -146,7 +146,7 @@ fun PartyCreateRoute(
             subtitle = stringResource(R.string.create_complete_modal_subtitle),
             notices = stringArrayResource(R.array.create_complete_modal_notices).toPersistentList(),
             agreement = stringResource(R.string.create_complete_modal_agreement),
-            confirmButtonText = stringResource(R.string.create_complete_modal_confirm),
+            confirmButtonText = stringResource(R.string.action_button_confirm),
             onDismiss = { viewModel.processIntent(OnCloseCreateModal) },
             onConfirm = { viewModel.processIntent(OnCreateConfirm) },
         )

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
@@ -63,7 +63,16 @@ class PartyDetailViewModel @Inject constructor(
             is PartyDetailIntent.OnDetailAddressChange -> updateState { copy(detailAddress = intent.value) }
             is PartyDetailIntent.OnContactChange -> updateState { copy(contact = intent.value, isContactError = false) }
             PartyDetailIntent.OnFinalJoinClick -> {
-                if (validateInputs()) postOrder()
+                if (validateInputs()) {
+                    updateState { copy(isParticipantNoticeModalVisible = true) }
+                }
+            }
+            PartyDetailIntent.OnParticipantNoticeDismiss -> {
+                updateState { copy(isParticipantNoticeModalVisible = false) }
+            }
+            PartyDetailIntent.OnParticipantNoticeConfirm -> {
+                updateState { copy(isParticipantNoticeModalVisible = false) }
+                postOrder()
             }
             PartyDetailIntent.OnJoinSuccessConfirm -> {
                 updateState { copy(isJoinSuccessDialogVisible = false) }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyJoinScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyJoinScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -37,6 +38,7 @@ import com.poti.android.core.designsystem.component.display.PotiListOptionPrice
 import com.poti.android.core.designsystem.component.display.PotiListOptionPriceSize
 import com.poti.android.core.designsystem.component.field.PotiShortTextField
 import com.poti.android.core.designsystem.component.modal.PotiLargeModal
+import com.poti.android.core.designsystem.component.modal.PotiNoticeModal
 import com.poti.android.core.designsystem.component.navigation.PotiBottomButton
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
@@ -45,6 +47,7 @@ import com.poti.android.presentation.party.detail.component.TotalPrice
 import com.poti.android.presentation.party.detail.model.PartyDetailEffect
 import com.poti.android.presentation.party.detail.model.PartyDetailIntent
 import com.poti.android.presentation.party.detail.model.PartyDetailUiState
+import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 fun PartyJoinRoute(
@@ -83,6 +86,19 @@ fun PartyJoinRoute(
             is PartyDetailEffect.ReloadDetail -> onReload(effect.partyId)
             else -> {}
         }
+    }
+
+    if (uiState.isParticipantNoticeModalVisible) {
+        PotiNoticeModal(
+            title = stringResource(R.string.party_join_notice_modal_title),
+            subtitle = stringResource(R.string.party_join_notice_modal_subtitle),
+            notices = stringArrayResource(R.array.party_join_notice_modal_notices).toPersistentList(),
+            agreement = stringResource(R.string.party_join_notice_modal_agreement),
+            confirmButtonText = stringResource(R.string.action_button_confirm),
+            onDismiss = { viewModel.processIntent(PartyDetailIntent.OnParticipantNoticeDismiss) },
+            onConfirm = { viewModel.processIntent(PartyDetailIntent.OnParticipantNoticeConfirm) },
+            modifier = modifier,
+        )
     }
 
     if (uiState.isJoinSuccessDialogVisible) {

--- a/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
@@ -31,6 +31,7 @@ data class PartyDetailUiState(
     val isPostalCodeError: Boolean = false,
     val isAddressError: Boolean = false,
     val isContactError: Boolean = false,
+    val isParticipantNoticeModalVisible: Boolean = false,
     val isJoinSuccessDialogVisible: Boolean = false,
 ) : UiState {
     val isDetailJoinEnable: Boolean
@@ -90,6 +91,10 @@ sealed interface PartyDetailIntent : UiIntent {
     data class OnContactChange(val value: String) : PartyDetailIntent
 
     data object OnFinalJoinClick : PartyDetailIntent
+
+    data object OnParticipantNoticeDismiss : PartyDetailIntent
+
+    data object OnParticipantNoticeConfirm : PartyDetailIntent
 
     data object OnJoinSuccessConfirm : PartyDetailIntent
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="action_button_reset">초기화</string>
     <string name="action_button_done">완료</string>
     <string name="action_button_continue">계속</string>
+    <string name="action_button_confirm">확인</string>
     <string name="action_button_select_all">전체 선택</string>
     <string name="action_button_refresh">초기화</string>
 
@@ -96,6 +97,16 @@
     <string name="party_join_order_contact_error">연락처를 입력해주세요</string>
     <string name="party_join_confirm_modal_title">참여가 완료되었어요</string>
     <string name="party_join_confirm_modal_text">모집이 끝나면 입금이 시작돼요</string>
+    <string name="party_join_notice_modal_title">참여자 안내 사항</string>
+    <string name="party_join_notice_modal_subtitle">참여 전 꼭 확인해 주세요!</string>
+    <string-array name="party_join_notice_modal_notices">
+        <item>참여 신청 후에는 취소할 수 없습니다. 참여 전 상품 정보를 꼭 확인해 주세요.</item>
+        <item>모집 완료 후 24시간 이내 입금을 완료해 주세요. 미입금 시 참여가 취소되며, 서비스 이용이 제한될 수 있습니다.</item>
+        <item>입금 요청 및 배송 등 주요 안내는 알림으로 전달됩니다.</item>
+        <item>마감일까지 최소 모집 인원이 모이지 않으면 분철은 자동 종료됩니다.</item>
+        <item>문의나 거래 중 문제가 발생하면 문의하기를 이용해 주세요.</item>
+    </string-array>
+    <string name="party_join_notice_modal_agreement">위 내용을 확인하였으며,\n안내 사항을 준수하겠습니다.</string>
 
     <!-- PartyCreate -->
     <string name="create_label_won">원</string>
@@ -153,7 +164,6 @@
         <item>참여자의 개인정보는 배송 목적 외 사용할 수 없으며, 거래 완료 후 즉시 삭제해 주세요.</item>
     </string-array>
     <string name="create_complete_modal_agreement">위 내용을 확인하였으며,\n안내 사항을 준수하겠습니다.</string>
-    <string name="create_complete_modal_confirm">확인</string>
 
     <!-- Party Status -->
     <string name="party_status_recruiting">모집 중</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #180

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 모집 완료 안내 모달을 PotiNoticeModal 공통 컴포넌트로 분리했습니다.
- 제목, 부제목, 안내 목록, 동의 문구, 버튼 문구를 외부에서 전달할 수 있도록 수정했습니다.
- 참여 정보 입력 화면에서 참여하기 버튼을 누르면 참여자 안내 모달이 표시되도록 연결했습니다.
- 참여자 안내 모달의 확인 버튼을 누른 경우에만 참여 요청을 수행하도록 상태 흐름을 변경했습니다.
- 참여 요청 성공 시 기존 참여 완료 모달이 이어서 표시됩니다.
- 공통 확인 버튼 문자열과 참여자 안내 문구를 문자열 리소스로 관리하도록 추가했습니다.

## Screenshot 📸

https://github.com/user-attachments/assets/94c45557-a337-4c74-a754-bd5c236951eb


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 기존 모집 완료 모달과 참여자 안내 모달이 동일한 UI 구조를 사용해 공통 컴포넌트로 분리했습니다.
- 참여 흐름은 참여하기 → 참여자 안내 확인 → 참여 요청 → 참여 완료 모달 순서입니다.
- 안내 모달을 닫거나 외부 영역을 누르면 참여 요청은 실행되지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 파티 참여 전 참가자 안내 모달을 표시합니다.
  - 안내 내용을 확인하거나 닫을 수 있으며, 확인 후 참여 절차가 진행됩니다.
  - 다양한 제목, 설명, 안내 목록, 동의 문구를 지원하는 공용 안내 모달을 제공합니다.
- **개선 사항**
  - 파티 생성 완료 모달이 새 공용 안내 모달로 변경되었습니다.
  - 안내 문구와 버튼 텍스트가 앱 리소스를 통해 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->