### PR TITLE
[Feat/#162] 분철팟 상세 공유 기능

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -77,6 +77,17 @@ jobs:
                   GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
               run: echo "${GOOGLE_SERVICES_JSON}" > app/google-services.json
 
+            - name: Create debug.keystore
+              if: steps.changes.outputs.android == 'true'
+              env:
+                  DEBUG_KEYSTORE: ${{ secrets.DEBUG_KEYSTORE }}
+              run: |
+                  if [ -z "$DEBUG_KEYSTORE" ]; then
+                    echo "::error::DEBUG_KEYSTORE secret is not set. Register it with: base64 -w0 app/debug.keystore"
+                    exit 1
+                  fi
+                  echo "$DEBUG_KEYSTORE" | base64 -d > app/debug.keystore
+
             - name: Run ktlintCheck
               if: steps.changes.outputs.android == 'true'
               id: ktlint

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,7 @@ dependencies {
 
     // Kakao
     implementation(libs.kakao.user)
+    implementation(libs.kakao.share)
 
     // Firebase
     implementation(platform(libs.firebase.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,8 +41,18 @@ android {
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] = kakaoNativeAppKey
     }
 
+    signingConfigs {
+        getByName("debug") {
+            storeFile = file("debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     buildTypes {
         debug {
+            signingConfig = signingConfigs.getByName("debug")
             buildConfigField("boolean", "USE_UI_MOCK", "false")
         }
         create("mock") {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,12 @@
 
     <queries>
         <package android:name="com.kakao.talk"/>
+        <package android:name="com.twitter.android"/>
+
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="market" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,16 @@
                     android:scheme="https"
                     android:host="${deepLinkHost}" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="kakao${KAKAO_NATIVE_APP_KEY}"
+                    android:host="kakaolink" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
+++ b/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
@@ -2,12 +2,12 @@ package com.poti.android.core.common.extension
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
 import androidx.core.net.toUri
 
 private const val X_PACKAGE_NAME = "com.twitter.android"
-private const val PLAY_STORE_MARKET_URL = "market://details?id="
-private const val PLAY_STORE_WEB_URL = "https://play.google.com/store/apps/details?id="
+private const val X_WEB_INTENT_URL = "https://x.com/intent/post?text="
 
 fun Context.toast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
@@ -22,7 +22,7 @@ fun Context.shareText(title: String, text: String) {
 }
 
 fun Context.shareTextToX(text: String) {
-    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+    val appIntent = Intent(Intent.ACTION_SEND).apply {
         type = "text/plain"
         putExtra(Intent.EXTRA_TEXT, text)
         setPackage(X_PACKAGE_NAME)
@@ -32,15 +32,9 @@ fun Context.shareTextToX(text: String) {
                 Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS,
         )
     }
+    val webIntent = Intent(Intent.ACTION_VIEW, "$X_WEB_INTENT_URL${Uri.encode(text)}".toUri())
 
-    runCatching { startActivity(shareIntent) }
-        .recoverCatching { openPlayStore(X_PACKAGE_NAME) }
-}
-
-fun Context.openPlayStore(packageName: String) {
-    val marketIntent = Intent(Intent.ACTION_VIEW, "$PLAY_STORE_MARKET_URL$packageName".toUri())
-    val webIntent = Intent(Intent.ACTION_VIEW, "$PLAY_STORE_WEB_URL$packageName".toUri())
-
-    runCatching { startActivity(marketIntent) }
+    runCatching { startActivity(appIntent) }
         .recoverCatching { startActivity(webIntent) }
 }
+

--- a/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
+++ b/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
@@ -26,6 +26,11 @@ fun Context.shareTextToX(text: String) {
         type = "text/plain"
         putExtra(Intent.EXTRA_TEXT, text)
         setPackage(X_PACKAGE_NAME)
+        addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_MULTIPLE_TASK or
+                Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS,
+        )
     }
 
     runCatching { startActivity(shareIntent) }

--- a/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
+++ b/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
 import androidx.core.net.toUri
+import timber.log.Timber
 
 private const val X_PACKAGE_NAME = "com.twitter.android"
 private const val X_WEB_INTENT_URL = "https://x.com/intent/post?text="
@@ -13,7 +14,10 @@ fun Context.toast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
 }
 
-fun Context.shareText(title: String, text: String) {
+fun Context.shareText(
+    title: String,
+    text: String,
+) {
     val sendIntent = Intent(Intent.ACTION_SEND).apply {
         type = "text/plain"
         putExtra(Intent.EXTRA_TEXT, text)
@@ -36,5 +40,5 @@ fun Context.shareTextToX(text: String) {
 
     runCatching { startActivity(appIntent) }
         .recoverCatching { startActivity(webIntent) }
+        .onFailure { Timber.e(it, "X 공유 실패") }
 }
-

--- a/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
+++ b/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
@@ -3,6 +3,11 @@ package com.poti.android.core.common.extension
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
+import androidx.core.net.toUri
+
+private const val X_PACKAGE_NAME = "com.twitter.android"
+private const val PLAY_STORE_MARKET_URL = "market://details?id="
+private const val PLAY_STORE_WEB_URL = "https://play.google.com/store/apps/details?id="
 
 fun Context.toast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
@@ -14,4 +19,23 @@ fun Context.shareText(title: String, text: String) {
         putExtra(Intent.EXTRA_TEXT, text)
     }
     startActivity(Intent.createChooser(sendIntent, title))
+}
+
+fun Context.shareTextToX(text: String) {
+    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+        setPackage(X_PACKAGE_NAME)
+    }
+
+    runCatching { startActivity(shareIntent) }
+        .recoverCatching { openPlayStore(X_PACKAGE_NAME) }
+}
+
+fun Context.openPlayStore(packageName: String) {
+    val marketIntent = Intent(Intent.ACTION_VIEW, "$PLAY_STORE_MARKET_URL$packageName".toUri())
+    val webIntent = Intent(Intent.ACTION_VIEW, "$PLAY_STORE_WEB_URL$packageName".toUri())
+
+    runCatching { startActivity(marketIntent) }
+        .recoverCatching { startActivity(webIntent) }
 }

--- a/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
+++ b/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
@@ -1,8 +1,17 @@
 package com.poti.android.core.common.extension
 
 import android.content.Context
+import android.content.Intent
 import android.widget.Toast
 
 fun Context.toast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}
+
+fun Context.shareText(title: String, text: String) {
+    val sendIntent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    startActivity(Intent.createChooser(sendIntent, title))
 }

--- a/app/src/main/java/com/poti/android/core/share/KakaoShareLauncher.kt
+++ b/app/src/main/java/com/poti/android/core/share/KakaoShareLauncher.kt
@@ -1,0 +1,59 @@
+package com.poti.android.core.share
+
+import android.content.Context
+import android.content.Intent
+import com.kakao.sdk.share.ShareClient
+import com.kakao.sdk.share.WebSharerClient
+import com.kakao.sdk.template.model.Content
+import com.kakao.sdk.template.model.FeedTemplate
+import com.kakao.sdk.template.model.Link
+import timber.log.Timber
+
+object KakaoShareLauncher {
+    const val LINK_HOST = "kakaolink"
+    const val PARAM_DEEP_LINK = "deepLink"
+
+    fun share(
+        context: Context,
+        title: String,
+        description: String,
+        imageUrl: String,
+        deepLink: String,
+    ) {
+        val template = FeedTemplate(
+            content = Content(
+                title = title,
+                description = description,
+                imageUrl = imageUrl,
+                link = Link(
+                    webUrl = deepLink,
+                    mobileWebUrl = deepLink,
+                    androidExecutionParams = mapOf(PARAM_DEEP_LINK to deepLink),
+                ),
+            ),
+        )
+
+        if (ShareClient.instance.isKakaoTalkSharingAvailable(context)) {
+            ShareClient.instance.shareDefault(context, template) { sharingResult, error ->
+                if (sharingResult != null) {
+                    context.startActivity(sharingResult.intent)
+                } else {
+                    Timber.e(error, "카카오톡 공유 실패")
+                }
+            }
+        } else {
+            shareWithWebSharer(context, template)
+        }
+    }
+
+    private fun shareWithWebSharer(
+        context: Context,
+        template: FeedTemplate,
+    ) {
+        runCatching {
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, WebSharerClient.instance.makeDefaultUrl(template)),
+            )
+        }.onFailure { Timber.e(it, "카카오 웹 공유 실패") }
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
@@ -15,12 +15,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import com.poti.android.core.auth.SocialLoginLauncher
 import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.share.KakaoShareLauncher
 import com.poti.android.domain.manager.AuthSessionManager
 import com.poti.android.presentation.party.PartyGraph
 import dagger.hilt.android.AndroidEntryPoint
@@ -61,7 +63,7 @@ class MainActivity : ComponentActivity() {
 
         requestNotificationPermission()
 
-        pendingDeepLink = intent?.data
+        pendingDeepLink = intent?.resolveDeepLink()
         intent?.data = null
 
         setContent {
@@ -98,7 +100,7 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
 
-        val uri = intent.data ?: return
+        val uri = intent.resolveDeepLink() ?: return
         intent.data = null
 
         if (viewModel.startDestination.value == PartyGraph) {
@@ -106,6 +108,13 @@ class MainActivity : ComponentActivity() {
         } else {
             pendingDeepLink = uri
         }
+    }
+
+    private fun Intent.resolveDeepLink(): Uri? {
+        val uri = data ?: return null
+        if (uri.host != KakaoShareLauncher.LINK_HOST) return uri
+
+        return uri.getQueryParameter(KakaoShareLauncher.PARAM_DEEP_LINK)?.toUri()
     }
 
     private fun consumeDeepLink(navController: NavHostController) {

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
@@ -41,7 +41,7 @@ import com.poti.android.presentation.party.detail.component.PartyDetailContent
 import com.poti.android.presentation.party.detail.component.PartyDetailHeaderInfo
 import com.poti.android.presentation.party.detail.component.PartyJoinBottomSheet
 import com.poti.android.presentation.party.detail.component.PartyParticipantsInfo
-import com.poti.android.presentation.party.detail.component.PartySharedButton
+import com.poti.android.presentation.party.detail.component.PartyShareButton
 import com.poti.android.presentation.party.detail.component.PartyUploaderInfo
 import com.poti.android.presentation.party.detail.model.PartyDetailEffect
 import com.poti.android.presentation.party.detail.model.PartyDetailIntent
@@ -189,17 +189,17 @@ private fun PartyDetailScreen(
             PotiDivider(styleType = PotiDividerStyle.LARGE)
 
             Text("System Share Sheet", Modifier.align(Alignment.CenterHorizontally))
-            PartySharedButton(
+            PartyShareButton(
                 onClick = onSystemShareClick,
             )
 
             Text("Kakao Share SDK", Modifier.align(Alignment.CenterHorizontally))
-            PartySharedButton(
+            PartyShareButton(
                 onClick = onKakaoShareClick,
             )
 
             Text("X(twitter) Intent", Modifier.align(Alignment.CenterHorizontally))
-            PartySharedButton(
+            PartyShareButton(
                 onClick = onXShareClick,
             )
 

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -22,6 +23,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.poti.android.R
 import com.poti.android.core.common.extension.onSuccess
+import com.poti.android.core.common.extension.shareText
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
@@ -35,6 +37,7 @@ import com.poti.android.presentation.party.detail.component.PartyDetailContent
 import com.poti.android.presentation.party.detail.component.PartyDetailHeaderInfo
 import com.poti.android.presentation.party.detail.component.PartyJoinBottomSheet
 import com.poti.android.presentation.party.detail.component.PartyParticipantsInfo
+import com.poti.android.presentation.party.detail.component.PartySharedButton
 import com.poti.android.presentation.party.detail.component.PartyUploaderInfo
 import com.poti.android.presentation.party.detail.model.PartyDetailEffect
 import com.poti.android.presentation.party.detail.model.PartyDetailIntent
@@ -50,6 +53,8 @@ fun PartyDetailRoute(
     modifier: Modifier = Modifier,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val shareChooserTitle = stringResource(R.string.party_detail_share_chooser_title)
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
@@ -57,6 +62,7 @@ fun PartyDetailRoute(
             PartyDetailEffect.NavigateToJoin -> onNavigateToJoin()
             is PartyDetailEffect.NavigateToProfile -> onNavigateToProfile(effect.userId)
             is PartyDetailEffect.ReloadDetail -> onReload(effect.partyId)
+            is PartyDetailEffect.SharePartyDetail -> context.shareText(shareChooserTitle, effect.shareText)
         }
     }
 
@@ -78,6 +84,7 @@ fun PartyDetailRoute(
             onBackClick = { viewModel.processIntent(PartyDetailIntent.OnBackClick) },
             onJoinClick = { viewModel.processIntent(PartyDetailIntent.OnDetailJoinClick) },
             onUploaderClick = { viewModel.processIntent(PartyDetailIntent.OnUploaderClick(it)) },
+            onShareClick = { viewModel.processIntent(PartyDetailIntent.OnShareClick) },
             modifier = modifier,
         )
     }
@@ -90,6 +97,7 @@ private fun PartyDetailScreen(
     onBackClick: () -> Unit,
     onJoinClick: () -> Unit,
     onUploaderClick: (Long) -> Unit,
+    onShareClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -165,6 +173,10 @@ private fun PartyDetailScreen(
 
             PotiDivider(styleType = PotiDividerStyle.LARGE)
 
+            PartySharedButton(
+                onClick = onShareClick,
+            )
+
             ParticipantGuidelines()
         }
     }
@@ -180,6 +192,7 @@ private fun PartyDetailScreenPreview() {
             onBackClick = {},
             onJoinClick = {},
             onUploaderClick = {},
+            onShareClick = {},
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
@@ -33,6 +33,7 @@ import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.navigation.PotiBottomButton
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.core.share.KakaoShareLauncher
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.domain.model.party.PartyDetail
 import com.poti.android.presentation.party.detail.component.ParticipantGuidelines
@@ -66,7 +67,13 @@ fun PartyDetailRoute(
             is PartyDetailEffect.NavigateToProfile -> onNavigateToProfile(effect.userId)
             is PartyDetailEffect.ReloadDetail -> onReload(effect.partyId)
             is PartyDetailEffect.ShareToSystem -> context.shareText(shareChooserTitle, effect.shareText)
-            is PartyDetailEffect.ShareToKakao -> Unit // TODO: 카카오 공유 SDK 연동 후 구현
+            is PartyDetailEffect.ShareToKakao -> KakaoShareLauncher.share(
+                context = context,
+                title = effect.title,
+                description = effect.description,
+                imageUrl = effect.imageUrl,
+                deepLink = effect.deepLink,
+            )
             is PartyDetailEffect.ShareToX -> context.shareTextToX(effect.shareText)
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
@@ -11,8 +11,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -24,6 +26,7 @@ import coil.compose.AsyncImage
 import com.poti.android.R
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.extension.shareText
+import com.poti.android.core.common.extension.shareTextToX
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
@@ -62,7 +65,9 @@ fun PartyDetailRoute(
             PartyDetailEffect.NavigateToJoin -> onNavigateToJoin()
             is PartyDetailEffect.NavigateToProfile -> onNavigateToProfile(effect.userId)
             is PartyDetailEffect.ReloadDetail -> onReload(effect.partyId)
-            is PartyDetailEffect.SharePartyDetail -> context.shareText(shareChooserTitle, effect.shareText)
+            is PartyDetailEffect.ShareToSystem -> context.shareText(shareChooserTitle, effect.shareText)
+            is PartyDetailEffect.ShareToKakao -> Unit // TODO: 카카오 공유 SDK 연동 후 구현
+            is PartyDetailEffect.ShareToX -> context.shareTextToX(effect.shareText)
         }
     }
 
@@ -84,7 +89,9 @@ fun PartyDetailRoute(
             onBackClick = { viewModel.processIntent(PartyDetailIntent.OnBackClick) },
             onJoinClick = { viewModel.processIntent(PartyDetailIntent.OnDetailJoinClick) },
             onUploaderClick = { viewModel.processIntent(PartyDetailIntent.OnUploaderClick(it)) },
-            onShareClick = { viewModel.processIntent(PartyDetailIntent.OnShareClick) },
+            onSystemShareClick = { viewModel.processIntent(PartyDetailIntent.OnSystemShareClick) },
+            onKakaoShareClick = { viewModel.processIntent(PartyDetailIntent.OnKakaoShareClick) },
+            onXShareClick = { viewModel.processIntent(PartyDetailIntent.OnXShareClick) },
             modifier = modifier,
         )
     }
@@ -97,7 +104,9 @@ private fun PartyDetailScreen(
     onBackClick: () -> Unit,
     onJoinClick: () -> Unit,
     onUploaderClick: (Long) -> Unit,
-    onShareClick: () -> Unit,
+    onSystemShareClick: () -> Unit,
+    onKakaoShareClick: () -> Unit,
+    onXShareClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -172,8 +181,19 @@ private fun PartyDetailScreen(
 
             PotiDivider(styleType = PotiDividerStyle.LARGE)
 
+            Text("System Share Sheet", Modifier.align(Alignment.CenterHorizontally))
             PartySharedButton(
-                onClick = onShareClick,
+                onClick = onSystemShareClick,
+            )
+
+            Text("Kakao Share SDK", Modifier.align(Alignment.CenterHorizontally))
+            PartySharedButton(
+                onClick = onKakaoShareClick,
+            )
+
+            Text("X(twitter) Intent", Modifier.align(Alignment.CenterHorizontally))
+            PartySharedButton(
+                onClick = onXShareClick,
             )
 
             ParticipantGuidelines()
@@ -191,7 +211,9 @@ private fun PartyDetailScreenPreview() {
             onBackClick = {},
             onJoinClick = {},
             onUploaderClick = {},
-            onShareClick = {},
+            onSystemShareClick = {},
+            onKakaoShareClick = {},
+            onXShareClick = {},
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
@@ -19,6 +19,7 @@ import com.poti.android.presentation.party.detail.model.PartyDetailEffect.*
 import com.poti.android.presentation.party.detail.model.PartyDetailIntent
 import com.poti.android.presentation.party.detail.model.PartyDetailUiState
 import com.poti.android.presentation.party.detail.navigation.PartyDetailGraph
+import com.poti.android.presentation.party.detail.navigation.partyDetailDeepLink
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import timber.log.Timber
@@ -61,8 +62,11 @@ class PartyDetailViewModel @Inject constructor(
                 updateState { copy(isJoinSuccessDialogVisible = false) }
                 sendEffect(ReloadDetail(partyId))
             }
+            PartyDetailIntent.OnShareClick -> sendEffect(SharePartyDetail(buildShareText(partyId)))
         }
     }
+
+    private fun buildShareText(partyId: Long): String = partyDetailDeepLink(partyId)
 
     private fun fetchPartyDetail() = launchScope {
         updateState { copy(partyDetail = ApiState.Loading) }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
@@ -70,7 +70,9 @@ class PartyDetailViewModel @Inject constructor(
                 updateState { copy(isJoinSuccessDialogVisible = false) }
                 sendEffect(ReloadDetail(partyId))
             }
-            PartyDetailIntent.OnShareClick -> sendEffect(SharePartyDetail(buildShareText(partyId)))
+            PartyDetailIntent.OnSystemShareClick -> sendEffect(ShareToSystem(buildShareText(partyId)))
+            PartyDetailIntent.OnKakaoShareClick -> sendEffect(ShareToKakao(buildShareText(partyId)))
+            PartyDetailIntent.OnXShareClick -> sendEffect(ShareToX(buildShareText(partyId)))
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.poti.android.presentation.party.detail
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.extension.getSuccessDataOrNull
 import com.poti.android.core.common.extension.toMoneyString
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.core.designsystem.component.field.FieldMenuItem
@@ -70,13 +71,24 @@ class PartyDetailViewModel @Inject constructor(
                 updateState { copy(isJoinSuccessDialogVisible = false) }
                 sendEffect(ReloadDetail(partyId))
             }
-            PartyDetailIntent.OnSystemShareClick -> sendEffect(ShareToSystem(buildShareText(partyId)))
-            PartyDetailIntent.OnKakaoShareClick -> sendEffect(ShareToKakao(buildShareText(partyId)))
-            PartyDetailIntent.OnXShareClick -> sendEffect(ShareToX(buildShareText(partyId)))
+            PartyDetailIntent.OnSystemShareClick -> sendEffect(ShareToSystem(partyDetailDeepLink(partyId)))
+            PartyDetailIntent.OnKakaoShareClick -> handleKakaoShare()
+            PartyDetailIntent.OnXShareClick -> sendEffect(ShareToX(partyDetailDeepLink(partyId)))
         }
     }
 
-    private fun buildShareText(partyId: Long): String = partyDetailDeepLink(partyId)
+    private fun handleKakaoShare() {
+        val partyDetail = uiState.value.partyDetail.getSuccessDataOrNull() ?: return
+
+        sendEffect(
+            ShareToKakao(
+                title = partyDetail.title,
+                description = "${partyDetail.artist} · ${partyDetail.currentCount}/${partyDetail.totalCount}명 모집 중",
+                imageUrl = partyDetail.images.firstOrNull()?.imageUrl.orEmpty(),
+                deepLink = partyDetailDeepLink(partyId),
+            ),
+        )
+    }
 
     private fun fetchPartyDetail() = launchScope {
         updateState { copy(partyDetail = ApiState.Loading) }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyParticipantsInfo.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyParticipantsInfo.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.poti.android.R
+import com.poti.android.core.designsystem.component.display.PotiEmptyStateInline
 import com.poti.android.core.designsystem.component.display.PotiPrimaryTag
 import com.poti.android.core.designsystem.component.display.PotiPrimaryTagColor
 import com.poti.android.core.designsystem.component.display.PotiPrimaryTagSize
@@ -45,26 +46,32 @@ fun PartyParticipantsInfo(
             )
         }
 
-        partyDetail.participants.forEach { participant ->
-            participant.selectedMembers.forEach { selectedMember ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    PotiProfileSummary(
-                        profileImageUrl = participant.profileImage,
-                        nickname = participant.nickname,
-                        sizeType = PotiProfileSummarySize.LARGE,
-                        rating = participant.rating.toString(),
-                        modifier = Modifier.weight(1f),
-                    )
+        if (partyDetail.participants.isNotEmpty()) {
+            partyDetail.participants.forEach { participant ->
+                participant.selectedMembers.forEach { selectedMember ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        PotiProfileSummary(
+                            profileImageUrl = participant.profileImage,
+                            nickname = participant.nickname,
+                            sizeType = PotiProfileSummarySize.LARGE,
+                            rating = participant.rating.toString(),
+                            modifier = Modifier.weight(1f),
+                        )
 
-                    PotiPrimaryTag(
-                        text = selectedMember,
-                        colorType = PotiPrimaryTagColor.GRAY,
-                        sizeType = PotiPrimaryTagSize.LARGE,
-                    )
+                        PotiPrimaryTag(
+                            text = selectedMember,
+                            colorType = PotiPrimaryTagColor.GRAY,
+                            sizeType = PotiPrimaryTagSize.LARGE,
+                        )
+                    }
                 }
             }
+        } else {
+            PotiEmptyStateInline(
+                text = stringResource(R.string.party_detail_participants_empty),
+            )
         }
     }
 }
@@ -75,6 +82,16 @@ private fun PartyParticipantsInfoPreview() {
     PotiTheme {
         PartyParticipantsInfo(
             partyDetail = UiMockData.partyDetail,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PartyParticipantsInfoPreviewEmpty() {
+    PotiTheme {
+        PartyParticipantsInfo(
+            partyDetail = UiMockData.partyDetail.copy(participants = emptyList()),
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/component/PartySharedButton.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/component/PartySharedButton.kt
@@ -1,0 +1,62 @@
+package com.poti.android.presentation.party.detail.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.core.common.extension.noRippleClickable
+import com.poti.android.R
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+@Composable
+fun PartySharedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .noRippleClickable(onClick)
+            .padding(vertical = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(
+            space = 8.dp,
+            alignment = Alignment.CenterHorizontally,
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_share),
+            contentDescription = null,
+            tint = PotiTheme.colors.gray800,
+            modifier = Modifier.size(24.dp),
+        )
+
+        Text(
+            text = stringResource(R.string.party_detail_share_button),
+            color = PotiTheme.colors.gray800,
+            style = PotiTheme.typography.button14sb,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PartySharedButtonPreview() {
+    PotiTheme {
+        PartySharedButton(
+            onClick = { },
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/party/detail/component/PartySharedButton.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/component/PartySharedButton.kt
@@ -15,16 +15,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.R
+import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.designsystem.theme.PotiTheme
 
 @Composable
-fun PartySharedButton(
+fun PartyShareButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -55,7 +54,7 @@ fun PartySharedButton(
 @Composable
 private fun PartySharedButtonPreview() {
     PotiTheme {
-        PartySharedButton(
+        PartyShareButton(
             onClick = { },
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
@@ -111,7 +111,12 @@ sealed interface PartyDetailEffect : UiEffect {
 
     data class ShareToSystem(val shareText: String) : PartyDetailEffect
 
-    data class ShareToKakao(val shareText: String) : PartyDetailEffect
+    data class ShareToKakao(
+        val title: String,
+        val description: String,
+        val imageUrl: String,
+        val deepLink: String,
+    ) : PartyDetailEffect
 
     data class ShareToX(val shareText: String) : PartyDetailEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
@@ -89,6 +89,8 @@ sealed interface PartyDetailIntent : UiIntent {
     data object OnFinalJoinClick : PartyDetailIntent
 
     data object OnJoinSuccessConfirm : PartyDetailIntent
+
+    data object OnShareClick : PartyDetailIntent
 }
 
 sealed interface PartyDetailEffect : UiEffect {
@@ -99,4 +101,6 @@ sealed interface PartyDetailEffect : UiEffect {
     data class NavigateToProfile(val userId: Long) : PartyDetailEffect
 
     data class ReloadDetail(val partyId: Long) : PartyDetailEffect
+
+    data class SharePartyDetail(val shareText: String) : PartyDetailEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
@@ -93,7 +93,11 @@ sealed interface PartyDetailIntent : UiIntent {
 
     data object OnJoinSuccessConfirm : PartyDetailIntent
 
-    data object OnShareClick : PartyDetailIntent
+    data object OnSystemShareClick : PartyDetailIntent
+
+    data object OnKakaoShareClick : PartyDetailIntent
+
+    data object OnXShareClick : PartyDetailIntent
 }
 
 sealed interface PartyDetailEffect : UiEffect {
@@ -105,5 +109,9 @@ sealed interface PartyDetailEffect : UiEffect {
 
     data class ReloadDetail(val partyId: Long) : PartyDetailEffect
 
-    data class SharePartyDetail(val shareText: String) : PartyDetailEffect
+    data class ShareToSystem(val shareText: String) : PartyDetailEffect
+
+    data class ShareToKakao(val shareText: String) : PartyDetailEffect
+
+    data class ShareToX(val shareText: String) : PartyDetailEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/navigation/PartyDetailNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/navigation/PartyDetailNavigation.kt
@@ -17,8 +17,13 @@ import com.poti.android.presentation.party.detail.PartyJoinRoute
 import com.poti.android.presentation.user.profile.navigation.navigateToProfile
 import kotlinx.serialization.Serializable
 
+private const val PARTY_DETAIL_DEEP_LINK_BASE_PATH = "${BuildConfig.DEEP_LINK_HOST}/pot"
+
 @Serializable
 data class PartyDetailGraph(val partyId: Long) : Route
+
+fun partyDetailDeepLink(partyId: Long): String =
+    "$PARTY_DETAIL_DEEP_LINK_BASE_PATH/$partyId"
 
 sealed interface PartyDetailRoute : Route {
     @Serializable
@@ -59,7 +64,7 @@ fun NavGraphBuilder.partyDetailNavGraph(
     navigation<PartyDetailGraph>(
         startDestination = PartyDetailRoute.Detail,
         deepLinks = listOf(
-            navDeepLink<PartyDetailGraph>(basePath = "${BuildConfig.DEEP_LINK_HOST}/pot"),
+            navDeepLink<PartyDetailGraph>(basePath = PARTY_DETAIL_DEEP_LINK_BASE_PATH),
         ),
     ) {
         slideComposable<PartyDetailRoute.Detail> { entry ->

--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5.5,12V18H19.5V12"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#7C7C83"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M16.5,8.429L12.5,5L8.5,8.429M12.5,5V14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#7C7C83"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="party_detail_shipping_price_format">%1$s %2$s원</string>
     <string name="party_detail_uploader">모집자</string>
     <string name="party_detail_participants">참여자</string>
+    <string name="party_detail_participants_empty">현재 참여 중인 사용자가 없어요</string>
     <string name="party_detail_review_count">%d개의 평가</string>
     <string name="party_detail_participants_count">%1$d/%2$d</string>
     <string-array name="party_detail_announcement">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="party_detail_join_party_closed">마감된 분철팟이에요</string>
     <string name="party_detail_upload_date_label">"%s 등록"</string>
     <string name="party_detail_share_button">이 분철팟 공유하기</string>
+    <string name="party_detail_share_chooser_title">분철팟 공유하기</string>
 
     <!-- PartyJoin -->
     <string name="party_join_option_member_label">멤버</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="party_detail_join_party">분철팟 참여하기</string>
     <string name="party_detail_join_party_closed">마감된 분철팟이에요</string>
     <string name="party_detail_upload_date_label">"%s 등록"</string>
+    <string name="party_detail_share_button">이 분철팟 공유하기</string>
 
     <!-- PartyJoin -->
     <string name="party_join_option_member_label">멤버</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,6 +105,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 
 # -- Kakao ---
 kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao" }
+kakao-share = { group = "com.kakao.sdk", name = "v2-share", version.ref = "kakao" }
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottieCompose" }
 
 # --- Firebase ---


### PR DESCRIPTION
## Related issue 🛠️
- closed #162 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 분철팟 상세 페이지에 공유하기 버튼을 추가했습니다.
- 시스템/카카오/X 3개의 공유 기능이 요구되나 현재 해당되는 UI 디자인이 미완료 되어, 임시로 `PartyShareButton`을 3개 배치해 기능 붙여두었습니다. 디자인 완료되면 UI 수정 예정입니다.
- 카카오 공유는 kakao share sdk로 구현했습니다. 현재 공유 메시지를 하드코딩으로 넣어두었으나 기획 픽스 후 카카오 디벨로퍼스에 template 제작해 template id 기반 방식으로 교체할 예정입니다.
- X 공유는 앱이 있는 경우 앱 연동, 앱이 없는 경우 웹으로 연동합니다.
- 이슈 외 변경 사항 : 분철팟 상세 페이지 - 참여자 없는 경우 EmtpyUi 누락되어 있어 추가했습니다.

## Screenshot 📸

| PartyShareButton |
| --- | 
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/1379b115-dcbe-4b82-8acf-80f70db0f1e4" /> |

| 시스템 공유 | 카카오 공유 | X 공유 (앱O) | X 공유 (앱X) |
| --- | --- | --- | --- |
| <video src="https://github.com/user-attachments/assets/752b4202-7f54-45bc-8f9c-583469b9382e" /> | <video src="https://github.com/user-attachments/assets/a75e3115-0b25-486d-a3b5-cf41ae71df83" /> | <video src="https://github.com/user-attachments/assets/1630e137-f979-4001-bee6-0eeabed34c2d" /> | <video src="https://github.com/user-attachments/assets/312d3d72-3ba8-420a-9026-7518fe2ea4e3" /> |

## Uncompleted Tasks 😅
- [ ] 공유하기 바텀시트 추가 (디자인 픽스 필요)
- [ ] 카카오 공유 템플릿 적용 (기획 픽스 필요)

## To Reviewers 📢
기디 픽스 완료 후에 PR 올리기에는 변경사항도 많고 너무 늦어질 것 같아 현 상태로 올립니다!

#### 카카오 SDK 연동을 위해 debug key를 공용으로 생성했습니다.
[노션](https://app.notion.com/p/3a3909fac41b804d8920f0979ba7cea9?source=copy_link#3ba909fac41b80ed929cedd586ad89c0) 참고해서 설정 부탁드립니당

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 파티 상세 화면에서 일반 공유, 카카오톡 공유, X 공유를 지원합니다.
  * X 앱 공유가 어려운 경우 웹 공유로 자동 전환됩니다.
  * 공유 링크를 통해 앱의 해당 파티 상세 화면으로 바로 이동할 수 있습니다.
* **개선**
  * 참여자가 없는 파티에는 안내 메시지가 표시됩니다.
  * 카카오톡을 사용할 수 없는 환경에서도 웹 공유를 이용할 수 있습니다.
* **버그 수정**
  * 공유 링크 수신 및 처리 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->