### PR TITLE
[Feat/#191] 알림 뷰 기능 구현 및 API 연동

### DIFF
--- a/app/src/main/java/com/poti/android/core/common/extension/StringExt.kt
+++ b/app/src/main/java/com/poti/android/core/common/extension/StringExt.kt
@@ -6,6 +6,7 @@ import com.poti.android.R
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoUnit
@@ -17,6 +18,8 @@ private const val MINUTES_PER_WEEK = MINUTES_PER_DAY * 7
 private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 private val MONTH_DAY_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("MM.dd")
 
+private val SERVER_OFFSET: ZoneOffset = ZoneOffset.UTC
+
 fun String.toPartyUploadDate(): String? {
     return try {
         val dateTime = LocalDateTime.parse(this)
@@ -27,16 +30,16 @@ fun String.toPartyUploadDate(): String? {
 }
 
 /**
- * 서버가 내려주는 시각(2026-08-19T08:30:16.135Z)을 상대 시간 문구로 변환합니다.
+ * 서버가 내려주는 시각을 상대 시간 문구로 변환합니다.
+ * 오프셋이 있는 형식(2026-08-19T08:30:16.135Z)과 없는 형식(2026-08-19T18:35:19.965804)을 모두 처리하며,
  * 7일이 지나면 MM.DD 형식 날짜로, 파싱에 실패하면 원본 문자열을 그대로 표시합니다.
  */
 @Composable
 fun String.toRelativeTime(): String {
-    val dateTime = runCatching {
-        OffsetDateTime.parse(this)
-            .atZoneSameInstant(ZoneId.systemDefault())
-            .toLocalDateTime()
-    }.getOrNull() ?: return this
+    val dateTime = toServerDateTime()
+        ?.atZoneSameInstant(ZoneId.systemDefault())
+        ?.toLocalDateTime()
+        ?: return this
 
     val minutes = ChronoUnit.MINUTES.between(dateTime, LocalDateTime.now())
 
@@ -48,3 +51,8 @@ fun String.toRelativeTime(): String {
         else -> dateTime.format(MONTH_DAY_FORMATTER)
     }
 }
+
+private fun String.toServerDateTime(): OffsetDateTime? =
+    runCatching { OffsetDateTime.parse(this) }
+        .recoverCatching { LocalDateTime.parse(this).atOffset(SERVER_OFFSET) }
+        .getOrNull()

--- a/app/src/main/java/com/poti/android/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/RepositoryModule.kt
@@ -6,6 +6,7 @@ import com.poti.android.data.repository.DeliveryRepositoryImpl
 import com.poti.android.data.repository.FileUploadRepositoryImpl
 import com.poti.android.data.repository.HomeRepositoryImpl
 import com.poti.android.data.repository.ImageRepositoryImpl
+import com.poti.android.data.repository.NotificationRepositoryImpl
 import com.poti.android.data.repository.ParticipationRepositoryImpl
 import com.poti.android.data.repository.PartyRepositoryImpl
 import com.poti.android.data.repository.PaymentRepositoryImpl
@@ -19,6 +20,7 @@ import com.poti.android.domain.repository.DeliveryRepository
 import com.poti.android.domain.repository.FileUploadRepository
 import com.poti.android.domain.repository.HomeRepository
 import com.poti.android.domain.repository.ImageRepository
+import com.poti.android.domain.repository.NotificationRepository
 import com.poti.android.domain.repository.ParticipationRepository
 import com.poti.android.domain.repository.PartyRepository
 import com.poti.android.domain.repository.PaymentRepository
@@ -86,4 +88,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindFileUploadRepository(fileUploadRepositoryImpl: FileUploadRepositoryImpl): FileUploadRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindNotificationRepository(notificationRepositoryImpl: NotificationRepositoryImpl): NotificationRepository
 }

--- a/app/src/main/java/com/poti/android/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/ServiceModule.kt
@@ -5,6 +5,7 @@ import com.poti.android.data.remote.service.AuthService
 import com.poti.android.data.remote.service.DeliveryService
 import com.poti.android.data.remote.service.HomeService
 import com.poti.android.data.remote.service.ImageService
+import com.poti.android.data.remote.service.NotificationService
 import com.poti.android.data.remote.service.ParticipationService
 import com.poti.android.data.remote.service.PartyService
 import com.poti.android.data.remote.service.PaymentService
@@ -84,4 +85,9 @@ object ServiceModule {
     @Singleton
     fun provideReviewService(retrofit: Retrofit): ReviewService =
         retrofit.create(ReviewService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideNotificationService(retrofit: Retrofit): NotificationService =
+        retrofit.create(NotificationService::class.java)
 }

--- a/app/src/main/java/com/poti/android/data/mapper/notification/NotificationMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/notification/NotificationMapper.kt
@@ -1,0 +1,24 @@
+package com.poti.android.data.mapper.notification
+
+import com.poti.android.data.remote.dto.response.notification.NotificationItemResponseDto
+import com.poti.android.data.remote.dto.response.notification.NotificationResponseDto
+import com.poti.android.domain.model.notification.Notification
+import com.poti.android.domain.model.notification.NotificationList
+import com.poti.android.domain.type.NotificationType
+
+fun NotificationResponseDto.toDomain(): NotificationList =
+    NotificationList(
+        notifications = content.map { it.toDomain() },
+        hasNext = hasNext,
+    )
+
+private fun NotificationItemResponseDto.toDomain(): Notification =
+    Notification(
+        id = id,
+        title = title,
+        body = body,
+        type = runCatching { NotificationType.valueOf(type) }.getOrDefault(NotificationType.EVENT),
+        deepLink = deeplink.orEmpty(),
+        isRead = read,
+        createdAt = createdAt,
+    )

--- a/app/src/main/java/com/poti/android/data/mapper/notification/NotificationSettingMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/notification/NotificationSettingMapper.kt
@@ -1,0 +1,10 @@
+package com.poti.android.data.mapper.notification
+
+import com.poti.android.data.remote.dto.response.notification.NotificationSettingResponseDto
+import com.poti.android.domain.model.notification.NotificationSetting
+
+fun NotificationSettingResponseDto.toDomain(): NotificationSetting =
+    NotificationSetting(
+        isTradeEnabled = tradeNotificationEnabled,
+        isEventEnabled = eventNotificationEnabled,
+    )

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -26,6 +26,8 @@ import com.poti.android.domain.model.home.Banner
 import com.poti.android.domain.model.home.GroupItem
 import com.poti.android.domain.model.home.HomeContent
 import com.poti.android.domain.model.image.PresignedUploadInfo
+import com.poti.android.domain.model.notification.Notification
+import com.poti.android.domain.model.notification.NotificationSetting
 import com.poti.android.domain.model.party.Members
 import com.poti.android.domain.model.party.Participant
 import com.poti.android.domain.model.party.PartyDetail
@@ -39,6 +41,7 @@ import com.poti.android.domain.model.user.UserMyPage
 import com.poti.android.domain.model.user.UserProfile
 import com.poti.android.domain.model.user.UserSummary
 import com.poti.android.domain.type.HistoryListType
+import com.poti.android.domain.type.NotificationType
 import com.poti.android.domain.type.ParticipantStatusType
 import com.poti.android.domain.type.PartyStatusType
 import com.poti.android.domain.model.party.GroupItem as PartyGroupItem
@@ -319,6 +322,23 @@ object UiMockData {
         favoriteArtistName = "IVE",
         participationSummary = HistorySummary(8, 2, 6),
         recruitSummary = userProfile.recruitSummary,
+    )
+
+    val notifications = List(10) { index ->
+        Notification(
+            id = index.toLong(),
+            title = if (index % 5 == 4) "이벤트 알림" else "거래 알림",
+            body = "포티에서 알림이 도착했어요.",
+            type = if (index % 5 == 4) NotificationType.EVENT else NotificationType.TRADE,
+            deepLink = "",
+            isRead = index % 3 == 0,
+            createdAt = "2026-06-06T12:00:00",
+        )
+    }
+
+    val notificationSetting = NotificationSetting(
+        isTradeEnabled = true,
+        isEventEnabled = true,
     )
 
     val userAuth = UserAuth(

--- a/app/src/main/java/com/poti/android/data/remote/datasource/NotificationRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/NotificationRemoteDataSource.kt
@@ -1,0 +1,31 @@
+package com.poti.android.data.remote.datasource
+
+import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.request.notification.NotificationSettingRequestDto
+import com.poti.android.data.remote.dto.response.notification.NotificationResponseDto
+import com.poti.android.data.remote.dto.response.notification.NotificationSettingResponseDto
+import com.poti.android.data.remote.service.NotificationService
+import javax.inject.Inject
+
+class NotificationRemoteDataSource @Inject constructor(
+    private val notificationService: NotificationService,
+) {
+    suspend fun getNotificationList(
+        page: Int?,
+        size: Int?,
+        sort: List<String>?,
+    ): BaseResponse<NotificationResponseDto> =
+        notificationService.getNotificationList(
+            page = page,
+            size = size,
+            sort = sort,
+        )
+
+    suspend fun getNotificationSetting(): BaseResponse<NotificationSettingResponseDto> =
+        notificationService.getNotificationSetting()
+
+    suspend fun patchNotificationSetting(
+        notificationSettingRequest: NotificationSettingRequestDto,
+    ): BaseResponse<NotificationSettingResponseDto> =
+        notificationService.patchNotificationSetting(body = notificationSettingRequest)
+}

--- a/app/src/main/java/com/poti/android/data/remote/dto/request/notification/NotificationSettingRequestDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/request/notification/NotificationSettingRequestDto.kt
@@ -1,0 +1,12 @@
+package com.poti.android.data.remote.dto.request.notification
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationSettingRequestDto(
+    @SerialName("tradeNotificationEnabled")
+    val tradeNotificationEnabled: Boolean,
+    @SerialName("eventNotificationEnabled")
+    val eventNotificationEnabled: Boolean,
+)

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/notification/NotificationResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/notification/NotificationResponseDto.kt
@@ -1,0 +1,30 @@
+package com.poti.android.data.remote.dto.response.notification
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationResponseDto(
+    @SerialName("content")
+    val content: List<NotificationItemResponseDto>,
+    @SerialName("hasNext")
+    val hasNext: Boolean,
+)
+
+@Serializable
+data class NotificationItemResponseDto(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("title")
+    val title: String,
+    @SerialName("body")
+    val body: String,
+    @SerialName("type")
+    val type: String,
+    @SerialName("deeplink")
+    val deeplink: String?,
+    @SerialName("read")
+    val read: Boolean,
+    @SerialName("createdAt")
+    val createdAt: String,
+)

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/notification/NotificationSettingResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/notification/NotificationSettingResponseDto.kt
@@ -1,0 +1,12 @@
+package com.poti.android.data.remote.dto.response.notification
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationSettingResponseDto(
+    @SerialName("tradeNotificationEnabled")
+    val tradeNotificationEnabled: Boolean,
+    @SerialName("eventNotificationEnabled")
+    val eventNotificationEnabled: Boolean,
+)

--- a/app/src/main/java/com/poti/android/data/remote/service/NotificationService.kt
+++ b/app/src/main/java/com/poti/android/data/remote/service/NotificationService.kt
@@ -1,0 +1,27 @@
+package com.poti.android.data.remote.service
+
+import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.request.notification.NotificationSettingRequestDto
+import com.poti.android.data.remote.dto.response.notification.NotificationResponseDto
+import com.poti.android.data.remote.dto.response.notification.NotificationSettingResponseDto
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.Query
+
+interface NotificationService {
+    @GET("/api/v1/notifications")
+    suspend fun getNotificationList(
+        @Query("page") page: Int?,
+        @Query("size") size: Int?,
+        @Query("sort") sort: List<String>?,
+    ): BaseResponse<NotificationResponseDto>
+
+    @GET("/api/v1/notifications/settings")
+    suspend fun getNotificationSetting(): BaseResponse<NotificationSettingResponseDto>
+
+    @PATCH("/api/v1/notifications/settings")
+    suspend fun patchNotificationSetting(
+        @Body body: NotificationSettingRequestDto,
+    ): BaseResponse<NotificationSettingResponseDto>
+}

--- a/app/src/main/java/com/poti/android/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/NotificationRepositoryImpl.kt
@@ -1,0 +1,83 @@
+package com.poti.android.data.repository
+
+import com.poti.android.core.network.model.handleApiResponse
+import com.poti.android.core.network.util.HttpResponseHandler
+import com.poti.android.data.mapper.notification.toDomain
+import com.poti.android.data.mock.UiMockData
+import com.poti.android.data.mock.executeWithUiMock
+import com.poti.android.data.remote.datasource.NotificationRemoteDataSource
+import com.poti.android.data.remote.dto.request.notification.NotificationSettingRequestDto
+import com.poti.android.domain.model.notification.NotificationList
+import com.poti.android.domain.model.notification.NotificationSetting
+import com.poti.android.domain.repository.NotificationRepository
+import javax.inject.Inject
+
+class NotificationRepositoryImpl @Inject constructor(
+    private val httpResponseHandler: HttpResponseHandler,
+    private val notificationRemoteDataSource: NotificationRemoteDataSource,
+) : NotificationRepository {
+    override suspend fun getNotifications(
+        page: Int,
+        size: Int,
+    ): Result<NotificationList> = executeWithUiMock(
+        mock = {
+            val notifications = UiMockData.notifications
+
+            NotificationList(
+                notifications = notifications
+                    .drop(page * size)
+                    .take(size),
+                hasNext = (page + 1) * size < notifications.size,
+            )
+        },
+        real = {
+            httpResponseHandler.safeApiCall {
+                notificationRemoteDataSource.getNotificationList(
+                    page = page,
+                    size = size,
+                    sort = null,
+                )
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
+
+    override suspend fun getNotificationSetting(): Result<NotificationSetting> = executeWithUiMock(
+        mock = { UiMockData.notificationSetting },
+        real = {
+            httpResponseHandler.safeApiCall {
+                notificationRemoteDataSource.getNotificationSetting()
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
+
+    override suspend fun updateNotificationSetting(
+        isTradeEnabled: Boolean,
+        isEventEnabled: Boolean,
+    ): Result<NotificationSetting> = executeWithUiMock(
+        mock = {
+            NotificationSetting(
+                isTradeEnabled = isTradeEnabled,
+                isEventEnabled = isEventEnabled,
+            )
+        },
+        real = {
+            httpResponseHandler.safeApiCall {
+                val requestDto = NotificationSettingRequestDto(
+                    tradeNotificationEnabled = isTradeEnabled,
+                    eventNotificationEnabled = isEventEnabled,
+                )
+                notificationRemoteDataSource
+                    .patchNotificationSetting(notificationSettingRequest = requestDto)
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/poti/android/domain/model/notification/NotificationList.kt
+++ b/app/src/main/java/com/poti/android/domain/model/notification/NotificationList.kt
@@ -1,0 +1,6 @@
+package com.poti.android.domain.model.notification
+
+data class NotificationList(
+    val notifications: List<Notification>,
+    val hasNext: Boolean,
+)

--- a/app/src/main/java/com/poti/android/domain/model/notification/NotificationSetting.kt
+++ b/app/src/main/java/com/poti/android/domain/model/notification/NotificationSetting.kt
@@ -1,0 +1,6 @@
+package com.poti.android.domain.model.notification
+
+data class NotificationSetting(
+    val isTradeEnabled: Boolean,
+    val isEventEnabled: Boolean,
+)

--- a/app/src/main/java/com/poti/android/domain/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/NotificationRepository.kt
@@ -1,0 +1,18 @@
+package com.poti.android.domain.repository
+
+import com.poti.android.domain.model.notification.NotificationList
+import com.poti.android.domain.model.notification.NotificationSetting
+
+interface NotificationRepository {
+    suspend fun getNotifications(
+        page: Int = 0,
+        size: Int = 20,
+    ): Result<NotificationList>
+
+    suspend fun getNotificationSetting(): Result<NotificationSetting>
+
+    suspend fun updateNotificationSetting(
+        isTradeEnabled: Boolean,
+        isEventEnabled: Boolean,
+    ): Result<NotificationSetting>
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/notification/GetNotificationSettingUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/notification/GetNotificationSettingUseCase.kt
@@ -1,0 +1,12 @@
+package com.poti.android.domain.usecase.notification
+
+import com.poti.android.domain.model.notification.NotificationSetting
+import com.poti.android.domain.repository.NotificationRepository
+import javax.inject.Inject
+
+class GetNotificationSettingUseCase @Inject constructor(
+    private val notificationRepository: NotificationRepository,
+) {
+    suspend operator fun invoke(): Result<NotificationSetting> =
+        notificationRepository.getNotificationSetting()
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/notification/GetNotificationsUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/notification/GetNotificationsUseCase.kt
@@ -1,0 +1,14 @@
+package com.poti.android.domain.usecase.notification
+
+import com.poti.android.domain.model.notification.NotificationList
+import com.poti.android.domain.repository.NotificationRepository
+import javax.inject.Inject
+
+class GetNotificationsUseCase @Inject constructor(
+    private val notificationRepository: NotificationRepository,
+) {
+    suspend operator fun invoke(
+        page: Int = 0,
+        size: Int = 20,
+    ): Result<NotificationList> = notificationRepository.getNotifications(page, size)
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/notification/UpdateNotificationSettingUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/notification/UpdateNotificationSettingUseCase.kt
@@ -1,0 +1,15 @@
+package com.poti.android.domain.usecase.notification
+
+import com.poti.android.domain.model.notification.NotificationSetting
+import com.poti.android.domain.repository.NotificationRepository
+import javax.inject.Inject
+
+class UpdateNotificationSettingUseCase @Inject constructor(
+    private val notificationRepository: NotificationRepository,
+) {
+    suspend operator fun invoke(
+        isTradeEnabled: Boolean,
+        isEventEnabled: Boolean,
+    ): Result<NotificationSetting> =
+        notificationRepository.updateNotificationSetting(isTradeEnabled, isEventEnabled)
+}

--- a/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListScreen.kt
@@ -1,5 +1,7 @@
 package com.poti.android.presentation.alarm.list
 
+import android.content.Context
+import android.content.Intent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +15,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
@@ -35,6 +38,7 @@ import com.poti.android.presentation.alarm.list.model.AlarmListUiState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import timber.log.Timber
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
@@ -52,6 +56,7 @@ fun AlarmListRoute(
         when (effect) {
             AlarmListUiEffect.NavigateBack -> onPopBackStack()
             AlarmListUiEffect.NavigateToSetting -> navigateToSetting()
+            is AlarmListUiEffect.OpenDeepLink -> context.openDeepLink(effect.deepLink)
             is AlarmListUiEffect.ShowToast -> context.toast(context.getString(effect.messageRes))
         }
     }
@@ -116,6 +121,14 @@ private fun AlarmListScreen(
             }
         }
     }
+}
+
+private fun Context.openDeepLink(deepLink: String) {
+    val intent = Intent(Intent.ACTION_VIEW, deepLink.toUri())
+        .setPackage(packageName)
+
+    runCatching { startActivity(intent) }
+        .onFailure { Timber.w(it, "Unable to open deep link: $deepLink") }
 }
 
 private val previewAlarmSamples = listOf(

--- a/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -17,6 +18,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.extension.toRelativeTime
+import com.poti.android.core.common.extension.toast
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.display.PotiDivider
@@ -44,11 +46,13 @@ fun AlarmListRoute(
     viewModel: AlarmListViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
             AlarmListUiEffect.NavigateBack -> onPopBackStack()
             AlarmListUiEffect.NavigateToSetting -> navigateToSetting()
+            is AlarmListUiEffect.ShowToast -> context.toast(context.getString(effect.messageRes))
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListViewModel.kt
@@ -1,22 +1,62 @@
 package com.poti.android.presentation.alarm.list
 
+import androidx.lifecycle.viewModelScope
 import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.model.notification.Notification
+import com.poti.android.domain.usecase.notification.GetNotificationsUseCase
 import com.poti.android.presentation.alarm.list.model.AlarmListUiEffect
 import com.poti.android.presentation.alarm.list.model.AlarmListUiIntent
 import com.poti.android.presentation.alarm.list.model.AlarmListUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val ALARM_PAGE_SIZE = 20
+
 @HiltViewModel
-class AlarmListViewModel @Inject constructor() : BaseViewModel<AlarmListUiState, AlarmListUiIntent, AlarmListUiEffect>(
-    initialState = AlarmListUiState(),
-) {
+class AlarmListViewModel @Inject constructor(
+    private val getNotificationsUseCase: GetNotificationsUseCase,
+) : BaseViewModel<AlarmListUiState, AlarmListUiIntent, AlarmListUiEffect>(
+        initialState = AlarmListUiState(),
+    ) {
+    init {
+        loadAlarms()
+    }
+
     override fun processIntent(intent: AlarmListUiIntent) {
         when (intent) {
             AlarmListUiIntent.OnBackClick -> sendEffect(AlarmListUiEffect.NavigateBack)
             AlarmListUiIntent.OnSettingClick -> sendEffect(AlarmListUiEffect.NavigateToSetting)
             is AlarmListUiIntent.OnAlarmClick -> handleAlarmClick(intent.alarm)
+        }
+    }
+
+    private fun loadAlarms() {
+        updateState { copy(alarmsLoadState = ApiState.Loading) }
+
+        viewModelScope.launch {
+            getNotificationsUseCase(
+                page = 0,
+                size = ALARM_PAGE_SIZE,
+            ).onSuccess { notificationList ->
+                updateState {
+                    copy(
+                        alarmsLoadState = ApiState.Success(
+                            notificationList.notifications.toImmutableList(),
+                        ),
+                    )
+                }
+            }.onFailure { error ->
+                updateState {
+                    copy(
+                        alarmsLoadState = ApiState.Failure(
+                            error.message ?: "Failed to load notifications",
+                        ),
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListViewModel.kt
@@ -62,5 +62,9 @@ class AlarmListViewModel @Inject constructor(
         }
     }
 
-    private fun handleAlarmClick(alarm: Notification) {}
+    private fun handleAlarmClick(alarm: Notification) {
+        if (alarm.deepLink.isBlank()) return
+
+        sendEffect(AlarmListUiEffect.OpenDeepLink(alarm.deepLink))
+    }
 }

--- a/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/list/AlarmListViewModel.kt
@@ -1,6 +1,7 @@
 package com.poti.android.presentation.alarm.list
 
 import androidx.lifecycle.viewModelScope
+import com.poti.android.R
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.model.notification.Notification
@@ -56,6 +57,7 @@ class AlarmListViewModel @Inject constructor(
                         ),
                     )
                 }
+                sendEffect(AlarmListUiEffect.ShowToast(R.string.alarm_load_failed))
             }
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/alarm/list/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/list/model/Contracts.kt
@@ -27,6 +27,10 @@ sealed interface AlarmListUiEffect : UiEffect {
 
     data object NavigateToSetting : AlarmListUiEffect
 
+    data class OpenDeepLink(
+        val deepLink: String,
+    ) : AlarmListUiEffect
+
     data class ShowToast(
         @param:StringRes val messageRes: Int,
     ) : AlarmListUiEffect

--- a/app/src/main/java/com/poti/android/presentation/alarm/list/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/list/model/Contracts.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.alarm.list.model
 
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
 import com.poti.android.core.base.UiEffect
 import com.poti.android.core.base.UiIntent
@@ -25,4 +26,8 @@ sealed interface AlarmListUiEffect : UiEffect {
     data object NavigateBack : AlarmListUiEffect
 
     data object NavigateToSetting : AlarmListUiEffect
+
+    data class ShowToast(
+        @param:StringRes val messageRes: Int,
+    ) : AlarmListUiEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
@@ -3,6 +3,7 @@ package com.poti.android.presentation.alarm.setting
 import android.content.Context
 import android.content.Intent
 import android.provider.Settings
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -129,7 +130,7 @@ private fun AlarmSettingScreen(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier.background(PotiTheme.colors.white),
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
+import com.poti.android.core.common.extension.toast
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiMenuToggle
 import com.poti.android.core.designsystem.component.modal.PotiLargeModal
@@ -34,10 +36,12 @@ fun AlarmSettingRoute(
     viewModel: AlarmSettingViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
             AlarmSettingUiEffect.NavigateBack -> onPopBackStack()
+            is AlarmSettingUiEffect.ShowToast -> context.toast(context.getString(effect.messageRes))
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
@@ -1,5 +1,8 @@
 package com.poti.android.presentation.alarm.setting
 
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,6 +21,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
 import com.poti.android.core.common.extension.toast
@@ -29,6 +34,7 @@ import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiEffect
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiIntent
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiState
+import timber.log.Timber
 
 @Composable
 fun AlarmSettingRoute(
@@ -42,9 +48,19 @@ fun AlarmSettingRoute(
         NotificationManagerCompat.from(context).areNotificationsEnabled()
     }
 
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.processIntent(
+            AlarmSettingUiIntent.OnResume(
+                isSystemNotificationEnabled = isSystemNotificationEnabled(),
+            ),
+        )
+    }
+
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
             AlarmSettingUiEffect.NavigateBack -> onPopBackStack()
+            AlarmSettingUiEffect.OpenSystemNotificationSetting ->
+                context.openSystemNotificationSetting()
             is AlarmSettingUiEffect.ShowToast -> context.toast(context.getString(effect.messageRes))
         }
     }
@@ -94,6 +110,14 @@ fun AlarmSettingRoute(
         },
         modifier = modifier,
     )
+}
+
+private fun Context.openSystemNotificationSetting() {
+    val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+        .putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+
+    runCatching { startActivity(intent) }
+        .onFailure { Timber.w(it, "Unable to open system notification setting") }
 }
 
 @Composable

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
@@ -37,6 +38,9 @@ fun AlarmSettingRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val isSystemNotificationEnabled = {
+        NotificationManagerCompat.from(context).areNotificationsEnabled()
+    }
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
@@ -73,10 +77,20 @@ fun AlarmSettingRoute(
         uiState = uiState,
         onBackClick = { viewModel.processIntent(AlarmSettingUiIntent.OnBackClick) },
         onTradeToggle = { enabled ->
-            viewModel.processIntent(AlarmSettingUiIntent.OnTradeToggle(enabled))
+            viewModel.processIntent(
+                AlarmSettingUiIntent.OnTradeToggle(
+                    enabled = enabled,
+                    isSystemNotificationEnabled = isSystemNotificationEnabled(),
+                ),
+            )
         },
         onEventToggle = { enabled ->
-            viewModel.processIntent(AlarmSettingUiIntent.OnEventToggle(enabled))
+            viewModel.processIntent(
+                AlarmSettingUiIntent.OnEventToggle(
+                    enabled = enabled,
+                    isSystemNotificationEnabled = isSystemNotificationEnabled(),
+                ),
+            )
         },
         modifier = modifier,
     )

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingViewModel.kt
@@ -27,8 +27,8 @@ class AlarmSettingViewModel @Inject constructor(
     override fun processIntent(intent: AlarmSettingUiIntent) {
         when (intent) {
             AlarmSettingUiIntent.OnBackClick -> sendEffect(AlarmSettingUiEffect.NavigateBack)
-            is AlarmSettingUiIntent.OnTradeToggle -> updateTradeAlarm(intent.enabled)
-            is AlarmSettingUiIntent.OnEventToggle -> updateEventAlarm(intent.enabled)
+            is AlarmSettingUiIntent.OnTradeToggle -> updateTradeAlarm(intent)
+            is AlarmSettingUiIntent.OnEventToggle -> updateEventAlarm(intent)
             AlarmSettingUiIntent.OnAllowSystemAlarm -> requestSystemAlarmPermission()
             AlarmSettingUiIntent.OnModalClose -> updateState { copy(showModal = false) }
         }
@@ -49,23 +49,29 @@ class AlarmSettingViewModel @Inject constructor(
         }
     }
 
-    private fun updateTradeAlarm(enabled: Boolean) {
+    private fun updateTradeAlarm(intent: AlarmSettingUiIntent.OnTradeToggle) {
         updateAlarmSetting(
-            isTradeEnabled = enabled,
+            isTradeEnabled = intent.enabled,
             isEventEnabled = uiState.value.isEventEnabled,
+            isTurnedOn = intent.enabled,
+            isSystemNotificationEnabled = intent.isSystemNotificationEnabled,
         )
     }
 
-    private fun updateEventAlarm(enabled: Boolean) {
+    private fun updateEventAlarm(intent: AlarmSettingUiIntent.OnEventToggle) {
         updateAlarmSetting(
             isTradeEnabled = uiState.value.isTradeEnabled,
-            isEventEnabled = enabled,
+            isEventEnabled = intent.enabled,
+            isTurnedOn = intent.enabled,
+            isSystemNotificationEnabled = intent.isSystemNotificationEnabled,
         )
     }
 
     private fun updateAlarmSetting(
         isTradeEnabled: Boolean,
         isEventEnabled: Boolean,
+        isTurnedOn: Boolean,
+        isSystemNotificationEnabled: Boolean,
     ) {
         if (uiState.value.updateState is ApiState.Loading) return
 
@@ -85,6 +91,10 @@ class AlarmSettingViewModel @Inject constructor(
                 isEventEnabled = isEventEnabled,
             ).onSuccess { _ ->
                 updateState { copy(updateState = ApiState.Success(Unit)) }
+
+                if (isTurnedOn && !isSystemNotificationEnabled) {
+                    showPermissionModal()
+                }
             }.onFailure { error ->
                 updateState {
                     copy(

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingViewModel.kt
@@ -30,6 +30,8 @@ class AlarmSettingViewModel @Inject constructor(
             is AlarmSettingUiIntent.OnTradeToggle -> updateTradeAlarm(intent)
             is AlarmSettingUiIntent.OnEventToggle -> updateEventAlarm(intent)
             AlarmSettingUiIntent.OnAllowSystemAlarm -> requestSystemAlarmPermission()
+            is AlarmSettingUiIntent.OnResume ->
+                closePermissionModalIfGranted(intent.isSystemNotificationEnabled)
             AlarmSettingUiIntent.OnModalClose -> updateState { copy(showModal = false) }
         }
     }
@@ -112,5 +114,13 @@ class AlarmSettingViewModel @Inject constructor(
         updateState { copy(showModal = true) }
     }
 
-    private fun requestSystemAlarmPermission() {}
+    private fun requestSystemAlarmPermission() {
+        sendEffect(AlarmSettingUiEffect.OpenSystemNotificationSetting)
+    }
+
+    private fun closePermissionModalIfGranted(isSystemNotificationEnabled: Boolean) {
+        if (!isSystemNotificationEnabled) return
+
+        updateState { copy(showModal = false) }
+    }
 }

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingViewModel.kt
@@ -1,16 +1,29 @@
 package com.poti.android.presentation.alarm.setting
 
+import androidx.lifecycle.viewModelScope
+import com.poti.android.R
 import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.notification.GetNotificationSettingUseCase
+import com.poti.android.domain.usecase.notification.UpdateNotificationSettingUseCase
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiEffect
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiIntent
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class AlarmSettingViewModel @Inject constructor() : BaseViewModel<AlarmSettingUiState, AlarmSettingUiIntent, AlarmSettingUiEffect>(
-    initialState = AlarmSettingUiState(),
-) {
+class AlarmSettingViewModel @Inject constructor(
+    private val getNotificationSettingUseCase: GetNotificationSettingUseCase,
+    private val updateNotificationSettingUseCase: UpdateNotificationSettingUseCase,
+) : BaseViewModel<AlarmSettingUiState, AlarmSettingUiIntent, AlarmSettingUiEffect>(
+        initialState = AlarmSettingUiState(),
+    ) {
+    init {
+        loadAlarmSetting()
+    }
+
     override fun processIntent(intent: AlarmSettingUiIntent) {
         when (intent) {
             AlarmSettingUiIntent.OnBackClick -> sendEffect(AlarmSettingUiEffect.NavigateBack)
@@ -21,14 +34,68 @@ class AlarmSettingViewModel @Inject constructor() : BaseViewModel<AlarmSettingUi
         }
     }
 
+    private fun loadAlarmSetting() {
+        viewModelScope.launch {
+            getNotificationSettingUseCase().onSuccess { setting ->
+                updateState {
+                    copy(
+                        isTradeEnabled = setting.isTradeEnabled,
+                        isEventEnabled = setting.isEventEnabled,
+                    )
+                }
+            }.onFailure { _ ->
+                sendEffect(AlarmSettingUiEffect.ShowToast(R.string.alarm_setting_load_failed))
+            }
+        }
+    }
+
     private fun updateTradeAlarm(enabled: Boolean) {
-        updateState { copy(isTradeEnabled = enabled) }
-        showPermissionModal()
+        updateAlarmSetting(
+            isTradeEnabled = enabled,
+            isEventEnabled = uiState.value.isEventEnabled,
+        )
     }
 
     private fun updateEventAlarm(enabled: Boolean) {
-        updateState { copy(isEventEnabled = enabled) }
-        showPermissionModal()
+        updateAlarmSetting(
+            isTradeEnabled = uiState.value.isTradeEnabled,
+            isEventEnabled = enabled,
+        )
+    }
+
+    private fun updateAlarmSetting(
+        isTradeEnabled: Boolean,
+        isEventEnabled: Boolean,
+    ) {
+        if (uiState.value.updateState is ApiState.Loading) return
+
+        val previousSetting = uiState.value
+
+        updateState {
+            copy(
+                isTradeEnabled = isTradeEnabled,
+                isEventEnabled = isEventEnabled,
+                updateState = ApiState.Loading,
+            )
+        }
+
+        viewModelScope.launch {
+            updateNotificationSettingUseCase(
+                isTradeEnabled = isTradeEnabled,
+                isEventEnabled = isEventEnabled,
+            ).onSuccess { _ ->
+                updateState { copy(updateState = ApiState.Success(Unit)) }
+            }.onFailure { error ->
+                updateState {
+                    copy(
+                        isTradeEnabled = previousSetting.isTradeEnabled,
+                        isEventEnabled = previousSetting.isEventEnabled,
+                        updateState = ApiState.Failure(error.toString()),
+                    )
+                }
+                sendEffect(AlarmSettingUiEffect.ShowToast(R.string.alarm_setting_update_failed))
+            }
+        }
     }
 
     private fun showPermissionModal() {

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/model/Contracts.kt
@@ -28,11 +28,17 @@ sealed interface AlarmSettingUiIntent : UiIntent {
 
     data object OnAllowSystemAlarm : AlarmSettingUiIntent
 
+    data class OnResume(
+        val isSystemNotificationEnabled: Boolean,
+    ) : AlarmSettingUiIntent
+
     data object OnModalClose : AlarmSettingUiIntent
 }
 
 sealed interface AlarmSettingUiEffect : UiEffect {
     data object NavigateBack : AlarmSettingUiEffect
+
+    data object OpenSystemNotificationSetting : AlarmSettingUiEffect
 
     data class ShowToast(
         @param:StringRes val messageRes: Int,

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/model/Contracts.kt
@@ -16,9 +16,15 @@ data class AlarmSettingUiState(
 sealed interface AlarmSettingUiIntent : UiIntent {
     data object OnBackClick : AlarmSettingUiIntent
 
-    data class OnTradeToggle(val enabled: Boolean) : AlarmSettingUiIntent
+    data class OnTradeToggle(
+        val enabled: Boolean,
+        val isSystemNotificationEnabled: Boolean,
+    ) : AlarmSettingUiIntent
 
-    data class OnEventToggle(val enabled: Boolean) : AlarmSettingUiIntent
+    data class OnEventToggle(
+        val enabled: Boolean,
+        val isSystemNotificationEnabled: Boolean,
+    ) : AlarmSettingUiIntent
 
     data object OnAllowSystemAlarm : AlarmSettingUiIntent
 

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/model/Contracts.kt
@@ -1,13 +1,16 @@
 package com.poti.android.presentation.alarm.setting.model
 
+import androidx.annotation.StringRes
 import com.poti.android.core.base.UiEffect
 import com.poti.android.core.base.UiIntent
 import com.poti.android.core.base.UiState
+import com.poti.android.core.common.state.ApiState
 
 data class AlarmSettingUiState(
     val isTradeEnabled: Boolean = true,
     val isEventEnabled: Boolean = true,
     val showModal: Boolean = false,
+    val updateState: ApiState<Unit> = ApiState.Init,
 ) : UiState
 
 sealed interface AlarmSettingUiIntent : UiIntent {
@@ -24,4 +27,8 @@ sealed interface AlarmSettingUiIntent : UiIntent {
 
 sealed interface AlarmSettingUiEffect : UiEffect {
     data object NavigateBack : AlarmSettingUiEffect
+
+    data class ShowToast(
+        @param:StringRes val messageRes: Int,
+    ) : AlarmSettingUiEffect
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,7 @@
     <!-- Alarm -->
     <string name="alarm_title">알림</string>
     <string name="alarm_empty">새로운 알림이 없어요\n알림이 도착하면 알려드릴게요</string>
+    <string name="alarm_load_failed">알림을 불러오지 못했어요</string>
 
     <string name="alarm_setting_title">알림 설정</string>
     <string name="alarm_setting_trade_title">거래 알림</string>
@@ -293,6 +294,8 @@
     <string name="alarm_setting_permission_modal_text">분철 진행 상황을 실시간으로 확인할 수 있도록 알림을 보내드려요.</string>
     <string name="alarm_setting_permission_modal_button">푸시 알림 허용</string>
     <string name="alarm_setting_permission_modal_sub_button">나중에</string>
+    <string name="alarm_setting_load_failed">알림 설정을 불러오지 못했어요</string>
+    <string name="alarm_setting_update_failed">알림 설정 변경에 실패했어요</string>
 
     <!-- Relative Time -->
     <string name="time_just_now">방금 전</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #191 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 알림 리스트 조회 API 연동
- 알림 클릭으로 딥링크 연동
- `toRelativeTime()` 날짜 파싱 실패 에러 수정
- 알림 설정 조회 API 연동
- 알림 설정 갱신 API 연동 - 낙관적 UI > 선 UI 업데이트 후 API 실패 시 기존 상태로 복구
- 알림 토글 ON으로 변경 시 시스템 권한 허용 여부 체크 > 미허용인 경우 모달 노출
    - 모달 내에서 `푸시 알림 허용` 클릭 시 시스템 설정 열림
    - 시스템 설정에서 알림 허용하고 돌아와야 모달 닫힘
    - 알림 허용 안 하고 그냥 돌아오면 모달 유지

## Screenshot 📸

| 스크린샷 |
| --- | 
| <video src="https://github.com/user-attachments/assets/22ff131c-c492-4c78-81c4-eb81db48ad97" width="250" /> | 


## Uncompleted Tasks 😅
- [ ] 알림 리스트 > Read 처리 : 서버 API 추가 필요할 것 같습니다!

## To Reviewers 📢
딥링크 호스트로 `dev-app`을 전달드렸는데 현재 딥링크가 `dev`로 와서 클릭해도 화면이 열리지 않습니다. 추후 수정 요청드리겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 목록을 조회하고 페이지 단위로 추가 로드할 수 있습니다.
  * 거래 알림과 이벤트 알림을 각각 켜거나 끌 수 있습니다.
  * 알림 선택 시 관련 화면으로 이동하며, 시스템 알림 권한 설정을 안내합니다.
  * 알림 및 설정 정보를 서버와 동기화합니다.

* **버그 수정**
  * 오프셋 유무와 관계없이 서버 시간을 안정적으로 파싱해 현지 시간으로 표시합니다.
  * 알림 조회 및 설정 변경 실패 시 안내 메시지를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->