### PR TITLE
[Feat/#182] 설정 및 사용자 관리 UI 구현

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,7 +30,6 @@ fun PotiListRadio(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier.fillMaxWidth(),
     ) {
         options.forEachIndexed { index, option ->
@@ -60,7 +60,8 @@ fun PotiListRadioItem(
                 interactionSource = null,
                 indication = null,
                 onClick = onClick,
-            ),
+            )
+            .padding(vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {

--- a/app/src/main/java/com/poti/android/core/designsystem/component/modal/PotiSmallModal.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/modal/PotiSmallModal.kt
@@ -34,6 +34,7 @@ import com.poti.android.core.designsystem.theme.PotiTheme
  * @param onDismissBtnClick 좌측 버튼 클릭 콜백입니다.
  * @param onConfirmBtnClick 우측 버튼 클릭 콜백입니다.
  * @param modifier
+ * @param confirmBtnType 우측 버튼 타입입니다. 기본값은 [ModalButtonType.MAIN]입니다.
  * @param dismissOnBackPress 시스템 뒤로가기 시 모달을 닫는 여부입니다. 기본값 true입니다.
  * @param dismissOnClickOutside 모달 바깥 영역 터치 시 모달을 닫는 여부입니다. 기본값 true입니다.
  */
@@ -47,6 +48,7 @@ fun PotiSmallModal(
     onDismissBtnClick: () -> Unit,
     onConfirmBtnClick: () -> Unit,
     modifier: Modifier = Modifier,
+    confirmBtnType: ModalButtonType = ModalButtonType.MAIN,
     dismissOnBackPress: Boolean = true,
     dismissOnClickOutside: Boolean = true,
 ) {
@@ -98,7 +100,7 @@ fun PotiSmallModal(
                     onClick = onConfirmBtnClick,
                     modifier = Modifier
                         .weight(1f),
-                    type = ModalButtonType.MAIN,
+                    type = confirmBtnType,
                 )
             }
         }

--- a/app/src/main/java/com/poti/android/core/designsystem/component/modal/PotiSmallModal.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/modal/PotiSmallModal.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.core.designsystem.component.button.ModalButtonType
@@ -69,12 +70,14 @@ fun PotiSmallModal(
                     .padding(top = 16.dp, bottom = 8.dp),
                 color = PotiTheme.colors.black,
                 style = PotiTheme.typography.body16sb,
+                textAlign = TextAlign.Center,
             )
 
             Text(
                 text = text,
                 color = PotiTheme.colors.gray800,
                 style = PotiTheme.typography.body16m,
+                textAlign = TextAlign.Center,
             )
 
             Row(

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyJoinScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyJoinScreen.kt
@@ -225,44 +225,44 @@ private fun PartyJoinScreen(
                     PotiShortTextField(
                         value = uiState.orderName,
                         onValueChanged = onOrderNameChange,
-                        placeholder = stringResource(R.string.party_join_order_name_placeholder),
-                        label = stringResource(R.string.field_label_name),
-                        error = if (uiState.isOrderNameError) stringResource(R.string.party_join_order_name_error) else "",
+                        placeholder = stringResource(R.string.delivery_name_placeholder),
+                        label = stringResource(R.string.delivery_name_label),
+                        error = if (uiState.isOrderNameError) stringResource(R.string.delivery_name_error) else "",
                         imeAction = ImeAction.Next,
                     )
 
                     PotiShortTextField(
                         value = uiState.postalCode,
                         onFieldClick = onAddressSearchClick,
-                        placeholder = stringResource(R.string.party_join_order_postal_placeholder),
-                        label = stringResource(R.string.party_join_order_postal_label),
-                        error = if (uiState.isPostalCodeError) stringResource(R.string.party_join_order_postal_error) else "",
+                        placeholder = stringResource(R.string.delivery_postal_placeholder),
+                        label = stringResource(R.string.delivery_postal_label),
+                        error = if (uiState.isPostalCodeError) stringResource(R.string.delivery_postal_error) else "",
                         onValueChanged = {},
                     )
 
                     PotiShortTextField(
                         value = uiState.address,
                         onFieldClick = onAddressSearchClick,
-                        placeholder = stringResource(R.string.party_join_order_address_placeholder),
-                        label = stringResource(R.string.party_join_order_address_label),
-                        error = if (uiState.isAddressError) stringResource(R.string.party_join_order_address_error) else "",
+                        placeholder = stringResource(R.string.delivery_address_placeholder),
+                        label = stringResource(R.string.delivery_address_label),
+                        error = if (uiState.isAddressError) stringResource(R.string.delivery_address_error) else "",
                         onValueChanged = {},
                     )
 
                     PotiShortTextField(
                         value = uiState.detailAddress,
                         onValueChanged = onDetailAddressChange,
-                        placeholder = stringResource(R.string.party_join_order_detail_address_placeholder),
-                        label = stringResource(R.string.party_join_order_detail_address_label),
+                        placeholder = stringResource(R.string.delivery_detail_address_placeholder),
+                        label = stringResource(R.string.delivery_detail_address_label),
                         imeAction = ImeAction.Next,
                     )
 
                     PotiShortTextField(
                         value = uiState.contact,
                         onValueChanged = onContactChange,
-                        placeholder = stringResource(R.string.party_join_order_contact_placeholder),
-                        label = stringResource(R.string.party_join_order_contact_label),
-                        error = if (uiState.isContactError) stringResource(R.string.party_join_order_contact_error) else "",
+                        placeholder = stringResource(R.string.delivery_contact_placeholder),
+                        label = stringResource(R.string.delivery_contact_label),
+                        error = if (uiState.isContactError) stringResource(R.string.delivery_contact_error) else "",
                         keyboardType = KeyboardType.Number,
                     )
                 }

--- a/app/src/main/java/com/poti/android/presentation/party/product/component/FilteredSortBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/component/FilteredSortBottomSheet.kt
@@ -50,7 +50,7 @@ fun FilteredSortBottomSheet(
             },
             modifier = Modifier
                 .padding(horizontal = 16.dp)
-                .padding(top = 16.dp, bottom = 48.dp),
+                .padding(bottom = 32.dp),
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/product/component/GoodsSortBottomSheet.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/component/GoodsSortBottomSheet.kt
@@ -54,7 +54,7 @@ fun GoodsSortBottomSheet(
             },
             modifier = Modifier
                 .padding(horizontal = 16.dp)
-                .padding(top = 16.dp, bottom = 48.dp),
+                .padding(bottom = 32.dp),
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
@@ -3,6 +3,8 @@ package com.poti.android.presentation.setting
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -24,6 +26,8 @@ fun SettingRoute(modifier: Modifier = Modifier) {
 fun SettingScreen(
     modifier: Modifier = Modifier,
 ) {
+    val scrollState = rememberScrollState()
+
     Column(
         modifier = modifier.fillMaxSize(),
     ) {
@@ -32,72 +36,78 @@ fun SettingScreen(
             title = stringResource(R.string.setting_title),
         )
 
-        Text(
-            text = stringResource(R.string.setting_my_info),
-            style = PotiTheme.typography.body14m,
-            color = PotiTheme.colors.gray800,
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState),
+        ) {
+            Text(
+                text = stringResource(R.string.setting_my_info),
+                style = PotiTheme.typography.body14m,
+                color = PotiTheme.colors.gray800,
+                modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
+            )
 
-        PotiMenuButton(
-            text = stringResource(R.string.setting_my_account),
-            onClick = {},
-            modifier = Modifier.padding(horizontal = 8.dp),
-        )
+            PotiMenuButton(
+                text = stringResource(R.string.setting_my_account),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
 
-        PotiMenuButton(
-            text = stringResource(R.string.setting_my_profile),
-            onClick = {},
-            modifier = Modifier.padding(horizontal = 8.dp),
-        )
+            PotiMenuButton(
+                text = stringResource(R.string.setting_my_profile),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
 
-        PotiMenuButton(
-            text = stringResource(R.string.setting_my_address),
-            onClick = {},
-            modifier = Modifier.padding(horizontal = 8.dp),
-        )
+            PotiMenuButton(
+                text = stringResource(R.string.setting_my_address),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
 
-        PotiDivider(
-            PotiDividerStyle.LARGE,
-            modifier = Modifier.padding(vertical = 8.dp),
-        )
+            PotiDivider(
+                PotiDividerStyle.LARGE,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
 
-        Text(
-            text = stringResource(R.string.setting_app),
-            style = PotiTheme.typography.body14m,
-            color = PotiTheme.colors.gray800,
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
-        )
+            Text(
+                text = stringResource(R.string.setting_app),
+                style = PotiTheme.typography.body14m,
+                color = PotiTheme.colors.gray800,
+                modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
+            )
 
-        PotiMenuButton(
-            text = stringResource(R.string.setting_alarm),
-            onClick = {},
-            modifier = Modifier.padding(horizontal = 8.dp),
-        )
+            PotiMenuButton(
+                text = stringResource(R.string.setting_alarm),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
 
-        PotiDivider(
-            PotiDividerStyle.LARGE,
-            modifier = Modifier.padding(vertical = 8.dp),
-        )
+            PotiDivider(
+                PotiDividerStyle.LARGE,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
 
-        Text(
-            text = stringResource(R.string.service_info),
-            style = PotiTheme.typography.body14m,
-            color = PotiTheme.colors.gray800,
-            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
-        )
+            Text(
+                text = stringResource(R.string.service_info),
+                style = PotiTheme.typography.body14m,
+                color = PotiTheme.colors.gray800,
+                modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
+            )
 
-        PotiMenuButton(
-            text = stringResource(R.string.setting_personal_info_privacy),
-            onClick = {},
-            modifier = Modifier.padding(horizontal = 8.dp),
-        )
+            PotiMenuButton(
+                text = stringResource(R.string.setting_personal_info_privacy),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
 
-        PotiMenuButton(
-            text = stringResource(R.string.version_info),
-            onClick = {},
-            modifier = Modifier.padding(horizontal = 8.dp),
-        )
+            PotiMenuButton(
+                text = stringResource(R.string.version_info),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
@@ -49,19 +49,19 @@ fun SettingScreen(
             )
 
             PotiMenuButton(
-                text = stringResource(R.string.setting_my_account),
+                text = stringResource(R.string.my_account),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
             PotiMenuButton(
-                text = stringResource(R.string.setting_my_profile),
+                text = stringResource(R.string.profile_management),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
             PotiMenuButton(
-                text = stringResource(R.string.setting_my_address),
+                text = stringResource(R.string.address_management),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
             )

--- a/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
@@ -106,6 +106,7 @@ fun SettingScreen(
                 text = stringResource(R.string.version_info),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
+                trailingText = "1.0.0",
             )
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
@@ -49,19 +49,19 @@ fun SettingScreen(
             )
 
             PotiMenuButton(
-                text = stringResource(R.string.my_account),
+                text = stringResource(R.string.setting_menu_account),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
             PotiMenuButton(
-                text = stringResource(R.string.profile_management),
+                text = stringResource(R.string.setting_menu_profile_management),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
             PotiMenuButton(
-                text = stringResource(R.string.address_management),
+                text = stringResource(R.string.setting_menu_address_management),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
             )

--- a/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
@@ -1,0 +1,75 @@
+package com.poti.android.presentation.setting
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.core.designsystem.component.display.PotiDivider
+import com.poti.android.core.designsystem.component.display.PotiDividerStyle
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+@Composable
+fun SettingRoute(modifier: Modifier = Modifier) {
+}
+
+@Composable
+fun SettingScreen(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        PotiHeaderPage(
+            onNavigationClick = {},
+            title = "헤더 타이틀",
+        )
+
+        Text(
+            text = "내 정보",
+            style = PotiTheme.typography.body14m,
+            color = PotiTheme.colors.gray800,
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
+        )
+
+        // TODO: PotiMenuButton 머지되면 추가
+
+        PotiDivider(
+            PotiDividerStyle.LARGE,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+
+        Text(
+            text = "앱 설정",
+            style = PotiTheme.typography.body14m,
+            color = PotiTheme.colors.gray800,
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
+        )
+
+        // TODO: PotiMenuButton 머지되면 추가
+
+        PotiDivider(
+            PotiDividerStyle.LARGE,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+
+        Text(
+            text = "서비스 정보",
+            style = PotiTheme.typography.body14m,
+            color = PotiTheme.colors.gray800,
+            modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
+        )
+
+        // TODO: PotiMenuButton 머지되면 추가
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingScreenPreview() {
+    SettingScreen()
+}

--- a/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
@@ -6,8 +6,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.component.button.PotiMenuButton
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
@@ -26,17 +29,33 @@ fun SettingScreen(
     ) {
         PotiHeaderPage(
             onNavigationClick = {},
-            title = "헤더 타이틀",
+            title = stringResource(R.string.setting_title),
         )
 
         Text(
-            text = "내 정보",
+            text = stringResource(R.string.setting_my_info),
             style = PotiTheme.typography.body14m,
             color = PotiTheme.colors.gray800,
             modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
         )
 
-        // TODO: PotiMenuButton 머지되면 추가
+        PotiMenuButton(
+            text = stringResource(R.string.setting_my_account),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
+
+        PotiMenuButton(
+            text = stringResource(R.string.setting_my_profile),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
+
+        PotiMenuButton(
+            text = stringResource(R.string.setting_my_address),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
 
         PotiDivider(
             PotiDividerStyle.LARGE,
@@ -44,13 +63,17 @@ fun SettingScreen(
         )
 
         Text(
-            text = "앱 설정",
+            text = stringResource(R.string.setting_app),
             style = PotiTheme.typography.body14m,
             color = PotiTheme.colors.gray800,
             modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
         )
 
-        // TODO: PotiMenuButton 머지되면 추가
+        PotiMenuButton(
+            text = stringResource(R.string.setting_alarm),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
 
         PotiDivider(
             PotiDividerStyle.LARGE,
@@ -58,13 +81,23 @@ fun SettingScreen(
         )
 
         Text(
-            text = "서비스 정보",
+            text = stringResource(R.string.service_info),
             style = PotiTheme.typography.body14m,
             color = PotiTheme.colors.gray800,
             modifier = Modifier.padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 8.dp),
         )
 
-        // TODO: PotiMenuButton 머지되면 추가
+        PotiMenuButton(
+            text = stringResource(R.string.setting_personal_info_privacy),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
+
+        PotiMenuButton(
+            text = stringResource(R.string.version_info),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
     }
 }
 

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
@@ -33,7 +33,7 @@ fun AccountSettingScreen(
     ) {
         PotiHeaderPage(
             onNavigationClick = {},
-            title = stringResource(R.string.my_account),
+            title = stringResource(R.string.account_setting_title),
         )
 
         Column(
@@ -76,7 +76,7 @@ fun AccountSettingScreen(
             )
 
             PotiMenuButton(
-                text = stringResource(R.string.account_withdrawal),
+                text = stringResource(R.string.account_withdrawal_menu),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
             )

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
@@ -1,0 +1,91 @@
+package com.poti.android.presentation.user.account
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.component.button.PotiMenuButton
+import com.poti.android.core.designsystem.component.display.PotiDivider
+import com.poti.android.core.designsystem.component.display.PotiDividerStyle
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+
+@Composable
+fun AccountSettingRoute(modifier: Modifier = Modifier) {
+}
+
+@Composable
+fun AccountSettingScreen(
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        PotiHeaderPage(
+            onNavigationClick = {},
+            title = stringResource(R.string.setting_my_account),
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState),
+        ) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            PotiMenuButton(
+                text = stringResource(R.string.account_name),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+                trailingText = "",
+            )
+
+            PotiMenuButton(
+                text = stringResource(R.string.account_email),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+                trailingText = "",
+            )
+
+            PotiMenuButton(
+                text = stringResource(R.string.social_account),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+                trailingText = "",
+            )
+
+            PotiDivider(
+                PotiDividerStyle.LARGE,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+
+            PotiMenuButton(
+                text = stringResource(R.string.account_logout),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
+
+            PotiMenuButton(
+                text = stringResource(R.string.account_withdrawal),
+                onClick = {},
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AccountSettingScreenPreview() {
+    AccountSettingScreen()
+}

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
@@ -33,7 +33,7 @@ fun AccountSettingScreen(
     ) {
         PotiHeaderPage(
             onNavigationClick = {},
-            title = stringResource(R.string.setting_my_account),
+            title = stringResource(R.string.my_account),
         )
 
         Column(

--- a/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
@@ -9,11 +9,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,6 +27,7 @@ import com.poti.android.core.designsystem.component.button.ActionButtonType
 import com.poti.android.core.designsystem.component.button.PotiActionButton
 import com.poti.android.core.designsystem.component.field.PotiShortTextField
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.theme.PotiTheme
 
 @Composable
 fun AddressManagementRoute(modifier: Modifier = Modifier) {
@@ -75,6 +80,14 @@ fun AddressManagementScreen(
                         label = stringResource(R.string.delivery_postal_label),
                         error = "",
                         onValueChanged = {},
+                        trailingIcon = {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(R.drawable.ic_search),
+                                contentDescription = null,
+                                tint = PotiTheme.colors.gray700,
+                                modifier = Modifier.size(24.dp),
+                            )
+                        },
                     )
 
                     PotiShortTextField(

--- a/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
@@ -44,7 +44,7 @@ fun AddressManagementScreen(
     ) {
         PotiHeaderPage(
             onNavigationClick = {},
-            title = stringResource(R.string.address_management),
+            title = stringResource(R.string.address_management_title),
         )
 
         BoxWithConstraints(

--- a/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
@@ -1,0 +1,126 @@
+package com.poti.android.presentation.user.address
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.component.button.ActionButtonType
+import com.poti.android.core.designsystem.component.button.PotiActionButton
+import com.poti.android.core.designsystem.component.field.PotiShortTextField
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+
+@Composable
+fun AddressManagementRoute(modifier: Modifier = Modifier) {
+}
+
+@Composable
+fun AddressManagementScreen(
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        PotiHeaderPage(
+            onNavigationClick = {},
+            title = stringResource(R.string.address_management),
+        )
+
+        BoxWithConstraints(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = maxHeight)
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = 16.dp),
+            ) {
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(28.dp),
+                ) {
+                    PotiShortTextField(
+                        value = "",
+                        onValueChanged = {},
+                        placeholder = stringResource(R.string.delivery_name_placeholder),
+                        label = stringResource(R.string.delivery_name_label),
+                        error = "",
+                        imeAction = ImeAction.Next,
+                    )
+
+                    PotiShortTextField(
+                        value = "",
+                        onFieldClick = {},
+                        placeholder = stringResource(R.string.delivery_postal_placeholder),
+                        label = stringResource(R.string.delivery_postal_label),
+                        error = "",
+                        onValueChanged = {},
+                    )
+
+                    PotiShortTextField(
+                        value = "",
+                        onFieldClick = {},
+                        placeholder = stringResource(R.string.delivery_address_placeholder),
+                        label = stringResource(R.string.delivery_address_label),
+                        error = "",
+                        onValueChanged = {},
+                    )
+
+                    PotiShortTextField(
+                        value = "",
+                        onValueChanged = {},
+                        placeholder = stringResource(R.string.delivery_detail_address_placeholder),
+                        label = stringResource(R.string.delivery_detail_address_label),
+                        imeAction = ImeAction.Next,
+                    )
+
+                    PotiShortTextField(
+                        value = "",
+                        onValueChanged = {},
+                        placeholder = stringResource(R.string.delivery_contact_placeholder),
+                        label = stringResource(R.string.delivery_contact_label),
+                        error = "",
+                        keyboardType = KeyboardType.Number,
+                    )
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                PotiActionButton(
+                    text = stringResource(R.string.action_button_save),
+                    onClick = {},
+                    type = ActionButtonType.DEACTIVE_MAIN,
+                    modifier = Modifier
+                        .padding(top = 4.dp, bottom = 14.dp)
+                        .fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddressManagementScreenPreview() {
+    AddressManagementScreen()
+}

--- a/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
@@ -1,13 +1,11 @@
 package com.poti.android.presentation.user.address
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -47,7 +45,7 @@ fun AddressManagementScreen(
             title = stringResource(R.string.address_management_title),
         )
 
-        BoxWithConstraints(
+        Column(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
@@ -55,7 +53,7 @@ fun AddressManagementScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .heightIn(min = maxHeight)
+                    .weight(1f)
                     .verticalScroll(scrollState)
                     .padding(horizontal = 16.dp),
             ) {
@@ -116,18 +114,17 @@ fun AddressManagementScreen(
                         keyboardType = KeyboardType.Number,
                     )
                 }
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                PotiActionButton(
-                    text = stringResource(R.string.action_button_save),
-                    onClick = {},
-                    type = ActionButtonType.DEACTIVE_MAIN,
-                    modifier = Modifier
-                        .padding(top = 4.dp, bottom = 14.dp)
-                        .fillMaxWidth(),
-                )
             }
+
+            PotiActionButton(
+                text = stringResource(R.string.action_button_save),
+                onClick = {},
+                type = ActionButtonType.DEACTIVE_MAIN,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 4.dp, bottom = 14.dp)
+                    .fillMaxWidth(),
+            )
         }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/component/EditableUserProfileImage.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/EditableUserProfileImage.kt
@@ -1,0 +1,78 @@
+package com.poti.android.presentation.user.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.common.extension.noRippleClickable
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+@Composable
+fun EditableUserProfileImage(
+    imageUrl: String?,
+    onEditClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    imageSize: Dp = 98.dp,
+    editButtonSize: Dp = 36.dp,
+    editButtonOverhang: Dp = 7.dp,
+) {
+    val containerWidth = imageSize + editButtonOverhang * 2
+    val editButtonXOffset = imageSize / 2 - editButtonSize / 2 + editButtonOverhang
+    val editButtonYOffset = imageSize / 2 - editButtonSize / 2
+
+    Box(
+        modifier = modifier.size(
+            width = containerWidth,
+            height = imageSize,
+        ),
+        contentAlignment = Alignment.Center,
+    ) {
+        UserProfileImage(
+            imageUrl = imageUrl,
+            size = imageSize,
+        )
+
+        Box(
+            modifier = Modifier
+                .size(editButtonSize)
+                .offset(
+                    x = editButtonXOffset,
+                    y = editButtonYOffset,
+                )
+                .clip(CircleShape)
+                .background(PotiTheme.colors.black)
+                .noRippleClickable(onEditClick),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_edit),
+                contentDescription = null,
+                modifier = Modifier.size(28.dp),
+                tint = PotiTheme.colors.white,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EditableUserProfileImagePreview() {
+    PotiTheme {
+        EditableUserProfileImage(
+            imageUrl = null,
+            onEditClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/component/EditableUserProfileImage.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/EditableUserProfileImage.kt
@@ -2,7 +2,6 @@ package com.poti.android.presentation.user.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
@@ -28,13 +27,9 @@ fun EditableUserProfileImage(
     editButtonSize: Dp = 36.dp,
     editButtonOverhang: Dp = 7.dp,
 ) {
-    val containerWidth = imageSize + editButtonOverhang * 2
-    val editButtonXOffset = imageSize / 2 - editButtonSize / 2 + editButtonOverhang
-    val editButtonYOffset = imageSize / 2 - editButtonSize / 2
-
     Box(
         modifier = modifier.size(
-            width = containerWidth,
+            width = imageSize + editButtonOverhang * 2,
             height = imageSize,
         ),
         contentAlignment = Alignment.Center,
@@ -46,11 +41,8 @@ fun EditableUserProfileImage(
 
         Box(
             modifier = Modifier
+                .align(Alignment.BottomEnd)
                 .size(editButtonSize)
-                .offset(
-                    x = editButtonXOffset,
-                    y = editButtonYOffset,
-                )
                 .clip(CircleShape)
                 .background(PotiTheme.colors.black)
                 .noRippleClickable(onEditClick),

--- a/app/src/main/java/com/poti/android/presentation/user/component/UserProfile.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/UserProfile.kt
@@ -1,25 +1,16 @@
 package com.poti.android.presentation.user.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
-import com.poti.android.R
 import com.poti.android.core.designsystem.theme.PotiTheme
 
 /**
@@ -37,20 +28,7 @@ fun UserProfile(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(imageUrl)
-                .placeholder(R.drawable.img_basic_profile)
-                .error(R.drawable.img_basic_profile)
-                .crossfade(true)
-                .build(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(98.dp)
-                .clip(CircleShape)
-                .background(PotiTheme.colors.gray100),
-        )
+        UserProfileImage(imageUrl = imageUrl)
 
         Spacer(Modifier.height(12.dp))
 

--- a/app/src/main/java/com/poti/android/presentation/user/component/UserProfileImage.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/UserProfileImage.kt
@@ -1,0 +1,47 @@
+package com.poti.android.presentation.user.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.poti.android.R
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+@Composable
+fun UserProfileImage(
+    imageUrl: String?,
+    modifier: Modifier = Modifier,
+    size: Dp = 98.dp,
+) {
+    AsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(imageUrl)
+            .placeholder(R.drawable.img_basic_profile)
+            .error(R.drawable.img_basic_profile)
+            .crossfade(true)
+            .build(),
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(PotiTheme.colors.gray100),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UserProfileImagePreview() {
+    PotiTheme {
+        UserProfileImage(imageUrl = null)
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
@@ -50,8 +50,8 @@ fun EditProfileScreen(
             PotiShortTextField(
                 value = "",
                 onValueChanged = {},
-                label = "닉네임",
-                placeholder = "닉네임",
+                label = stringResource(R.string.profile_nickname),
+                placeholder = stringResource(R.string.profile_nickname),
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
         }

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
@@ -1,0 +1,65 @@
+package com.poti.android.presentation.user.editprofile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.component.field.PotiShortTextField
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.presentation.user.component.EditableUserProfileImage
+
+@Composable
+fun EditProfileRoute(modifier: Modifier = Modifier) {
+}
+
+@Composable
+fun EditProfileScreen(
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        PotiHeaderPage(
+            onNavigationClick = {},
+            title = stringResource(R.string.profile_management),
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState),
+        ) {
+            EditableUserProfileImage(
+                imageUrl = null,
+                onEditClick = {},
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 16.dp, bottom = 24.dp),
+            )
+
+            PotiShortTextField(
+                value = "",
+                onValueChanged = {},
+                label = "닉네임",
+                placeholder = "닉네임",
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EditProfileScreenPreview() {
+    EditProfileScreen()
+}

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
@@ -31,7 +31,7 @@ fun EditProfileScreen(
     ) {
         PotiHeaderPage(
             onNavigationClick = {},
-            title = stringResource(R.string.profile_management),
+            title = stringResource(R.string.profile_management_title),
         )
 
         Column(

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/WithdrawalScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/WithdrawalScreen.kt
@@ -1,0 +1,89 @@
+package com.poti.android.presentation.user.withdrawal
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.component.button.ActionButtonType
+import com.poti.android.core.designsystem.component.button.PotiActionButton
+import com.poti.android.core.designsystem.component.display.PotiListRadio
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.theme.PotiTheme
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+fun WithdrawalRoute(modifier: Modifier = Modifier) {
+}
+
+@Composable
+fun WithdrawalScreen(
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        PotiHeaderPage(
+            onNavigationClick = {},
+            title = stringResource(R.string.withdrawal_title),
+        )
+
+        BoxWithConstraints(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = maxHeight)
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = 16.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.withdrawal_reason_label),
+                    style = PotiTheme.typography.body14m,
+                    color = PotiTheme.colors.gray800,
+                    modifier = Modifier.padding(top = 12.dp, bottom = 8.dp),
+                )
+
+                PotiListRadio(
+                    options = stringArrayResource(R.array.withdrawal_reason_options).toImmutableList(),
+                    selectedOptionIndex = 1,
+                    onClick = {},
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                PotiActionButton(
+                    text = stringResource(R.string.withdrawal_button),
+                    onClick = {},
+                    type = ActionButtonType.DEACTIVE_MAIN,
+                    modifier = Modifier
+                        .padding(top = 4.dp, bottom = 14.dp)
+                        .fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WithdrawalScreenPreview() {
+    WithdrawalScreen()
+}

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/WithdrawalScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/WithdrawalScreen.kt
@@ -1,11 +1,8 @@
 package com.poti.android.presentation.user.withdrawal
 
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -42,7 +39,7 @@ fun WithdrawalScreen(
             title = stringResource(R.string.withdrawal_title),
         )
 
-        BoxWithConstraints(
+        Column(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
@@ -50,7 +47,7 @@ fun WithdrawalScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .heightIn(min = maxHeight)
+                    .weight(1f)
                     .verticalScroll(scrollState)
                     .padding(horizontal = 16.dp),
             ) {
@@ -66,18 +63,17 @@ fun WithdrawalScreen(
                     selectedOptionIndex = 1,
                     onClick = {},
                 )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                PotiActionButton(
-                    text = stringResource(R.string.withdrawal_button),
-                    onClick = {},
-                    type = ActionButtonType.DEACTIVE_MAIN,
-                    modifier = Modifier
-                        .padding(top = 4.dp, bottom = 14.dp)
-                        .fillMaxWidth(),
-                )
             }
+
+            PotiActionButton(
+                text = stringResource(R.string.withdrawal_button),
+                onClick = {},
+                type = ActionButtonType.DEACTIVE_MAIN,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 4.dp, bottom = 14.dp)
+                    .fillMaxWidth(),
+            )
         }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/component/WithdrawalModal.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/component/WithdrawalModal.kt
@@ -1,0 +1,28 @@
+package com.poti.android.presentation.user.withdrawal.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.poti.android.R
+import com.poti.android.core.designsystem.component.modal.PotiSmallModal
+
+@Composable
+fun WithdrawalModal(modifier: Modifier = Modifier) {
+    PotiSmallModal(
+        onDismissRequest = {},
+        title = stringResource(R.string.withdrawal_confirm_modal_title),
+        text = stringResource(R.string.withdrawal_confirm_modal_text),
+        dismissBtnText = stringResource(R.string.withdrawal_confirm_modal_dismiss),
+        confirmBtnText = stringResource(R.string.withdrawal_confirm_modal_confirm),
+        onDismissBtnClick = {},
+        onConfirmBtnClick = {},
+        modifier = modifier,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WithdrawalModalPreview() {
+    WithdrawalModal()
+}

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/component/WithdrawalModal.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/component/WithdrawalModal.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.poti.android.R
+import com.poti.android.core.designsystem.component.button.ModalButtonType
 import com.poti.android.core.designsystem.component.modal.PotiSmallModal
 
 @Composable
@@ -18,6 +19,7 @@ fun WithdrawalModal(modifier: Modifier = Modifier) {
         onDismissBtnClick = {},
         onConfirmBtnClick = {},
         modifier = modifier,
+        confirmBtnType = ModalButtonType.SECONDARY,
     )
 }
 

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/component/WithdrawalUnavailableModal.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/component/WithdrawalUnavailableModal.kt
@@ -1,0 +1,86 @@
+package com.poti.android.presentation.user.withdrawal.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.component.button.ModalButtonType
+import com.poti.android.core.designsystem.component.button.PotiModalButton
+import com.poti.android.core.designsystem.component.modal.PotiModal
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+@Composable
+fun WithdrawalUnavailableModal(
+    onDismissRequest: () -> Unit,
+    onConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PotiModal(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.padding(horizontal = 36.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(top = 36.dp, bottom = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_notice),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(bottom = 12.dp)
+                    .size(48.dp),
+                tint = PotiTheme.colors.sementicRed,
+            )
+
+            Text(
+                text = stringResource(R.string.withdrawal_unavailable_modal_title),
+                color = PotiTheme.colors.black,
+                style = PotiTheme.typography.title18sb,
+                textAlign = TextAlign.Center,
+            )
+
+            Text(
+                text = stringResource(R.string.withdrawal_unavailable_modal_text),
+                modifier = Modifier.padding(top = 8.dp),
+                color = PotiTheme.colors.gray800,
+                style = PotiTheme.typography.body14m,
+                textAlign = TextAlign.Center,
+            )
+
+            PotiModalButton(
+                text = stringResource(R.string.withdrawal_unavailable_modal_confirm),
+                onClick = onConfirmClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 27.dp),
+                type = ModalButtonType.SECONDARY,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WithdrawalUnavailableModalPreview() {
+    PotiTheme {
+        WithdrawalUnavailableModal(
+            onDismissRequest = {},
+            onConfirmClick = {},
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,5 +329,8 @@
     <string name="withdrawal_confirm_modal_text">회원탈퇴 후에는 계정 정보가 모두 삭제되며, 복구할 수 없어요.</string>
     <string name="withdrawal_confirm_modal_dismiss">취소</string>
     <string name="withdrawal_confirm_modal_confirm">탈퇴</string>
+    <string name="withdrawal_unavailable_modal_title">회원 탈퇴를 할 수 없어요</string>
+    <string name="withdrawal_unavailable_modal_text">진행 중인 모집이나 참여 내역이 있어 지금은 탈퇴할 수 없어요. 진행 중인 거래가 모두 종료된 후 다시 시도해 주세요.</string>
+    <string name="withdrawal_unavailable_modal_confirm">확인</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -280,4 +280,16 @@
     <!-- FCM -->
     <string name="default_notification_channel_name">기본 알림</string>
 
+    <!-- Setting -->
+    <string name="setting_title">설정</string>
+    <string name="setting_my_info">내 정보</string>
+    <string name="setting_my_account">내 계정</string>
+    <string name="setting_my_profile">내 프로필 관리</string>
+    <string name="setting_my_address">내 주소 관리</string>
+    <string name="setting_app">앱 설정</string>
+    <string name="setting_alarm">알림 설정</string>
+    <string name="service_info">서비스 정보</string>
+    <string name="setting_personal_info_privacy">개인정보 처리방침 및 이용 약관</string>
+    <string name="version_info">버전 정보</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,4 +299,7 @@
     <string name="account_logout">로그아웃</string>
     <string name="account_withdrawal">회원탈퇴</string>
 
+    <string name="profile_management">내 프로필 관리</string>
+    <string name="profile_nickname">닉네임</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,19 +291,37 @@
     <string name="service_info">서비스 정보</string>
     <string name="setting_personal_info_privacy">개인정보 처리방침 및 이용 약관</string>
     <string name="version_info">버전 정보</string>
+    <string name="setting_menu_account">내 계정</string>
+    <string name="setting_menu_profile_management">내 프로필 관리</string>
+    <string name="setting_menu_address_management">내 주소 관리</string>
 
-    <string name="my_account">내 계정</string>
+    <!-- Account Setting -->
+    <string name="account_setting_title">내 계정</string>
     <string name="account_name">이름</string>
     <string name="account_email">이메일</string>
     <string name="social_account">연결된 소셜 계정</string>
 
     <string name="account_logout">로그아웃</string>
-    <string name="account_withdrawal">회원탈퇴</string>
+    <string name="account_withdrawal_menu">회원탈퇴</string>
 
-    <string name="profile_management">내 프로필 관리</string>
+    <!-- Profile Management -->
+    <string name="profile_management_title">내 프로필 관리</string>
     <string name="profile_nickname">닉네임</string>
 
-    <string name="address_management">내 주소 관리</string>
+    <!-- Address Management -->
+    <string name="address_management_title">내 주소 관리</string>
     <string name="address_name">이름</string>
+
+    <!-- Withdrawal -->
+    <string name="withdrawal_title">회원 탈퇴</string>
+    <string name="withdrawal_reason_label">탈퇴 사유</string>
+    <string name="withdrawal_reason_goods_difficulty">원하는 굿즈를 찾기 어려워요.</string>
+    <string name="withdrawal_reason_process_inconvenient">분철 모집 또는 참여 과정이 불편해요.</string>
+    <string name="withdrawal_reason_lack_features">필요한 기능이 부족해요.</string>
+    <string name="withdrawal_reason_frequent_errors">오류나 버그를 자주 경험했어요.</string>
+    <string name="withdrawal_reason_using_other_service">다른 서비스를 이용하고 있어요.</string>
+    <string name="withdrawal_reason_low_usage">이용 빈도가 낮아요.</string>
+    <string name="withdrawal_reason_etc">기타</string>
+    <string name="withdrawal_button">탈퇴하기</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,6 @@
     <string name="action_button_refresh">초기화</string>
 
     <!-- Field Component -->
-    <string name="field_label_name">이름</string>
     <string name="search_bar_placeholder">검색어를 입력하세요</string>
     <string name="search_message_empty_result">검색 결과가 없어요\n다른 키워드로 다시 검색해보세요</string>
 
@@ -83,19 +82,20 @@
     <string name="party_join_total_price">총 입금 예정 금액</string>
     <string name="party_join_button">참여하기</string>
     <string name="party_join_order_info">주문자 정보</string>
-    <string name="party_join_order_name_placeholder">이름을 입력하세요</string>
-    <string name="party_join_order_name_error">이름을 입력해주세요</string>
-    <string name="party_join_order_postal_label">우편번호</string>
-    <string name="party_join_order_postal_placeholder">우편번호를 입력하세요</string>
-    <string name="party_join_order_postal_error">우편번호를 입력해주세요</string>
-    <string name="party_join_order_address_label">주소</string>
-    <string name="party_join_order_address_placeholder">주소를 입력하세요</string>
-    <string name="party_join_order_address_error">주소를 입력해주세요</string>
-    <string name="party_join_order_detail_address_label">상세주소</string>
-    <string name="party_join_order_detail_address_placeholder">상세주소를 입력하세요</string>
-    <string name="party_join_order_contact_label">연락처</string>
-    <string name="party_join_order_contact_placeholder">연락처를 입력하세요</string>
-    <string name="party_join_order_contact_error">연락처를 입력해주세요</string>
+    <string name="delivery_name_label">이름</string>
+    <string name="delivery_name_placeholder">이름을 입력하세요</string>
+    <string name="delivery_name_error">이름을 입력해주세요</string>
+    <string name="delivery_postal_label">우편번호</string>
+    <string name="delivery_postal_placeholder">우편번호를 입력하세요</string>
+    <string name="delivery_postal_error">우편번호를 입력해주세요</string>
+    <string name="delivery_address_label">주소</string>
+    <string name="delivery_address_placeholder">주소를 입력하세요</string>
+    <string name="delivery_address_error">주소를 입력해주세요</string>
+    <string name="delivery_detail_address_label">상세주소</string>
+    <string name="delivery_detail_address_placeholder">상세주소를 입력하세요</string>
+    <string name="delivery_contact_label">연락처</string>
+    <string name="delivery_contact_placeholder">연락처를 입력하세요</string>
+    <string name="delivery_contact_error">연락처를 입력해주세요</string>
     <string name="party_join_confirm_modal_title">참여가 완료되었어요</string>
     <string name="party_join_confirm_modal_text">모집이 끝나면 입금이 시작돼요</string>
     <string name="party_join_notice_modal_title">참여자 안내 사항</string>
@@ -283,15 +283,13 @@
     <!-- Setting -->
     <string name="setting_title">설정</string>
     <string name="setting_my_info">내 정보</string>
-    <string name="setting_my_account">내 계정</string>
-    <string name="setting_my_profile">내 프로필 관리</string>
-    <string name="setting_my_address">내 주소 관리</string>
     <string name="setting_app">앱 설정</string>
     <string name="setting_alarm">알림 설정</string>
     <string name="service_info">서비스 정보</string>
     <string name="setting_personal_info_privacy">개인정보 처리방침 및 이용 약관</string>
     <string name="version_info">버전 정보</string>
 
+    <string name="my_account">내 계정</string>
     <string name="account_name">이름</string>
     <string name="account_email">이메일</string>
     <string name="social_account">연결된 소셜 계정</string>
@@ -301,5 +299,8 @@
 
     <string name="profile_management">내 프로필 관리</string>
     <string name="profile_nickname">닉네임</string>
+
+    <string name="address_management">내 주소 관리</string>
+    <string name="address_name">이름</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,4 +292,11 @@
     <string name="setting_personal_info_privacy">개인정보 처리방침 및 이용 약관</string>
     <string name="version_info">버전 정보</string>
 
+    <string name="account_name">이름</string>
+    <string name="account_email">이메일</string>
+    <string name="social_account">연결된 소셜 계정</string>
+
+    <string name="account_logout">로그아웃</string>
+    <string name="account_withdrawal">회원탈퇴</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,13 +315,15 @@
     <!-- Withdrawal -->
     <string name="withdrawal_title">회원 탈퇴</string>
     <string name="withdrawal_reason_label">탈퇴 사유</string>
-    <string name="withdrawal_reason_goods_difficulty">원하는 굿즈를 찾기 어려워요.</string>
-    <string name="withdrawal_reason_process_inconvenient">분철 모집 또는 참여 과정이 불편해요.</string>
-    <string name="withdrawal_reason_lack_features">필요한 기능이 부족해요.</string>
-    <string name="withdrawal_reason_frequent_errors">오류나 버그를 자주 경험했어요.</string>
-    <string name="withdrawal_reason_using_other_service">다른 서비스를 이용하고 있어요.</string>
-    <string name="withdrawal_reason_low_usage">이용 빈도가 낮아요.</string>
-    <string name="withdrawal_reason_etc">기타</string>
+    <string-array name="withdrawal_reason_options">
+        <item>원하는 굿즈를 찾기 어려워요.</item>
+        <item>분철 모집 또는 참여 과정이 불편해요.</item>
+        <item>필요한 기능이 부족해요.</item>
+        <item>오류나 버그를 자주 경험했어요.</item>
+        <item>다른 서비스를 이용하고 있어요.</item>
+        <item>이용 빈도가 낮아요.</item>
+        <item>기타</item>
+    </string-array>
     <string name="withdrawal_button">탈퇴하기</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,10 +22,27 @@
     <string name="action_button_confirm">확인</string>
     <string name="action_button_select_all">전체 선택</string>
     <string name="action_button_refresh">초기화</string>
+    <string name="action_button_save">저장</string>
 
     <!-- Field Component -->
     <string name="search_bar_placeholder">검색어를 입력하세요</string>
     <string name="search_message_empty_result">검색 결과가 없어요\n다른 키워드로 다시 검색해보세요</string>
+
+    <!-- Delivery Field -->
+    <string name="delivery_name_label">이름</string>
+    <string name="delivery_name_placeholder">이름을 입력하세요</string>
+    <string name="delivery_name_error">이름을 입력해주세요</string>
+    <string name="delivery_postal_label">우편번호</string>
+    <string name="delivery_postal_placeholder">우편번호를 입력하세요</string>
+    <string name="delivery_postal_error">우편번호를 입력해주세요</string>
+    <string name="delivery_address_label">주소</string>
+    <string name="delivery_address_placeholder">주소를 입력하세요</string>
+    <string name="delivery_address_error">주소를 입력해주세요</string>
+    <string name="delivery_detail_address_label">상세주소</string>
+    <string name="delivery_detail_address_placeholder">상세주소를 입력하세요</string>
+    <string name="delivery_contact_label">연락처</string>
+    <string name="delivery_contact_placeholder">연락처를 입력하세요</string>
+    <string name="delivery_contact_error">연락처를 입력해주세요</string>
 
 
     <!-- LoginScreen -->
@@ -82,20 +99,6 @@
     <string name="party_join_total_price">총 입금 예정 금액</string>
     <string name="party_join_button">참여하기</string>
     <string name="party_join_order_info">주문자 정보</string>
-    <string name="delivery_name_label">이름</string>
-    <string name="delivery_name_placeholder">이름을 입력하세요</string>
-    <string name="delivery_name_error">이름을 입력해주세요</string>
-    <string name="delivery_postal_label">우편번호</string>
-    <string name="delivery_postal_placeholder">우편번호를 입력하세요</string>
-    <string name="delivery_postal_error">우편번호를 입력해주세요</string>
-    <string name="delivery_address_label">주소</string>
-    <string name="delivery_address_placeholder">주소를 입력하세요</string>
-    <string name="delivery_address_error">주소를 입력해주세요</string>
-    <string name="delivery_detail_address_label">상세주소</string>
-    <string name="delivery_detail_address_placeholder">상세주소를 입력하세요</string>
-    <string name="delivery_contact_label">연락처</string>
-    <string name="delivery_contact_placeholder">연락처를 입력하세요</string>
-    <string name="delivery_contact_error">연락처를 입력해주세요</string>
     <string name="party_join_confirm_modal_title">참여가 완료되었어요</string>
     <string name="party_join_confirm_modal_text">모집이 끝나면 입금이 시작돼요</string>
     <string name="party_join_notice_modal_title">참여자 안내 사항</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,5 +325,9 @@
         <item>기타</item>
     </string-array>
     <string name="withdrawal_button">탈퇴하기</string>
+    <string name="withdrawal_confirm_modal_title">정말 탈퇴하시겠어요?</string>
+    <string name="withdrawal_confirm_modal_text">회원탈퇴 후에는 계정 정보가 모두 삭제되며, 복구할 수 없어요.</string>
+    <string name="withdrawal_confirm_modal_dismiss">취소</string>
+    <string name="withdrawal_confirm_modal_confirm">탈퇴</string>
 
 </resources>


### PR DESCRIPTION
## Related issue 🛠️
- closed #182

## Work Description ✏️
<!--작업 내용을 작성해주세요-->

### 설정 화면 구현

- 설정 화면 UI를 추가했습니다.
- 내 정보, 앱 설정, 서비스 정보 섹션을 구성했습니다.
- 설정 화면에 스크롤을 적용해 작은 화면에서도 전체 메뉴를 확인할 수 있도록 했습니다.

### 사용자 관리 화면 구현

- 내 계정 화면 UI를 추가했습니다.
- 내 프로필 관리 화면 UI를 추가했습니다.
- 내 주소 관리 화면 UI를 추가했습니다.
- 주소 입력 필드에 공통 배송지 문자열 리소스를 적용했습니다.
- 우편번호 입력 필드에 검색 아이콘을 추가했습니다.
- 화면 높이가 충분할 때는 저장 버튼이 하단에 위치하고, 작은 화면에서는 입력 영역과 함께 스크롤되도록 구성했습니다.

### 회원 탈퇴 UI 구현

- 회원 탈퇴 사유 선택 화면을 추가했습니다.
- 탈퇴 사유 문자열을 string-array 리소스로 분리했습니다.
- 탈퇴 확인 모달을 추가했습니다.
- 진행 중인 거래가 있어 탈퇴할 수 없는 경우를 위한 탈퇴 불가 안내 모달을 추가했습니다.

### 공통 컴포넌트 정리

- UserProfileImage 컴포넌트를 분리해 프로필 이미지 UI를 재사용할 수 있도록 했습니다.
- EditableUserProfileImage 컴포넌트를 추가해 프로필 편집 화면에서 사용할 수 있도록 했습니다.
- PotiSmallModal 텍스트를 가운데 정렬하도록 수정했습니다.
- PotiListRadio의 패딩 구조를 조정하고, 기존 사용처의 간격이 달라지지 않도록 반영했습니다.

### 문자열 리소스 정리

- 설정, 계정, 프로필 관리, 주소 관리, 회원 탈퇴 화면에 사용되는 문구를 string resource로 분리했습니다.
- 배송지 입력 필드에서 공통으로 사용할 수 있도록 delivery_* 문자열 리소스를 정리했습니다.
- 프로필 관리 화면의 닉네임 입력 필드 문구를 string resource로 분리했습니다.

## Screenshot 📸

| 설정 화면 | 내 계정 관리 | 내 주소 관리 |
| --- | --- | --- |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/6007e625-c1e6-460c-8e64-1a92b31eb787" />| <img width="250" alt="image" src="https://github.com/user-attachments/assets/a94b1060-872c-4aa0-9798-2e5387967d79" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/06c52b8b-a82c-4153-be58-ebe1bb1b9214" /> |

| 내 프로필 관리 | 회원 탈퇴 |
| --- | --- |
| <img width="269" height="578" alt="image" src="https://github.com/user-attachments/assets/40d6038f-79c9-46b9-83ef-35748a6096f1" /> | <img width="267" height="582" alt="image" src="https://github.com/user-attachments/assets/e062d930-47cb-4191-a527-4e7d5afa01c1" /> |

| 탈퇴 확인 모달 | 탈퇴 불가 모달 |
| --- | --- |
| <img width="330" height="211" alt="image" src="https://github.com/user-attachments/assets/bcaac9b7-be55-4478-83ee-bcb9ab81ad84" /> | <img width="325" height="261" alt="image" src="https://github.com/user-attachments/assets/28ca9808-a0af-4949-b68d-24f6c74ecb1f" /> |

## Uncompleted Tasks 😅
- [ ] 내비게이션 연결
- [ ] Contracts.kt 작성
- [ ] ViewModel 로직 구현
- [ ] API 연결

## To Reviewers 📢

- 이번 PR은 설정 및 사용자 관리 관련 UI 구현 중심입니다.
- Route의 실제 내비게이션/이벤트 연결과 API 연동은 후속 작업에서 진행할 예정입니다.
- PotiListRadio의 기본 패딩 구조를 변경하면서 기존 바텀시트 사용처의 간격이 달라지지 않도록 함께 조정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 설정, 계정 설정, 프로필 편집, 주소 관리, 회원 탈퇴 화면을 추가했습니다.
  * 프로필 이미지 표시·편집과 회원 탈퇴 확인·불가 안내 모달을 제공합니다.
  * 배송 정보 입력 문구와 탈퇴 사유 선택 항목을 추가했습니다.

* **개선**
  * 라디오 목록과 모달의 여백 및 텍스트 정렬을 개선했습니다.
  * 정렬 선택 화면의 하단 여백을 조정했습니다.
  * 모달 확인 버튼 유형을 상황에 맞게 설정할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->