### PR TITLE
[Feat/#184] 마이페이지, 프로필, 최애 아티스트 선택 화면 적용 및 API 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/android,androidstudio,macos,windows,linux,kotlin
 # Edit at https://www.toptal.com/developers/gitignore?templates=android,androidstudio,macos,windows,linux,kotlin
 
-GEMINI.md
+.claude/
+.codex/
+
 .kotlin/
 
 ### Android ###

--- a/app/src/main/java/com/poti/android/data/mapper/user/ProfileMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/user/ProfileMapper.kt
@@ -8,19 +8,17 @@ import com.poti.android.domain.model.user.UserProfile
 fun ProfileResponseDto.toDomain(): UserProfile =
     UserProfile(
         userId = userId,
-        email = email,
         nickname = nickname,
         profileImageUrl = profileImageUrl,
         ratingAvg = ratingAvg,
         activityMessage = activityMessage,
         joinedAt = joinedAt,
-        hasFavoriteArtist = hasFavoriteArtist,
+        participationSummary = participationSummary.toDomain(),
         recruitSummary = recruitSummary.toDomain(),
     )
 
 fun ProfileSummaryDto.toDomain(): HistorySummary =
     HistorySummary(
-        total = total,
         inProgress = inProgress,
         completed = completed,
     )

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -298,26 +298,25 @@ object UiMockData {
 
     val userProfile = UserProfile(
         userId = 1,
-        email = "poti@example.com",
         nickname = "포티공주",
         profileImageUrl = "",
         ratingAvg = 4.8,
         activityMessage = "안전하고 즐거운 분철해요.",
         joinedAt = "2026.01",
-        hasFavoriteArtist = true,
-        recruitSummary = HistorySummary(12, 2, 10),
+        participationSummary = HistorySummary(2, 6),
+        recruitSummary = HistorySummary(2, 10),
     )
 
     val userMyPage = UserMyPage(
         nickname = userProfile.nickname,
-        email = userProfile.email,
+        email = "poti@example.com",
         profileImageUrl = null,
         ratingAvg = userProfile.ratingAvg.toString(),
         activityMessage = userProfile.activityMessage,
         joinedAt = userProfile.joinedAt,
         hasFavoriteArtist = true,
         favoriteArtistName = "IVE",
-        participationSummary = HistorySummary(8, 2, 6),
+        participationSummary = userProfile.participationSummary,
         recruitSummary = userProfile.recruitSummary,
     )
 

--- a/app/src/main/java/com/poti/android/data/remote/datasource/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/UserRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.poti.android.data.remote.datasource
 
 import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.request.user.FavoriteArtistRequestDto
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
 import com.poti.android.data.remote.dto.response.user.MyPageResponseDto
@@ -15,6 +16,9 @@ class UserRemoteDataSource @Inject constructor(
 ) {
     suspend fun patchOnboarding(onboardingRequest: OnboardingRequestDto): BaseResponse<OnboardingResponseDto> =
         userService.patchOnboarding(onboardingRequest = onboardingRequest)
+
+    suspend fun patchFavoriteArtist(favoriteArtistRequest: FavoriteArtistRequestDto): BaseResponse<Unit> =
+        userService.patchFavoriteArtist(favoriteArtistRequest = favoriteArtistRequest)
 
     suspend fun postNicknameDuplicate(nicknameDuplicateRequest: NicknameDuplicateRequestDto): BaseResponse<NicknameDuplicateResponseDto> =
         userService.postNicknameDuplicate(nicknameDuplicateRequest = nicknameDuplicateRequest)

--- a/app/src/main/java/com/poti/android/data/remote/dto/request/user/FavoriteArtistRequestDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/request/user/FavoriteArtistRequestDto.kt
@@ -1,0 +1,10 @@
+package com.poti.android.data.remote.dto.request.user
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FavoriteArtistRequestDto(
+    @SerialName("artistId")
+    val artistId: Long,
+)

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/user/ProfileResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/user/ProfileResponseDto.kt
@@ -7,8 +7,6 @@ import kotlinx.serialization.Serializable
 data class ProfileResponseDto(
     @SerialName("userId")
     val userId: Long,
-    @SerialName("email")
-    val email: String,
     @SerialName("nickname")
     val nickname: String,
     @SerialName("profileImageUrl")
@@ -19,8 +17,8 @@ data class ProfileResponseDto(
     val activityMessage: String,
     @SerialName("joinedAt")
     val joinedAt: String,
-    @SerialName("hasFavoriteArtist")
-    val hasFavoriteArtist: Boolean,
+    @SerialName("participationSummary")
+    val participationSummary: ProfileSummaryDto,
     @SerialName("recruitSummary")
     val recruitSummary: ProfileSummaryDto,
 )

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/user/ProfileSummaryDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/user/ProfileSummaryDto.kt
@@ -5,8 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ProfileSummaryDto(
-    @SerialName("total")
-    val total: Int,
     @SerialName("inProgress")
     val inProgress: Int,
     @SerialName("completed")

--- a/app/src/main/java/com/poti/android/data/remote/service/UserService.kt
+++ b/app/src/main/java/com/poti/android/data/remote/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.poti.android.data.remote.service
 
 import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.request.user.FavoriteArtistRequestDto
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
 import com.poti.android.data.remote.dto.response.user.MyPageResponseDto
@@ -18,6 +19,11 @@ interface UserService {
     suspend fun patchOnboarding(
         @Body onboardingRequest: OnboardingRequestDto,
     ): BaseResponse<OnboardingResponseDto>
+
+    @PATCH("/api/v1/users/me/favorite-artist")
+    suspend fun patchFavoriteArtist(
+        @Body favoriteArtistRequest: FavoriteArtistRequestDto,
+    ): BaseResponse<Unit>
 
     @POST("/api/v1/users/nickname/duplicate")
     suspend fun postNicknameDuplicate(

--- a/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.poti.android.data.repository
 
 import com.poti.android.core.network.model.handleApiResponse
+import com.poti.android.core.network.model.handleNullableApiResponse
 import com.poti.android.core.network.util.HttpResponseHandler
 import com.poti.android.data.mapper.user.toDomain
 import com.poti.android.data.mock.UiMockData
@@ -43,7 +44,7 @@ class UserRepositoryImpl @Inject constructor(
             httpResponseHandler.safeApiCall {
                 val requestDto = FavoriteArtistRequestDto(artistId = artistId)
                 userRemoteDataSource.patchFavoriteArtist(favoriteArtistRequest = requestDto)
-                    .handleApiResponse()
+                    .handleNullableApiResponse()
                     .getOrThrow()
                 Unit
             }

--- a/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.poti.android.data.mapper.user.toDomain
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.data.mock.executeWithUiMock
 import com.poti.android.data.remote.datasource.UserRemoteDataSource
+import com.poti.android.data.remote.dto.request.user.FavoriteArtistRequestDto
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
 import com.poti.android.domain.model.user.UserMyPage
@@ -29,6 +30,19 @@ class UserRepositoryImpl @Inject constructor(
                     favoriteArtistId = favoriteArtistId,
                 )
                 userRemoteDataSource.patchOnboarding(onboardingRequest = requestDto)
+                    .handleApiResponse()
+                    .getOrThrow()
+                Unit
+            }
+        },
+    )
+
+    override suspend fun patchFavoriteArtist(artistId: Long): Result<Unit> = executeWithUiMock(
+        mock = { Unit },
+        real = {
+            httpResponseHandler.safeApiCall {
+                val requestDto = FavoriteArtistRequestDto(artistId = artistId)
+                userRemoteDataSource.patchFavoriteArtist(favoriteArtistRequest = requestDto)
                     .handleApiResponse()
                     .getOrThrow()
                 Unit

--- a/app/src/main/java/com/poti/android/domain/model/user/UserProfile.kt
+++ b/app/src/main/java/com/poti/android/domain/model/user/UserProfile.kt
@@ -2,18 +2,16 @@ package com.poti.android.domain.model.user
 
 data class UserProfile(
     val userId: Long,
-    val email: String,
     val nickname: String,
     val profileImageUrl: String,
     val ratingAvg: Double,
     val activityMessage: String,
     val joinedAt: String,
-    val hasFavoriteArtist: Boolean,
+    val participationSummary: HistorySummary,
     val recruitSummary: HistorySummary,
 )
 
 data class HistorySummary(
-    val total: Int,
     val inProgress: Int,
     val completed: Int,
 )

--- a/app/src/main/java/com/poti/android/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/UserRepository.kt
@@ -9,6 +9,10 @@ interface UserRepository {
         favoriteArtistId: Long?,
     ): Result<Unit>
 
+    suspend fun patchFavoriteArtist(
+        artistId: Long,
+    ): Result<Unit>
+
     suspend fun postNicknameDuplicate(
         nickname: String,
     ): Result<Boolean>

--- a/app/src/main/java/com/poti/android/domain/usecase/user/UpdateFavoriteArtistUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/user/UpdateFavoriteArtistUseCase.kt
@@ -1,0 +1,12 @@
+package com.poti.android.domain.usecase.user
+
+import com.poti.android.domain.repository.UserRepository
+import javax.inject.Inject
+
+class UpdateFavoriteArtistUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(
+        artistId: Long,
+    ): Result<Unit> = userRepository.patchFavoriteArtist(artistId)
+}

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListScreen.kt
@@ -136,7 +136,7 @@ private fun HistoryListScreen(
                 ongoingCount = uiState.ongoingCount,
                 endedCount = uiState.endedCount,
                 onTabSelected = onTabChanged,
-                modifier = Modifier.padding(start = 16.dp)
+                modifier = Modifier.padding(start = 16.dp),
             )
 
             if (uiState.items.isEmpty()) {

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListScreen.kt
@@ -22,10 +22,12 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.poti.android.R
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.display.PotiEmptyStateInline
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPrimaryToggle
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderSection
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderTabType
 import com.poti.android.core.designsystem.theme.PotiTheme
@@ -38,6 +40,7 @@ import com.poti.android.presentation.history.component.HistoryCardItem
 import com.poti.android.presentation.history.list.model.HistoryListUiEffect
 import com.poti.android.presentation.history.list.model.HistoryListUiIntent
 import com.poti.android.presentation.history.list.model.HistoryListUiState
+import com.poti.android.presentation.history.list.model.HistoryMode
 import com.poti.android.presentation.history.mapper.color
 import com.poti.android.presentation.history.mapper.labelResId
 import com.poti.android.presentation.history.mapper.statusColor
@@ -68,6 +71,9 @@ fun HistoryListRoute(
         uiState = uiState,
         onBackClick = { viewModel.processIntent(HistoryListUiIntent.OnBackClick) },
         onSwitchModeClick = { viewModel.processIntent(HistoryListUiIntent.OnSwitchModeClick) },
+        onModeSelected = { mode ->
+            viewModel.processIntent(HistoryListUiIntent.OnModeSelected(mode))
+        },
         onTabChanged = { tab ->
             viewModel.processIntent(HistoryListUiIntent.OnTabSelected(tab))
         },
@@ -83,6 +89,7 @@ private fun HistoryListScreen(
     uiState: HistoryListUiState,
     onBackClick: () -> Unit,
     onSwitchModeClick: () -> Unit,
+    onModeSelected: (HistoryMode) -> Unit,
     onTabChanged: (PotiHeaderTabType) -> Unit,
     onCardClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
@@ -91,11 +98,21 @@ private fun HistoryListScreen(
         modifier = modifier,
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            PotiHeaderPage(
-                onNavigationClick = onBackClick,
-                title = stringResource(uiState.titleRes),
-                onTrailingIconClick = onSwitchModeClick,
-            )
+            if (uiState.isRootEntry) {
+                PotiHeaderPrimaryToggle(
+                    firstText = stringResource(R.string.header_primary_history_recruit),
+                    secondText = stringResource(R.string.header_primary_history_participate),
+                    firstSelected = uiState.isRecruitMode,
+                    onFirstClick = { onModeSelected(HistoryMode.RECRUIT) },
+                    onSecondClick = { onModeSelected(HistoryMode.PARTICIPATION) },
+                )
+            } else {
+                PotiHeaderPage(
+                    onNavigationClick = onBackClick,
+                    title = stringResource(uiState.titleRes),
+                    onTrailingIconClick = onSwitchModeClick,
+                )
+            }
         },
     ) { innerPadding ->
         Column(
@@ -119,6 +136,7 @@ private fun HistoryListScreen(
                 ongoingCount = uiState.ongoingCount,
                 endedCount = uiState.endedCount,
                 onTabSelected = onTabChanged,
+                modifier = Modifier.padding(start = 16.dp)
             )
 
             if (uiState.items.isEmpty()) {
@@ -130,7 +148,7 @@ private fun HistoryListScreen(
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(
-                        horizontal = 16.dp,
+                        horizontal = 8.dp,
                         vertical = 12.dp,
                     ),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -186,9 +204,11 @@ private fun HistoryListScreenPreview_Ongoing() {
                     ),
                 ),
                 selectedTab = PotiHeaderTabType.ONGOING,
+                isRootEntry = true,
             ),
             onBackClick = {},
             onSwitchModeClick = {},
+            onModeSelected = {},
             onTabChanged = {},
             onCardClick = {},
         )
@@ -212,6 +232,7 @@ private fun HistoryListScreenPreview_Ended() {
             ),
             onBackClick = {},
             onSwitchModeClick = {},
+            onModeSelected = {},
             onTabChanged = {},
             onCardClick = {},
         )

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
@@ -100,6 +100,8 @@ class HistoryListViewModel @Inject constructor(
     }
 
     private fun selectTab(tab: PotiHeaderTabType) {
+        if (uiState.value.selectedTab == tab) return
+
         updateState { copy(selectedTab = tab) }
         loadUserHistoryList()
     }

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
@@ -37,8 +37,9 @@ class HistoryListViewModel @Inject constructor(
 
     override fun processIntent(intent: HistoryListUiIntent) {
         when (intent) {
-            HistoryListUiIntent.OnBackClick -> sendEffect(HistoryListUiEffect.NavigateBack)
+            HistoryListUiIntent.OnBackClick -> sendEffect(NavigateBack)
             HistoryListUiIntent.OnSwitchModeClick -> switchMode()
+            is HistoryListUiIntent.OnModeSelected -> selectMode(intent.mode)
             is HistoryListUiIntent.OnTabSelected -> selectTab(intent.tab)
             is HistoryListUiIntent.OnCardClick -> {
                 if (uiState.value.mode == HistoryMode.RECRUIT) {
@@ -60,6 +61,8 @@ class HistoryListViewModel @Inject constructor(
                     HistorySummaryType.COMPLETED -> PotiHeaderTabType.ENDED
                     else -> PotiHeaderTabType.ONGOING
                 },
+                // 인자 없이 진입하면 하단 내비게이션 경로로 간주합니다.
+                isRootEntry = initialMode == null,
             )
         }
 
@@ -76,6 +79,19 @@ class HistoryListViewModel @Inject constructor(
         updateState {
             copy(
                 mode = newMode,
+                selectedTab = PotiHeaderTabType.ONGOING,
+            )
+        }
+
+        loadUserHistoryList()
+    }
+
+    private fun selectMode(mode: HistoryMode) {
+        if (uiState.value.mode == mode) return
+
+        updateState {
+            copy(
+                mode = mode,
                 selectedTab = PotiHeaderTabType.ONGOING,
             )
         }

--- a/app/src/main/java/com/poti/android/presentation/history/list/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/model/Contracts.kt
@@ -13,7 +13,6 @@ data class HistoryListUiState(
     val historyListLoadState: ApiState<HistoryListContent> = ApiState.Init,
     val mode: HistoryMode = HistoryMode.RECRUIT,
     val selectedTab: PotiHeaderTabType = PotiHeaderTabType.ONGOING,
-    /** 하단 내비게이션으로 진입했는지 여부입니다. true면 뒤로가기 없이 모드 토글 헤더를 사용합니다. */
     val isRootEntry: Boolean = false,
 ) : UiState {
     val titleRes = when (mode) {

--- a/app/src/main/java/com/poti/android/presentation/history/list/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/model/Contracts.kt
@@ -11,13 +11,17 @@ import com.poti.android.domain.model.history.HistoryListContent
 
 data class HistoryListUiState(
     val historyListLoadState: ApiState<HistoryListContent> = ApiState.Init,
-    val mode: HistoryMode = HistoryMode.PARTICIPATION,
+    val mode: HistoryMode = HistoryMode.RECRUIT,
     val selectedTab: PotiHeaderTabType = PotiHeaderTabType.ONGOING,
+    /** 하단 내비게이션으로 진입했는지 여부입니다. true면 뒤로가기 없이 모드 토글 헤더를 사용합니다. */
+    val isRootEntry: Boolean = false,
 ) : UiState {
     val titleRes = when (mode) {
         HistoryMode.RECRUIT -> R.string.user_history_recruit
         HistoryMode.PARTICIPATION -> R.string.user_history_participate
     }
+
+    val isRecruitMode = mode == HistoryMode.RECRUIT
 
     val emptyTextRes = when (mode) {
         HistoryMode.RECRUIT -> {
@@ -48,6 +52,8 @@ sealed interface HistoryListUiIntent : UiIntent {
     data object OnBackClick : HistoryListUiIntent
 
     data object OnSwitchModeClick : HistoryListUiIntent
+
+    data class OnModeSelected(val mode: HistoryMode) : HistoryListUiIntent
 
     data class OnTabSelected(val tab: PotiHeaderTabType) : HistoryListUiIntent
 

--- a/app/src/main/java/com/poti/android/presentation/user/component/BadgeButton.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/BadgeButton.kt
@@ -63,7 +63,7 @@ private fun BadgeButtonPreview() {
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             BadgeButton(
-                bias = "나의 최애 선택하기",
+                bias = "나의 최애 선택",
                 onClick = {},
                 modifier = Modifier,
             )

--- a/app/src/main/java/com/poti/android/presentation/user/component/HistorySummaryCard.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/HistorySummaryCard.kt
@@ -28,11 +28,8 @@ import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.user.HistorySummary
 import kotlinx.serialization.Serializable
 
-// TODO: [천민재] ALL은 Figma 개편으로 UI에서 제거되었으나, API 응답(HistorySummary.total)과
-//  분철 내역 진입 파라미터로는 여전히 사용되므로 enum 값은 유지한다.
 @Serializable
 enum class HistorySummaryType {
-    ALL,
     IN_PROGRESS,
     COMPLETED,
 }
@@ -138,7 +135,6 @@ private fun HistoryItem(
 @Composable
 private fun HistorySummaryCardPreview() {
     val summary = HistorySummary(
-        total = 7,
         inProgress = 2,
         completed = 5,
     )

--- a/app/src/main/java/com/poti/android/presentation/user/component/InquirySection.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/component/InquirySection.kt
@@ -1,0 +1,69 @@
+package com.poti.android.presentation.user.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.component.button.PotiInlineButton
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+@Composable
+fun InquirySection(
+    onInquiryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(PotiTheme.colors.white)
+            .padding(horizontal = 16.dp, vertical = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.user_inquiry_description),
+            modifier = Modifier.fillMaxWidth(),
+            color = PotiTheme.colors.gray800,
+            style = PotiTheme.typography.body14sb,
+            textAlign = TextAlign.Center,
+        )
+
+        PotiInlineButton(
+            text = stringResource(R.string.user_inquiry_action),
+            onClick = onInquiryClick,
+            modifier = Modifier.widthIn(min = 97.dp),
+            showIcon = false,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun InquirySectionPreview() {
+    PotiTheme {
+        Column(
+            modifier = Modifier
+                .background(PotiTheme.colors.gray100)
+                .padding(16.dp),
+        ) {
+            InquirySection(
+                onInquiryClick = {},
+                modifier = Modifier.width(328.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistScreen.kt
@@ -1,0 +1,173 @@
+package com.poti.android.presentation.user.favoriteartist
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.poti.android.R
+import com.poti.android.core.common.extension.noRippleClickable
+import com.poti.android.core.common.extension.onSuccess
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.core.common.util.HandleSideEffects
+import com.poti.android.core.designsystem.component.display.PotiArtistButton
+import com.poti.android.core.designsystem.component.navigation.PotiBottomButton
+import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.data.mock.UiMockData
+import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiEffect
+import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiIntent
+import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiState
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+fun FavoriteArtistRoute(
+    onPopBackStack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: FavoriteArtistViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    HandleSideEffects(viewModel.sideEffect) { effect ->
+        when (effect) {
+            FavoriteArtistUiEffect.NavigateBack -> onPopBackStack()
+            FavoriteArtistUiEffect.SaveSuccess -> onPopBackStack()
+        }
+    }
+
+    FavoriteArtistScreen(
+        uiState = uiState,
+        onBackClick = { viewModel.processIntent(FavoriteArtistUiIntent.OnBackClick) },
+        onArtistClick = { artistId ->
+            viewModel.processIntent(FavoriteArtistUiIntent.OnArtistSelect(artistId))
+        },
+        onSaveClick = { viewModel.processIntent(FavoriteArtistUiIntent.OnSaveClick) },
+        onInquiryClick = { viewModel.processIntent(FavoriteArtistUiIntent.OnInquiryClick) },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun FavoriteArtistScreen(
+    uiState: FavoriteArtistUiState,
+    onBackClick: () -> Unit,
+    onArtistClick: (Long) -> Unit,
+    onSaveClick: () -> Unit,
+    onInquiryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            PotiHeaderPage(
+                onNavigationClick = onBackClick,
+                title = stringResource(R.string.favorite_artist_title),
+            )
+        },
+        bottomBar = {
+            Column(
+                modifier = Modifier.background(PotiTheme.colors.white),
+            ) {
+                InquiryRow(
+                    onInquiryClick = onInquiryClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 12.dp),
+                )
+
+                PotiBottomButton(
+                    text = stringResource(R.string.action_button_done),
+                    onClick = onSaveClick,
+                    enabled = uiState.isSaveEnabled,
+                )
+            }
+        },
+    ) { innerPadding ->
+        uiState.artists.onSuccess { artists ->
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentPadding = PaddingValues(
+                    start = 20.dp,
+                    end = 20.dp,
+                    top = 8.dp,
+                ),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(25.dp),
+            ) {
+                items(
+                    items = artists,
+                    key = { artist -> artist.artistId },
+                ) { artist ->
+                    PotiArtistButton(
+                        imageUrl = artist.logoImageUrl,
+                        text = artist.name,
+                        selected = (uiState.selectedArtistId == artist.artistId),
+                        onClick = { onArtistClick(artist.artistId) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InquiryRow(
+    onInquiryClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.favorite_artist_empty_group),
+            color = PotiTheme.colors.gray800,
+            style = PotiTheme.typography.body14m,
+        )
+
+        Text(
+            text = stringResource(R.string.user_inquiry_action),
+            modifier = Modifier.noRippleClickable(onClick = onInquiryClick),
+            color = PotiTheme.colors.poti800,
+            style = PotiTheme.typography.body14sb,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FavoriteArtistScreenPreview() {
+    PotiTheme {
+        FavoriteArtistScreen(
+            uiState = FavoriteArtistUiState(
+                artists = ApiState.Success(UiMockData.artists.toImmutableList()),
+                selectedArtistId = 1L,
+            ),
+            onBackClick = {},
+            onArtistClick = {},
+            onSaveClick = {},
+            onInquiryClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistScreen.kt
@@ -1,14 +1,13 @@
 package com.poti.android.presentation.user.favoriteartist
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Scaffold
@@ -17,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -44,6 +44,8 @@ fun FavoriteArtistRoute(
     viewModel: FavoriteArtistViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uriHandler = LocalUriHandler.current
+    val inquiryUrl = stringResource(R.string.user_inquiry_url)
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
@@ -59,7 +61,7 @@ fun FavoriteArtistRoute(
             viewModel.processIntent(FavoriteArtistUiIntent.OnArtistSelect(artistId))
         },
         onSaveClick = { viewModel.processIntent(FavoriteArtistUiIntent.OnSaveClick) },
-        onInquiryClick = { viewModel.processIntent(FavoriteArtistUiIntent.OnInquiryClick) },
+        onInquiryClick = { uriHandler.openUri(inquiryUrl) },
         modifier = modifier,
     )
 }
@@ -82,22 +84,11 @@ private fun FavoriteArtistScreen(
             )
         },
         bottomBar = {
-            Column(
-                modifier = Modifier.background(PotiTheme.colors.white),
-            ) {
-                InquiryRow(
-                    onInquiryClick = onInquiryClick,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 12.dp),
-                )
-
-                PotiBottomButton(
-                    text = stringResource(R.string.action_button_done),
-                    onClick = onSaveClick,
-                    enabled = uiState.isSaveEnabled,
-                )
-            }
+            PotiBottomButton(
+                text = stringResource(R.string.action_button_done),
+                onClick = onSaveClick,
+                enabled = uiState.isSaveEnabled,
+            )
         },
     ) { innerPadding ->
         uiState.artists.onSuccess { artists ->
@@ -125,6 +116,15 @@ private fun FavoriteArtistScreen(
                         onClick = { onArtistClick(artist.artistId) },
                     )
                 }
+
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    InquiryRow(
+                        onInquiryClick = onInquiryClick,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 72.dp),
+                    )
+                }
             }
         }
     }
@@ -136,7 +136,9 @@ private fun InquiryRow(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier
+            .noRippleClickable(onClick = onInquiryClick)
+            .padding(vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -148,7 +150,6 @@ private fun InquiryRow(
 
         Text(
             text = stringResource(R.string.user_inquiry_action),
-            modifier = Modifier.noRippleClickable(onClick = onInquiryClick),
             color = PotiTheme.colors.poti800,
             style = PotiTheme.typography.body14sb,
         )

--- a/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistViewModel.kt
@@ -28,7 +28,6 @@ class FavoriteArtistViewModel @Inject constructor(
             FavoriteArtistUiIntent.OnBackClick -> sendEffect(FavoriteArtistUiEffect.NavigateBack)
             is FavoriteArtistUiIntent.OnArtistSelect -> selectArtist(intent.artistId)
             FavoriteArtistUiIntent.OnSaveClick -> saveFavoriteArtist()
-            FavoriteArtistUiIntent.OnInquiryClick -> Unit // TODO: [천민재] 추후 구글폼 링크 연결
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistViewModel.kt
@@ -1,0 +1,67 @@
+package com.poti.android.presentation.user.favoriteartist
+
+import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.artist.GetArtistsUseCase
+import com.poti.android.domain.usecase.user.UpdateFavoriteArtistUseCase
+import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiEffect
+import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiIntent
+import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class FavoriteArtistViewModel @Inject constructor(
+    private val getArtistsUseCase: GetArtistsUseCase,
+    private val updateFavoriteArtistUseCase: UpdateFavoriteArtistUseCase,
+) : BaseViewModel<FavoriteArtistUiState, FavoriteArtistUiIntent, FavoriteArtistUiEffect>(
+        initialState = FavoriteArtistUiState(),
+    ) {
+    init {
+        fetchArtists()
+    }
+
+    override fun processIntent(intent: FavoriteArtistUiIntent) {
+        when (intent) {
+            FavoriteArtistUiIntent.OnBackClick -> sendEffect(FavoriteArtistUiEffect.NavigateBack)
+            is FavoriteArtistUiIntent.OnArtistSelect -> selectArtist(intent.artistId)
+            FavoriteArtistUiIntent.OnSaveClick -> saveFavoriteArtist()
+            FavoriteArtistUiIntent.OnInquiryClick -> Unit // TODO: [천민재] 추후 구글폼 링크 연결
+        }
+    }
+
+    private fun fetchArtists() = launchScope {
+        getArtistsUseCase()
+            .onSuccess { artists ->
+                updateState { copy(artists = ApiState.Success(artists.toImmutableList())) }
+            }
+            .onFailure { error ->
+                updateState { copy(artists = ApiState.Failure(error.message ?: "Failed")) }
+            }
+    }
+
+    private fun selectArtist(artistId: Long) {
+        updateState { copy(selectedArtistId = artistId) }
+    }
+
+    private fun saveFavoriteArtist() {
+        val artistId = uiState.value.selectedArtistId ?: return
+        if (uiState.value.isSaving) return
+
+        launchScope {
+            updateState { copy(isSaving = true) }
+
+            updateFavoriteArtistUseCase(artistId)
+                .onSuccess {
+                    updateState { copy(isSaving = false) }
+                    sendEffect(FavoriteArtistUiEffect.SaveSuccess)
+                }
+                .onFailure { error ->
+                    Timber.e(error, "최애 아티스트 저장 실패")
+                    updateState { copy(isSaving = false) }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistViewModel.kt
@@ -1,5 +1,7 @@
 package com.poti.android.presentation.user.favoriteartist
 
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.usecase.artist.GetArtistsUseCase
@@ -7,6 +9,7 @@ import com.poti.android.domain.usecase.user.UpdateFavoriteArtistUseCase
 import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiEffect
 import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiIntent
 import com.poti.android.presentation.user.favoriteartist.model.FavoriteArtistUiState
+import com.poti.android.presentation.user.mypage.navigation.MyPageRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import timber.log.Timber
@@ -16,9 +19,12 @@ import javax.inject.Inject
 class FavoriteArtistViewModel @Inject constructor(
     private val getArtistsUseCase: GetArtistsUseCase,
     private val updateFavoriteArtistUseCase: UpdateFavoriteArtistUseCase,
+    savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<FavoriteArtistUiState, FavoriteArtistUiIntent, FavoriteArtistUiEffect>(
         initialState = FavoriteArtistUiState(),
     ) {
+    private val favoriteArtistName = savedStateHandle.toRoute<MyPageRoute.FavoriteArtist>().favoriteArtistName
+
     init {
         fetchArtists()
     }
@@ -34,7 +40,14 @@ class FavoriteArtistViewModel @Inject constructor(
     private fun fetchArtists() = launchScope {
         getArtistsUseCase()
             .onSuccess { artists ->
-                updateState { copy(artists = ApiState.Success(artists.toImmutableList())) }
+                val currentArtistId = artists.firstOrNull { it.name == favoriteArtistName }?.artistId
+
+                updateState {
+                    copy(
+                        artists = ApiState.Success(artists.toImmutableList()),
+                        selectedArtistId = currentArtistId,
+                    )
+                }
             }
             .onFailure { error ->
                 updateState { copy(artists = ApiState.Failure(error.message ?: "Failed")) }

--- a/app/src/main/java/com/poti/android/presentation/user/favoriteartist/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/favoriteartist/model/Contracts.kt
@@ -1,0 +1,33 @@
+package com.poti.android.presentation.user.favoriteartist.model
+
+import com.poti.android.core.base.UiEffect
+import com.poti.android.core.base.UiIntent
+import com.poti.android.core.base.UiState
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.model.artist.Artist
+import kotlinx.collections.immutable.ImmutableList
+
+data class FavoriteArtistUiState(
+    val artists: ApiState<ImmutableList<Artist>> = ApiState.Loading,
+    val selectedArtistId: Long? = null,
+    val isSaving: Boolean = false,
+) : UiState {
+    val isSaveEnabled: Boolean
+        get() = selectedArtistId != null && !isSaving
+}
+
+sealed interface FavoriteArtistUiIntent : UiIntent {
+    data object OnBackClick : FavoriteArtistUiIntent
+
+    data class OnArtistSelect(val artistId: Long) : FavoriteArtistUiIntent
+
+    data object OnSaveClick : FavoriteArtistUiIntent
+
+    data object OnInquiryClick : FavoriteArtistUiIntent
+}
+
+sealed interface FavoriteArtistUiEffect : UiEffect {
+    data object NavigateBack : FavoriteArtistUiEffect
+
+    data object SaveSuccess : FavoriteArtistUiEffect
+}

--- a/app/src/main/java/com/poti/android/presentation/user/favoriteartist/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/favoriteartist/model/Contracts.kt
@@ -22,8 +22,6 @@ sealed interface FavoriteArtistUiIntent : UiIntent {
     data class OnArtistSelect(val artistId: Long) : FavoriteArtistUiIntent
 
     data object OnSaveClick : FavoriteArtistUiIntent
-
-    data object OnInquiryClick : FavoriteArtistUiIntent
 }
 
 sealed interface FavoriteArtistUiEffect : UiEffect {

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
 import com.poti.android.core.common.extension.onSuccess
@@ -41,15 +43,24 @@ import com.poti.android.presentation.user.mypage.model.MyPageUiIntent
 @Composable
 fun MyPageRoute(
     onNavigateToHistoryList: (HistoryMode, HistorySummaryType) -> Unit,
+    onNavigateToFavoriteArtist: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.processIntent(MyPageUiIntent.OnResume)
+    }
+
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
             is MyPageUiEffect.NavigateToHistoryList -> {
                 onNavigateToHistoryList(effect.mode, effect.tab)
+            }
+
+            MyPageUiEffect.NavigateToFavoriteArtist -> {
+                onNavigateToFavoriteArtist()
             }
         }
     }
@@ -57,7 +68,7 @@ fun MyPageRoute(
     uiState.userMyPageLoadState.onSuccess { userMyPage ->
         MyPageScreen(
             userMyPage = userMyPage,
-            onArtistClick = {}, // TODO: [천민재] 최애 아티스트 ID 필요
+            onArtistClick = { viewModel.processIntent(MyPageUiIntent.OnArtistClick) },
             onInquiryClick = {}, // TODO: [천민재] 추후 구글폼 링크 연결
             onHistoryClick = { mode, type ->
                 viewModel.processIntent(

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -110,7 +110,8 @@ private fun MyPageScreen(
                 .fillMaxSize()
                 .background(PotiTheme.colors.gray100)
                 .verticalScroll(scrollState)
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 37.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -44,7 +44,7 @@ import com.poti.android.presentation.user.mypage.model.MyPageUiIntent
 @Composable
 fun MyPageRoute(
     onNavigateToHistoryList: (HistoryMode, HistorySummaryType) -> Unit,
-    onNavigateToFavoriteArtist: () -> Unit,
+    onNavigateToFavoriteArtist: (String?) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
@@ -62,8 +62,8 @@ fun MyPageRoute(
                 onNavigateToHistoryList(effect.mode, effect.tab)
             }
 
-            MyPageUiEffect.NavigateToFavoriteArtist -> {
-                onNavigateToFavoriteArtist()
+            is MyPageUiEffect.NavigateToFavoriteArtist -> {
+                onNavigateToFavoriteArtist(effect.favoriteArtistName)
             }
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -31,6 +31,7 @@ import com.poti.android.presentation.history.list.model.HistoryMode
 import com.poti.android.presentation.user.component.BadgeButton
 import com.poti.android.presentation.user.component.HistorySummaryCard
 import com.poti.android.presentation.user.component.HistorySummaryType
+import com.poti.android.presentation.user.component.InquirySection
 import com.poti.android.presentation.user.component.RatingBadge
 import com.poti.android.presentation.user.component.UserInfo
 import com.poti.android.presentation.user.component.UserProfile
@@ -57,6 +58,7 @@ fun MyPageRoute(
         MyPageScreen(
             userMyPage = userMyPage,
             onArtistClick = {},
+            onInquiryClick = {},
             onHistoryClick = { mode, type ->
                 viewModel.processIntent(
                     MyPageUiIntent.OnHistoryClick(mode, type),
@@ -71,6 +73,7 @@ fun MyPageRoute(
 private fun MyPageScreen(
     userMyPage: UserMyPage,
     onArtistClick: () -> Unit,
+    onInquiryClick: () -> Unit,
     onHistoryClick: (HistoryMode, HistorySummaryType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -154,6 +157,11 @@ private fun MyPageScreen(
                     modifier = Modifier.weight(1f),
                 )
             }
+
+            InquirySection(
+                onInquiryClick = onInquiryClick,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }
@@ -184,6 +192,7 @@ private fun ProfileScreenPreview() {
                 ),
             ),
             onArtistClick = {},
+            onInquiryClick = {},
             onHistoryClick = { _, _ -> },
             modifier = Modifier,
         )
@@ -216,6 +225,7 @@ private fun ProfileScreenPreview2() {
                 ),
             ),
             onArtistClick = {},
+            onInquiryClick = {},
             onHistoryClick = { _, _ -> },
             modifier = Modifier,
         )

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -48,6 +49,8 @@ fun MyPageRoute(
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uriHandler = LocalUriHandler.current
+    val inquiryUrl = stringResource(R.string.user_inquiry_url)
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.processIntent(MyPageUiIntent.OnResume)
@@ -69,7 +72,7 @@ fun MyPageRoute(
         MyPageScreen(
             userMyPage = userMyPage,
             onArtistClick = { viewModel.processIntent(MyPageUiIntent.OnArtistClick) },
-            onInquiryClick = {}, // TODO: [천민재] 추후 구글폼 링크 연결
+            onInquiryClick = { uriHandler.openUri(inquiryUrl) },
             onHistoryClick = { mode, type ->
                 viewModel.processIntent(
                     MyPageUiIntent.OnHistoryClick(mode, type),

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -57,8 +57,8 @@ fun MyPageRoute(
     uiState.userMyPageLoadState.onSuccess { userMyPage ->
         MyPageScreen(
             userMyPage = userMyPage,
-            onArtistClick = {},
-            onInquiryClick = {},
+            onArtistClick = {}, // TODO: [천민재] 최애 아티스트 ID 필요
+            onInquiryClick = {}, // TODO: [천민재] 추후 구글폼 링크 연결
             onHistoryClick = { mode, type ->
                 viewModel.processIntent(
                     MyPageUiIntent.OnHistoryClick(mode, type),
@@ -86,9 +86,9 @@ private fun MyPageScreen(
         PotiHeaderPrimary(
             title = stringResource(R.string.user_my_page_title),
             firstIconRes = R.drawable.ic_setting,
-            onFirstIconClick = {},
+            onFirstIconClick = {}, // TODO [천민재] 설정 페이지 이동처리
             secondIconRes = R.drawable.ic_alarm,
-            onSecondIconClick = {},
+            onSecondIconClick = {}, // TODO [천민재] 알람페이지 이동처리
             containerColor = PotiTheme.colors.gray100,
         )
         Column(

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -181,12 +181,10 @@ private fun ProfileScreenPreview() {
                 hasFavoriteArtist = true,
                 favoriteArtistName = "아이브(ive)",
                 participationSummary = HistorySummary(
-                    total = 12,
                     inProgress = 3,
                     completed = 9,
                 ),
                 recruitSummary = HistorySummary(
-                    total = 7,
                     inProgress = 2,
                     completed = 5,
                 ),
@@ -214,12 +212,10 @@ private fun ProfileScreenPreview2() {
                 hasFavoriteArtist = true,
                 favoriteArtistName = null,
                 participationSummary = HistorySummary(
-                    total = 12,
                     inProgress = 3,
                     completed = 9,
                 ),
                 recruitSummary = HistorySummary(
-                    total = 7,
                     inProgress = 2,
                     completed = 5,
                 ),

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageViewModel.kt
@@ -38,12 +38,7 @@ class MyPageViewModel @Inject constructor(
     private fun handleArtistClick() {
         val userMyPage = (uiState.value.userMyPageLoadState as? ApiState.Success)?.data ?: return
 
-        if (userMyPage.hasFavoriteArtist) {
-            // TODO: [천민재] 최애가 이미 있을 때의 동작은 기획 확인 후 처리 예정
-            return
-        }
-
-        sendEffect(NavigateToFavoriteArtist)
+        sendEffect(NavigateToFavoriteArtist(userMyPage.favoriteArtistName))
     }
 
     private fun loadUserMyPage() = launchScope {

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageViewModel.kt
@@ -18,6 +18,8 @@ class MyPageViewModel @Inject constructor(
     ) {
     override fun processIntent(intent: MyPageUiIntent) {
         when (intent) {
+            MyPageUiIntent.OnArtistClick -> handleArtistClick()
+            MyPageUiIntent.OnResume -> loadUserMyPage()
             is MyPageUiIntent.OnHistoryClick -> {
                 sendEffect(
                     NavigateToHistoryList(
@@ -31,6 +33,17 @@ class MyPageViewModel @Inject constructor(
 
     init {
         loadUserMyPage()
+    }
+
+    private fun handleArtistClick() {
+        val userMyPage = (uiState.value.userMyPageLoadState as? ApiState.Success)?.data ?: return
+
+        if (userMyPage.hasFavoriteArtist) {
+            // TODO: [천민재] 최애가 이미 있을 때의 동작은 기획 확인 후 처리 예정
+            return
+        }
+
+        sendEffect(NavigateToFavoriteArtist)
     }
 
     private fun loadUserMyPage() = launchScope {

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/model/Contracts.kt
@@ -24,7 +24,9 @@ sealed interface MyPageUiIntent : UiIntent {
 }
 
 sealed interface MyPageUiEffect : UiEffect {
-    data object NavigateToFavoriteArtist : MyPageUiEffect
+    data class NavigateToFavoriteArtist(
+        val favoriteArtistName: String?,
+    ) : MyPageUiEffect
 
     data class NavigateToHistoryList(
         val mode: HistoryMode,

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/model/Contracts.kt
@@ -13,6 +13,10 @@ data class MyPageUiState(
 ) : UiState
 
 sealed interface MyPageUiIntent : UiIntent {
+    data object OnArtistClick : MyPageUiIntent
+
+    data object OnResume : MyPageUiIntent
+
     data class OnHistoryClick(
         val mode: HistoryMode,
         val tab: HistorySummaryType,
@@ -20,6 +24,8 @@ sealed interface MyPageUiIntent : UiIntent {
 }
 
 sealed interface MyPageUiEffect : UiEffect {
+    data object NavigateToFavoriteArtist : MyPageUiEffect
+
     data class NavigateToHistoryList(
         val mode: HistoryMode,
         val tab: HistorySummaryType,

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
@@ -1,12 +1,15 @@
 package com.poti.android.presentation.user.mypage.navigation
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.poti.android.core.common.extension.slideComposable
+import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.core.navigation.Route
 import com.poti.android.presentation.history.navigation.navigateToHistoryList
 import com.poti.android.presentation.user.favoriteartist.FavoriteArtistRoute
@@ -37,7 +40,10 @@ fun NavGraphBuilder.myPageNavGraph(
         MyPageRoute(
             onNavigateToHistoryList = navController::navigateToHistoryList,
             onNavigateToFavoriteArtist = navController::navigateToFavoriteArtist,
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(PotiTheme.colors.gray100)
+                .padding(paddingValues),
         )
     }
     slideComposable<MyPageRoute.FavoriteArtist> {

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
@@ -6,18 +6,27 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.poti.android.core.common.extension.slideComposable
 import com.poti.android.core.navigation.Route
 import com.poti.android.presentation.history.navigation.navigateToHistoryList
+import com.poti.android.presentation.user.favoriteartist.FavoriteArtistRoute
 import com.poti.android.presentation.user.mypage.MyPageRoute
 import kotlinx.serialization.Serializable
 
 sealed interface MyPageRoute : Route {
     @Serializable
     data object MyPage : MyPageRoute
+
+    @Serializable
+    data object FavoriteArtist : MyPageRoute
 }
 
 fun NavController.navigateToMyPage() {
     navigate(MyPageRoute.MyPage)
+}
+
+fun NavController.navigateToFavoriteArtist() {
+    navigate(MyPageRoute.FavoriteArtist)
 }
 
 fun NavGraphBuilder.myPageNavGraph(
@@ -27,6 +36,13 @@ fun NavGraphBuilder.myPageNavGraph(
     composable<MyPageRoute.MyPage> {
         MyPageRoute(
             onNavigateToHistoryList = navController::navigateToHistoryList,
+            onNavigateToFavoriteArtist = navController::navigateToFavoriteArtist,
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
+    slideComposable<MyPageRoute.FavoriteArtist> {
+        FavoriteArtistRoute(
+            onPopBackStack = navController::popBackStack,
             modifier = Modifier.padding(paddingValues),
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
@@ -21,15 +21,17 @@ sealed interface MyPageRoute : Route {
     data object MyPage : MyPageRoute
 
     @Serializable
-    data object FavoriteArtist : MyPageRoute
+    data class FavoriteArtist(
+        val favoriteArtistName: String? = null,
+    ) : MyPageRoute
 }
 
 fun NavController.navigateToMyPage() {
     navigate(MyPageRoute.MyPage)
 }
 
-fun NavController.navigateToFavoriteArtist() {
-    navigate(MyPageRoute.FavoriteArtist)
+fun NavController.navigateToFavoriteArtist(favoriteArtistName: String?) {
+    navigate(MyPageRoute.FavoriteArtist(favoriteArtistName))
 }
 
 fun NavGraphBuilder.myPageNavGraph(

--- a/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
@@ -107,17 +107,13 @@ private fun ProfileScreen(
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            // 타인의 모집/참여 내역은 조회할 수 없으므로 onItemClick을 전달하지 않는다.
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                // TODO: [천민재] 변경된 디자인에는 참여 내역 카드가 추가되었으나,
-                //  프로필 API(ProfileResponse)가 아직 participationSummary를 내려주지 않는다.
-                //  서버 반영 후 UserProfile.participationSummary로 교체할 것.
                 HistorySummaryCard(
                     title = stringResource(R.string.user_history_participate),
-                    summary = HistorySummary(total = 0, inProgress = 0, completed = 0),
+                    summary = userProfile.participationSummary,
                     modifier = Modifier.weight(1f),
                 )
 
@@ -138,15 +134,16 @@ private fun ProfileScreenPreview() {
         ProfileScreen(
             userProfile = UserProfile(
                 userId = 1L,
-                email = "akkma@app.jam",
                 nickname = "분철의 악마",
                 profileImageUrl = "",
                 ratingAvg = 4.8,
                 activityMessage = "최근 3일 이내 활동",
                 joinedAt = "2025-12-28",
-                hasFavoriteArtist = true,
+                participationSummary = HistorySummary(
+                    inProgress = 3,
+                    completed = 9,
+                ),
                 recruitSummary = HistorySummary(
-                    total = 7,
                     inProgress = 2,
                     completed = 5,
                 ),

--- a/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/profile/ProfileScreen.kt
@@ -77,7 +77,8 @@ private fun ProfileScreen(
                 .fillMaxSize()
                 .background(PotiTheme.colors.gray100)
                 .verticalScroll(scrollState)
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 20.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {

--- a/app/src/main/java/com/poti/android/presentation/user/profile/navigation/ProfileNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/profile/navigation/ProfileNavigation.kt
@@ -1,11 +1,14 @@
 package com.poti.android.presentation.user.profile.navigation
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import com.poti.android.core.common.extension.slideComposable
+import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.core.navigation.Route
 import com.poti.android.presentation.user.profile.ProfileScreenRoute
 import kotlinx.serialization.Serializable
@@ -26,7 +29,10 @@ fun NavGraphBuilder.profileNavGraph(
     slideComposable<ProfileRoute.Profile> {
         ProfileScreenRoute(
             onPopBackStack = onPopBackStack,
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(PotiTheme.colors.gray100)
+                .padding(paddingValues),
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,6 +254,10 @@
     <string name="user_inquiry_description">궁금한 점이나 건의사항이 있다면 알려주세요</string>
     <string name="user_inquiry_action">문의하기</string>
 
+    <!-- Favorite Artist -->
+    <string name="favorite_artist_title">나의 최애 선택</string>
+    <string name="favorite_artist_empty_group">원하는 그룹이 없다면</string>
+
     <!-- History List -->
     <string name="history_empty_recruit_ongoing">진행 중인 모집 내역이 없어요</string>
     <string name="history_empty_recruit_ended">지난 모집 내역이 없어요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,7 +250,7 @@
     <string name="user_history_ongoing">진행중</string>
     <string name="user_history_ended">종료</string>
     <string name="user_my_page_title">마이</string>
-    <string name="user_select_favorite_artist">나의 최애 선택하기</string>
+    <string name="user_select_favorite_artist">나의 최애 선택</string>
 
     <!-- History List -->
     <string name="history_empty_recruit_ongoing">진행 중인 모집 내역이 없어요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -251,6 +251,8 @@
     <string name="user_history_ended">종료</string>
     <string name="user_my_page_title">마이</string>
     <string name="user_select_favorite_artist">나의 최애 선택</string>
+    <string name="user_inquiry_description">궁금한 점이나 건의사항이 있다면 알려주세요</string>
+    <string name="user_inquiry_action">문의하기</string>
 
     <!-- History List -->
     <string name="history_empty_recruit_ongoing">진행 중인 모집 내역이 없어요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,7 @@
     <string name="user_select_favorite_artist">나의 최애 선택</string>
     <string name="user_inquiry_description">궁금한 점이나 건의사항이 있다면 알려주세요</string>
     <string name="user_inquiry_action">문의하기</string>
+    <string name="user_inquiry_url" translatable="false">https://poti-support.notion.site/3c4909fac41b80f4b881e8a5850d6574</string>
 
     <!-- Favorite Artist -->
     <string name="favorite_artist_title">나의 최애 선택</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #184

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 최애 선택 버튼 문구를 `나의 최애 선택하기`에서 `나의 최애 선택`으로 통일했습니다.
- 마이페이지 내역 카드 아래에 문의하기 섹션을 추가했습니다.
- 분철 내역 헤더를 모집내역/참여내역 토글로 교체했습니다. 기존 PotiHeaderPrimaryToggle을 사용했으며, 하단 내비게이션으로 진입한 경우에만 적용되고 마이페이지에서 진입한 경우는 기존 뒤로가기 헤더를 유지합니다.
- 프로필 화면의 참여 내역 카드를 하드코딩된 0에서 실제 API 값으로 연결했습니다.
- 프로필 API 응답에서 제거된 total, email, hasFavoriteArtist 필드를 삭제하고 신규 추가된 participationSummary를 반영했습니다.
total 제거로 사용처가 없어진 HistorySummaryType.ALL도 정리했습니다.
- 최애 아티스트 변경 API(`PATCH /api/v1/users/me/favorite-artist`)를 연결했습니다.
- 최애 선택 화면을 새로 구현했습니다. 기존 PotiArtistButton, PotiBottomButton, GetArtistsUseCase를 재사용했고,
아티스트를 선택해야 완료 버튼이 활성화됩니다.
- 마이페이지 최애 뱃지에서 최애 선택 화면으로 이동하도록 연결했습니다. 저장 후 돌아오면 마이페이지가 갱신됩니다.

## Screenshot 📸

| 마이페이지 및 바텀바를 통한 분철 내역 | 최애 아티스트 선택하기 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/96308eb8-f0a7-4871-a05a-d723527a9883" controls width="600"></video> | <video src="https://github.com/user-attachments/assets/1f7d116f-63eb-4a85-9f8e-be4d96f0cca0" width="600" /> |

## Uncompleted Tasks 😅
- [ ] 최애가 이미 있을 때 뱃지를 누르면 동작하지 않습니다. 기획 확인 중이며 후속 이슈로 처리하겠습니다
- [ ] 문의하기 버튼은 구글폼 링크 대기 중입니다.
- [ ] 마이페이지와 프로필에서 바텀바 라운드 바깥 영역 색이 화면 배경과 다릅니다. 이번 범위가 아니라 후속 이슈로 같이 처리하겠습니다

## To Reviewers 📢
- 마이페이지에 ON_RESUME 재조회를 추가해서 최초 진입 시 API가 2번 호출됩니다.
기존 HistoryListViewModel도 같은 구조라 맞춰뒀는데, 정리가 필요하면 따로 다루면 좋겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지에서 관심 아티스트를 선택하고 저장할 수 있습니다.
  * 관심 아티스트가 설정되지 않은 경우 선택 화면으로 이동할 수 있습니다.
  * 마이페이지에 문의 안내 영역과 문의 버튼이 추가되었습니다.
  * 이력 화면에서 모집 내역과 참여 내역을 토글로 전환할 수 있습니다.

* **개선**
  * 프로필 화면의 참여 내역 요약이 실제 데이터로 표시됩니다.
  * 화면 재진입 시 마이페이지 정보가 최신 상태로 갱신됩니다.
  * 관심 아티스트 및 이력 관련 문구와 표시 방식이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->