### PR TITLE
[Feat/#190] 설정 화면 로직 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,12 +67,14 @@ android {
             versionNameSuffix = "-dev"
             buildConfigField("String", "BASE_URL", buildConfigString(requiredLocalProperty("poti.dev.base.url")))
             buildConfigField("String", "DEEP_LINK_HOST", buildConfigString("https://dev-app.poti.kr"))
+            buildConfigField("String", "HTTP_LOG_LEVEL", buildConfigString("BODY"))
             manifestPlaceholders["deepLinkHost"] = "dev-app.poti.kr"
         }
         create("prod") {
             dimension = "server"
             buildConfigField("String", "BASE_URL", buildConfigString(requiredLocalProperty("poti.prod.base.url")))
             buildConfigField("String", "DEEP_LINK_HOST", buildConfigString("https://app.poti.kr"))
+            buildConfigField("String", "HTTP_LOG_LEVEL", buildConfigString("BASIC"))
             manifestPlaceholders["deepLinkHost"] = "app.poti.kr"
         }
     }

--- a/app/src/main/java/com/poti/android/core/common/constant/ExternalLinks.kt
+++ b/app/src/main/java/com/poti/android/core/common/constant/ExternalLinks.kt
@@ -1,0 +1,6 @@
+package com.poti.android.core.common.constant
+
+object ExternalLinks {
+    const val INQUIRY = "https://poti-support.notion.site/3c4909fac41b80f4b881e8a5850d6574"
+    const val TERMS = "https://poti-support.notion.site/3c6909fac41b80139587d8d110e6d0d1"
+}

--- a/app/src/main/java/com/poti/android/core/common/util/NicknameValidator.kt
+++ b/app/src/main/java/com/poti/android/core/common/util/NicknameValidator.kt
@@ -1,0 +1,28 @@
+package com.poti.android.core.common.util
+
+import com.poti.android.R
+import com.poti.android.core.network.model.NetworkError
+import com.poti.android.presentation.onboarding.model.ErrorText
+
+object NicknameValidator {
+    const val MIN_LENGTH = 2
+
+    private val NICKNAME_REGEX = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$".toRegex()
+
+    fun validateFormat(nickname: String): ErrorText? = when {
+        nickname.isEmpty() -> null
+        nickname.length < MIN_LENGTH -> ErrorText.StringResource(R.string.onboarding_nickname_error_min_length)
+        !nickname.matches(NICKNAME_REGEX) -> ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)
+        else -> null
+    }
+
+    fun duplicateNicknameError(): ErrorText = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)
+
+    fun toDuplicationCheckError(error: Throwable): ErrorText = when {
+        error !is NetworkError.BadRequest -> ErrorText.StringResource(R.string.onboarding_nickname_error_server)
+        error.code == DUPLICATE_NICKNAME_ERROR_CODE -> ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)
+        else -> ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)
+    }
+
+    private const val DUPLICATE_NICKNAME_ERROR_CODE = 40003
+}

--- a/app/src/main/java/com/poti/android/core/network/util/HttpResponseHandler.kt
+++ b/app/src/main/java/com/poti/android/core/network/util/HttpResponseHandler.kt
@@ -1,10 +1,12 @@
 package com.poti.android.core.network.util
 
+import com.poti.android.BuildConfig
 import com.poti.android.core.common.util.suspendRunCatching
 import com.poti.android.core.network.model.BaseResponse
 import com.poti.android.core.network.model.NetworkError
 import kotlinx.serialization.json.Json
 import retrofit2.HttpException
+import timber.log.Timber
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import javax.inject.Inject
@@ -37,6 +39,16 @@ class HttpResponseHandler @Inject constructor(
 
         val serverMsg = errorResponse?.message ?: e.message()
         val serverCode = errorResponse?.code
+
+        if (BuildConfig.DEBUG) {
+            Timber.tag("HttpResponseHandler").d(
+                "HTTP error. status=%s, serverCode=%s, message=%s, body=%s",
+                e.code(),
+                serverCode,
+                serverMsg,
+                errorBody,
+            )
+        }
 
         return when (e.code()) {
             400 -> NetworkError.BadRequest(serverCode, serverMsg)

--- a/app/src/main/java/com/poti/android/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/poti/android/data/di/NetworkModule.kt
@@ -31,10 +31,12 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideLoggingInterceptor(): HttpLoggingInterceptor = HttpLoggingInterceptor().apply {
-        level = if (BuildConfig.DEBUG) {
-            HttpLoggingInterceptor.Level.BASIC
-        } else {
+        level = if (!BuildConfig.DEBUG) {
             HttpLoggingInterceptor.Level.NONE
+        } else {
+            runCatching {
+                HttpLoggingInterceptor.Level.valueOf(BuildConfig.HTTP_LOG_LEVEL)
+            }.getOrDefault(HttpLoggingInterceptor.Level.BASIC)
         }
     }
 

--- a/app/src/main/java/com/poti/android/data/mapper/user/AccountMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/user/AccountMapper.kt
@@ -1,0 +1,12 @@
+package com.poti.android.data.mapper.user
+
+import com.poti.android.data.remote.dto.response.user.AccountResponseDto
+import com.poti.android.domain.model.auth.SocialType
+import com.poti.android.domain.model.user.UserAccount
+
+fun AccountResponseDto.toDomain(): UserAccount =
+    UserAccount(
+        nickname = nickname,
+        email = email,
+        socialType = SocialType.valueOf(socialType),
+    )

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -47,6 +47,8 @@ import com.poti.android.domain.model.party.GroupItem as PartyGroupItem
 import com.poti.android.domain.model.party.PartySummary as PartyListSummary
 
 object UiMockData {
+    private const val MOCK_USER_EMAIL = "poti@example.com"
+
     private val historyPartySummary = PartySummary(
         imageUrl = "",
         artist = "IVE",
@@ -311,7 +313,7 @@ object UiMockData {
 
     val userMyPage = UserMyPage(
         nickname = userProfile.nickname,
-        email = "poti@example.com",
+        email = MOCK_USER_EMAIL,
         profileImageUrl = null,
         ratingAvg = userProfile.ratingAvg.toString(),
         activityMessage = userProfile.activityMessage,
@@ -323,8 +325,8 @@ object UiMockData {
     )
 
     val userAccount = UserAccount(
-        nickname = userProfile.nickname,
-        email = userProfile.email,
+        nickname = userMyPage.nickname,
+        email = userMyPage.email,
         socialType = SocialType.KAKAO,
     )
 

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -4,6 +4,7 @@ import com.poti.android.domain.model.artist.Artist
 import com.poti.android.domain.model.artist.ArtistSearchResult
 import com.poti.android.domain.model.artist.Member
 import com.poti.android.domain.model.artist.MemberPriceOption
+import com.poti.android.domain.model.auth.SocialType
 import com.poti.android.domain.model.auth.UserAuth
 import com.poti.android.domain.model.delivery.DeliveryOption
 import com.poti.android.domain.model.history.DeliveryDetail
@@ -35,6 +36,7 @@ import com.poti.android.domain.model.party.ProductCategory
 import com.poti.android.domain.model.party.ProductPartyList
 import com.poti.android.domain.model.payment.PaymentResult
 import com.poti.android.domain.model.user.HistorySummary
+import com.poti.android.domain.model.user.UserAccount
 import com.poti.android.domain.model.user.UserMyPage
 import com.poti.android.domain.model.user.UserProfile
 import com.poti.android.domain.model.user.UserSummary
@@ -319,6 +321,12 @@ object UiMockData {
         favoriteArtistName = "IVE",
         participationSummary = HistorySummary(8, 2, 6),
         recruitSummary = userProfile.recruitSummary,
+    )
+
+    val userAccount = UserAccount(
+        nickname = userProfile.nickname,
+        email = userProfile.email,
+        socialType = SocialType.KAKAO,
     )
 
     val userAuth = UserAuth(

--- a/app/src/main/java/com/poti/android/data/remote/datasource/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/UserRemoteDataSource.kt
@@ -3,6 +3,7 @@ package com.poti.android.data.remote.datasource
 import com.poti.android.core.network.model.BaseResponse
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
+import com.poti.android.data.remote.dto.response.user.AccountResponseDto
 import com.poti.android.data.remote.dto.response.user.MyPageResponseDto
 import com.poti.android.data.remote.dto.response.user.NicknameDuplicateResponseDto
 import com.poti.android.data.remote.dto.response.user.OnboardingResponseDto
@@ -24,4 +25,7 @@ class UserRemoteDataSource @Inject constructor(
 
     suspend fun getUserProfile(userId: Long): BaseResponse<ProfileResponseDto> =
         userService.getUserProfile(userId)
+
+    suspend fun getUserAccount(): BaseResponse<AccountResponseDto> =
+        userService.getUserAccount()
 }

--- a/app/src/main/java/com/poti/android/data/remote/datasource/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/UserRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.poti.android.data.remote.datasource
 
 import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.request.user.EditProfileRequestDto
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
 import com.poti.android.data.remote.dto.response.user.AccountResponseDto
@@ -28,4 +29,7 @@ class UserRemoteDataSource @Inject constructor(
 
     suspend fun getUserAccount(): BaseResponse<AccountResponseDto> =
         userService.getUserAccount()
+
+    suspend fun patchProfile(editProfileRequest: EditProfileRequestDto): BaseResponse<Unit> =
+        userService.patchProfile(editProfileRequest = editProfileRequest)
 }

--- a/app/src/main/java/com/poti/android/data/remote/dto/request/user/EditProfileRequestDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/request/user/EditProfileRequestDto.kt
@@ -1,0 +1,12 @@
+package com.poti.android.data.remote.dto.request.user
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EditProfileRequestDto(
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("profileImageUrl")
+    val profileImageUrl: String,
+)

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/user/AccountResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/user/AccountResponseDto.kt
@@ -1,0 +1,14 @@
+package com.poti.android.data.remote.dto.response.user
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AccountResponseDto(
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("email")
+    val email: String,
+    @SerialName("socialType")
+    val socialType: String,
+)

--- a/app/src/main/java/com/poti/android/data/remote/service/UserService.kt
+++ b/app/src/main/java/com/poti/android/data/remote/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.poti.android.data.remote.service
 
 import com.poti.android.core.network.model.BaseResponse
+import com.poti.android.data.remote.dto.request.user.EditProfileRequestDto
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
 import com.poti.android.data.remote.dto.response.user.AccountResponseDto
@@ -35,4 +36,9 @@ interface UserService {
 
     @GET("/api/v1/users/me/account")
     suspend fun getUserAccount(): BaseResponse<AccountResponseDto>
+
+    @PATCH("/api/v1/users/me/profile")
+    suspend fun patchProfile(
+        @Body editProfileRequest: EditProfileRequestDto,
+    ): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/poti/android/data/remote/service/UserService.kt
+++ b/app/src/main/java/com/poti/android/data/remote/service/UserService.kt
@@ -3,6 +3,7 @@ package com.poti.android.data.remote.service
 import com.poti.android.core.network.model.BaseResponse
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
+import com.poti.android.data.remote.dto.response.user.AccountResponseDto
 import com.poti.android.data.remote.dto.response.user.MyPageResponseDto
 import com.poti.android.data.remote.dto.response.user.NicknameDuplicateResponseDto
 import com.poti.android.data.remote.dto.response.user.OnboardingResponseDto
@@ -31,4 +32,7 @@ interface UserService {
     suspend fun getUserProfile(
         @Path("userId") userId: Long,
     ): BaseResponse<ProfileResponseDto>
+
+    @GET("/api/v1/users/me/account")
+    suspend fun getUserAccount(): BaseResponse<AccountResponseDto>
 }

--- a/app/src/main/java/com/poti/android/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/AuthRepositoryImpl.kt
@@ -74,6 +74,12 @@ class AuthRepositoryImpl @Inject constructor(
         },
     )
 
+    override suspend fun logout(): Result<Unit> = suspendRunCatching {
+        deleteFcmToken()
+        authTokenStore.clearAll()
+        authSessionManager.triggerLogout()
+    }
+
     override suspend fun withdrawal(): Result<Unit> = executeWithUiMock(
         mock = {
             authTokenStore.clearAll()

--- a/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.poti.android.data.mock.executeWithUiMock
 import com.poti.android.data.remote.datasource.UserRemoteDataSource
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
+import com.poti.android.domain.model.user.UserAccount
 import com.poti.android.domain.model.user.UserMyPage
 import com.poti.android.domain.model.user.UserProfile
 import com.poti.android.domain.repository.UserRepository
@@ -70,6 +71,18 @@ class UserRepositoryImpl @Inject constructor(
         real = {
             httpResponseHandler.safeApiCall {
                 userRemoteDataSource.getUserProfile(userId)
+                    .handleApiResponse()
+                    .getOrThrow()
+                    .toDomain()
+            }
+        },
+    )
+
+    override suspend fun getUserAccount(): Result<UserAccount> = executeWithUiMock(
+        mock = { UiMockData.userAccount },
+        real = {
+            httpResponseHandler.safeApiCall {
+                userRemoteDataSource.getUserAccount()
                     .handleApiResponse()
                     .getOrThrow()
                     .toDomain()

--- a/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
@@ -118,7 +118,7 @@ class UserRepositoryImpl @Inject constructor(
                     profileImageUrl = profileImageUrl,
                 )
                 userRemoteDataSource.patchProfile(editProfileRequest = requestDto)
-                    .handleApiResponse()
+                    .handleNullableApiResponse()
                     .getOrThrow()
                 Unit
             }

--- a/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/UserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.poti.android.data.mapper.user.toDomain
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.data.mock.executeWithUiMock
 import com.poti.android.data.remote.datasource.UserRemoteDataSource
+import com.poti.android.data.remote.dto.request.user.EditProfileRequestDto
 import com.poti.android.data.remote.dto.request.user.NicknameDuplicateRequestDto
 import com.poti.android.data.remote.dto.request.user.OnboardingRequestDto
 import com.poti.android.domain.model.user.UserAccount
@@ -86,6 +87,25 @@ class UserRepositoryImpl @Inject constructor(
                     .handleApiResponse()
                     .getOrThrow()
                     .toDomain()
+            }
+        },
+    )
+
+    override suspend fun patchProfile(
+        nickname: String,
+        profileImageUrl: String,
+    ): Result<Unit> = executeWithUiMock(
+        mock = { Unit },
+        real = {
+            httpResponseHandler.safeApiCall {
+                val requestDto = EditProfileRequestDto(
+                    nickname = nickname,
+                    profileImageUrl = profileImageUrl,
+                )
+                userRemoteDataSource.patchProfile(editProfileRequest = requestDto)
+                    .handleApiResponse()
+                    .getOrThrow()
+                Unit
             }
         },
     )

--- a/app/src/main/java/com/poti/android/domain/model/user/UserAccount.kt
+++ b/app/src/main/java/com/poti/android/domain/model/user/UserAccount.kt
@@ -1,0 +1,9 @@
+package com.poti.android.domain.model.user
+
+import com.poti.android.domain.model.auth.SocialType
+
+data class UserAccount(
+    val nickname: String,
+    val email: String,
+    val socialType: SocialType,
+)

--- a/app/src/main/java/com/poti/android/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/AuthRepository.kt
@@ -15,5 +15,7 @@ interface AuthRepository {
 
     suspend fun saveOnboardingState(isCompleted: Boolean): Result<Unit>
 
+    suspend fun logout(): Result<Unit>
+
     suspend fun withdrawal(): Result<Unit>
 }

--- a/app/src/main/java/com/poti/android/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.poti.android.domain.repository
 
+import com.poti.android.domain.model.user.UserAccount
 import com.poti.android.domain.model.user.UserMyPage
 import com.poti.android.domain.model.user.UserProfile
 
@@ -18,4 +19,6 @@ interface UserRepository {
     suspend fun getUserProfile(
         userId: Long,
     ): Result<UserProfile>
+
+    suspend fun getUserAccount(): Result<UserAccount>
 }

--- a/app/src/main/java/com/poti/android/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/UserRepository.kt
@@ -21,4 +21,9 @@ interface UserRepository {
     ): Result<UserProfile>
 
     suspend fun getUserAccount(): Result<UserAccount>
+
+    suspend fun patchProfile(
+        nickname: String,
+        profileImageUrl: String,
+    ): Result<Unit>
 }

--- a/app/src/main/java/com/poti/android/domain/usecase/auth/LogoutUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/auth/LogoutUseCase.kt
@@ -1,0 +1,10 @@
+package com.poti.android.domain.usecase.auth
+
+import com.poti.android.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(): Result<Unit> = authRepository.logout()
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/user/EditProfileUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/user/EditProfileUseCase.kt
@@ -1,0 +1,16 @@
+package com.poti.android.domain.usecase.user
+
+import com.poti.android.domain.repository.UserRepository
+import javax.inject.Inject
+
+class EditProfileUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(
+        nickname: String,
+        profileImageUrl: String,
+    ): Result<Unit> = userRepository.patchProfile(
+        nickname = nickname,
+        profileImageUrl = profileImageUrl,
+    )
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/user/GetUserAccountUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/user/GetUserAccountUseCase.kt
@@ -1,0 +1,11 @@
+package com.poti.android.domain.usecase.user
+
+import com.poti.android.domain.model.user.UserAccount
+import com.poti.android.domain.repository.UserRepository
+import javax.inject.Inject
+
+class GetUserAccountUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(): Result<UserAccount> = userRepository.getUserAccount()
+}

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.alarm.setting
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -87,11 +88,14 @@ private fun AlarmSettingScreen(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.white),
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,
             title = stringResource(R.string.alarm_setting_title),
+            containerColor = PotiTheme.colors.white,
         )
 
         PotiMenuToggle(

--- a/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/list/HistoryListViewModel.kt
@@ -31,9 +31,11 @@ class HistoryListViewModel @Inject constructor(
 ) : BaseViewModel<HistoryListUiState, HistoryListUiIntent, HistoryListUiEffect>(
         initialState = HistoryListUiState(),
     ) {
-    private val route = savedStateHandle.toRoute<HistoryRoute.HistoryList>()
-    private val initialMode = route.mode
-    private val initialType = route.type
+    private val route = runCatching {
+        savedStateHandle.toRoute<HistoryRoute.HistoryList>()
+    }.getOrNull()
+    private val initialMode = route?.mode
+    private val initialType = route?.type
 
     override fun processIntent(intent: HistoryListUiIntent) {
         when (intent) {

--- a/app/src/main/java/com/poti/android/presentation/history/navigation/HistoryNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/navigation/HistoryNavigation.kt
@@ -21,6 +21,9 @@ import kotlinx.serialization.Serializable
 
 sealed interface HistoryRoute : Route {
     @Serializable
+    data object HistoryTab : HistoryRoute
+
+    @Serializable
     data class HistoryList(
         val mode: HistoryMode? = null,
         val type: HistorySummaryType? = null,
@@ -64,6 +67,15 @@ fun NavGraphBuilder.historyNavGraph(
     navController: NavController,
     paddingValues: PaddingValues,
 ) {
+    composable<HistoryRoute.HistoryTab> {
+        HistoryListRoute(
+            onPopBackStack = navController::popBackStack,
+            onNavigateToRecruiterDetail = navController::navigateToRecruiterDetail,
+            onNavigateToParticipantDetail = navController::navigateToParticipantDetail,
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
+
     composable<HistoryRoute.HistoryList> {
         HistoryListRoute(
             onPopBackStack = navController::popBackStack,

--- a/app/src/main/java/com/poti/android/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainNavHost.kt
@@ -16,8 +16,7 @@ import com.poti.android.presentation.onboarding.navigation.onboardingNavGraph
 import com.poti.android.presentation.party.partyNavGraph
 import com.poti.android.presentation.splash.SplashRoute
 import com.poti.android.presentation.splash.splashNavGraph
-import com.poti.android.presentation.user.mypage.navigation.myPageNavGraph
-import com.poti.android.presentation.user.profile.navigation.profileNavGraph
+import com.poti.android.presentation.user.userNavGraph
 
 private const val DURATION = 160
 
@@ -64,13 +63,9 @@ fun MainNavHost(
             navController = navigator.navController,
             paddingValues = paddingValues,
         )
-        myPageNavGraph(
+        userNavGraph(
             navController = navigator.navController,
             paddingValues = paddingValues,
-        )
-        profileNavGraph(
-            paddingValues = paddingValues,
-            onPopBackStack = navigator.navController::popBackStack,
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/main/MainTab.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainTab.kt
@@ -21,7 +21,7 @@ enum class MainTab(
     HISTORY(
         iconResId = R.drawable.ic_history,
         label = R.string.bottom_nav_history,
-        route = HistoryRoute.HistoryList(),
+        route = HistoryRoute.HistoryTab,
     ),
     MYPAGE(
         iconResId = R.drawable.ic_mypage,

--- a/app/src/main/java/com/poti/android/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/onboarding/OnboardingViewModel.kt
@@ -3,7 +3,7 @@ package com.poti.android.presentation.onboarding
 import com.poti.android.R
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
-import com.poti.android.core.network.model.NetworkError
+import com.poti.android.core.common.util.NicknameValidator
 import com.poti.android.domain.usecase.artist.GetArtistsUseCase
 import com.poti.android.domain.usecase.user.CheckNicknameDuplicationUseCase
 import com.poti.android.domain.usecase.user.SaveOnboardingUseCase
@@ -15,8 +15,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import timber.log.Timber
 import javax.inject.Inject
-
-private val NICKNAME_REGEX = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$".toRegex()
 
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
@@ -49,18 +47,10 @@ class OnboardingViewModel @Inject constructor(
     }
 
     private fun handleNicknameChange(value: String) {
-        val hasSpecialChar = !value.matches(NICKNAME_REGEX)
-
-        val initialError: ErrorText? = when {
-            value.length < 2 && value.isNotEmpty() -> ErrorText.StringResource(R.string.onboarding_nickname_error_min_length)
-            hasSpecialChar -> ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)
-            else -> null
-        }
-
         updateState {
             copy(
                 nickname = value,
-                nicknameError = initialError,
+                nicknameError = NicknameValidator.validateFormat(value),
                 isNicknameValid = false,
             )
         }
@@ -72,7 +62,7 @@ class OnboardingViewModel @Inject constructor(
         checkNicknameDuplicationUseCase(nickname)
             .onSuccess { isDuplicated ->
                 if (isDuplicated) {
-                    updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
+                    updateState { copy(nicknameError = NicknameValidator.duplicateNicknameError()) }
                     return@onSuccess
                 }
                 updateState {
@@ -85,27 +75,16 @@ class OnboardingViewModel @Inject constructor(
                 fetchArtists()
             }
             .onFailure { error ->
-                if (error is NetworkError.BadRequest) {
-                    when (error.code) {
-                        40003 -> {
-                            updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
-                        }
-                        else -> {
-                            updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)) }
-                        }
-                    }
-                } else {
-                    updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_server)) }
-                }
+                updateState { copy(nicknameError = NicknameValidator.toDuplicationCheckError(error)) }
             }
     }
 
     private fun handleNicknameNextClick() {
         val currentState = uiState.value
 
-        if (currentState.nicknameError == null && currentState.nickname.length >= 2) {
+        if (currentState.nicknameError == null && currentState.nickname.length >= NicknameValidator.MIN_LENGTH) {
             checkNicknameDuplication(currentState.nickname)
-        } else if (currentState.nickname.length < 2) {
+        } else if (currentState.nickname.length < NicknameValidator.MIN_LENGTH) {
             updateState {
                 copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_min_length))
             }

--- a/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/SettingScreen.kt
@@ -7,23 +7,68 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
+import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiMenuButton
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.presentation.setting.model.SettingUiEffect
+import com.poti.android.presentation.setting.model.SettingUiIntent
 
 @Composable
-fun SettingRoute(modifier: Modifier = Modifier) {
+fun SettingRoute(
+    onPopBackStack: () -> Unit,
+    onNavigateToAccount: () -> Unit,
+    onNavigateToProfileManagement: () -> Unit,
+    onNavigateToAddressManagement: () -> Unit,
+    onNavigateToAlarmSetting: () -> Unit,
+    onNavigateToPersonalInfoPrivacy: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SettingViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    HandleSideEffects(viewModel.sideEffect) { effect ->
+        when (effect) {
+            SettingUiEffect.NavigateBack -> onPopBackStack()
+            SettingUiEffect.NavigateToAccount -> onNavigateToAccount()
+            SettingUiEffect.NavigateToProfileManagement -> onNavigateToProfileManagement()
+            SettingUiEffect.NavigateToAddressManagement -> onNavigateToAddressManagement()
+            SettingUiEffect.NavigateToAlarmSetting -> onNavigateToAlarmSetting()
+            SettingUiEffect.NavigateToPersonalInfoPrivacy -> onNavigateToPersonalInfoPrivacy()
+        }
+    }
+
+    SettingScreen(
+        appVersion = uiState.appVersion,
+        onBackClick = { viewModel.processIntent(SettingUiIntent.OnBackClick) },
+        onAccountClick = { viewModel.processIntent(SettingUiIntent.OnAccountClick) },
+        onProfileManagementClick = { viewModel.processIntent(SettingUiIntent.OnProfileManagementClick) },
+        onAddressManagementClick = { viewModel.processIntent(SettingUiIntent.OnAddressManagementClick) },
+        onAlarmClick = { viewModel.processIntent(SettingUiIntent.OnAlarmClick) },
+        onPersonalInfoPrivacyClick = { viewModel.processIntent(SettingUiIntent.OnPersonalInfoPrivacyClick) },
+        modifier = modifier,
+    )
 }
 
 @Composable
-fun SettingScreen(
+private fun SettingScreen(
+    appVersion: String,
+    onBackClick: () -> Unit,
+    onAccountClick: () -> Unit,
+    onProfileManagementClick: () -> Unit,
+    onAddressManagementClick: () -> Unit,
+    onAlarmClick: () -> Unit,
+    onPersonalInfoPrivacyClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -32,7 +77,7 @@ fun SettingScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         PotiHeaderPage(
-            onNavigationClick = {},
+            onNavigationClick = onBackClick,
             title = stringResource(R.string.setting_title),
         )
 
@@ -50,19 +95,19 @@ fun SettingScreen(
 
             PotiMenuButton(
                 text = stringResource(R.string.setting_menu_account),
-                onClick = {},
+                onClick = onAccountClick,
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
             PotiMenuButton(
                 text = stringResource(R.string.setting_menu_profile_management),
-                onClick = {},
+                onClick = onProfileManagementClick,
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
             PotiMenuButton(
                 text = stringResource(R.string.setting_menu_address_management),
-                onClick = {},
+                onClick = onAddressManagementClick,
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
@@ -80,7 +125,7 @@ fun SettingScreen(
 
             PotiMenuButton(
                 text = stringResource(R.string.setting_alarm),
-                onClick = {},
+                onClick = onAlarmClick,
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
@@ -98,7 +143,7 @@ fun SettingScreen(
 
             PotiMenuButton(
                 text = stringResource(R.string.setting_personal_info_privacy),
-                onClick = {},
+                onClick = onPersonalInfoPrivacyClick,
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
@@ -106,7 +151,7 @@ fun SettingScreen(
                 text = stringResource(R.string.version_info),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
-                trailingText = "1.0.0",
+                trailingText = appVersion,
             )
         }
     }
@@ -115,5 +160,13 @@ fun SettingScreen(
 @Preview(showBackground = true)
 @Composable
 private fun SettingScreenPreview() {
-    SettingScreen()
+    SettingScreen(
+        appVersion = "1.0.0",
+        onBackClick = {},
+        onAccountClick = {},
+        onProfileManagementClick = {},
+        onAddressManagementClick = {},
+        onAlarmClick = {},
+        onPersonalInfoPrivacyClick = {},
+    )
 }

--- a/app/src/main/java/com/poti/android/presentation/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/SettingViewModel.kt
@@ -1,0 +1,25 @@
+package com.poti.android.presentation.setting
+
+import com.poti.android.BuildConfig
+import com.poti.android.core.base.BaseViewModel
+import com.poti.android.presentation.setting.model.SettingUiEffect
+import com.poti.android.presentation.setting.model.SettingUiIntent
+import com.poti.android.presentation.setting.model.SettingUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingViewModel @Inject constructor() : BaseViewModel<SettingUiState, SettingUiIntent, SettingUiEffect>(
+    initialState = SettingUiState(appVersion = BuildConfig.VERSION_NAME),
+) {
+    override fun processIntent(intent: SettingUiIntent) {
+        when (intent) {
+            SettingUiIntent.OnBackClick -> sendEffect(SettingUiEffect.NavigateBack)
+            SettingUiIntent.OnAccountClick -> sendEffect(SettingUiEffect.NavigateToAccount)
+            SettingUiIntent.OnProfileManagementClick -> sendEffect(SettingUiEffect.NavigateToProfileManagement)
+            SettingUiIntent.OnAddressManagementClick -> sendEffect(SettingUiEffect.NavigateToAddressManagement)
+            SettingUiIntent.OnAlarmClick -> sendEffect(SettingUiEffect.NavigateToAlarmSetting)
+            SettingUiIntent.OnPersonalInfoPrivacyClick -> sendEffect(SettingUiEffect.NavigateToPersonalInfoPrivacy)
+        }
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/setting/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/setting/model/Contracts.kt
@@ -1,0 +1,37 @@
+package com.poti.android.presentation.setting.model
+
+import com.poti.android.core.base.UiEffect
+import com.poti.android.core.base.UiIntent
+import com.poti.android.core.base.UiState
+
+data class SettingUiState(
+    val appVersion: String = "",
+) : UiState
+
+sealed interface SettingUiIntent : UiIntent {
+    data object OnBackClick : SettingUiIntent
+
+    data object OnAccountClick : SettingUiIntent
+
+    data object OnProfileManagementClick : SettingUiIntent
+
+    data object OnAddressManagementClick : SettingUiIntent
+
+    data object OnAlarmClick : SettingUiIntent
+
+    data object OnPersonalInfoPrivacyClick : SettingUiIntent
+}
+
+sealed interface SettingUiEffect : UiEffect {
+    data object NavigateBack : SettingUiEffect
+
+    data object NavigateToAccount : SettingUiEffect
+
+    data object NavigateToProfileManagement : SettingUiEffect
+
+    data object NavigateToAddressManagement : SettingUiEffect
+
+    data object NavigateToAlarmSetting : SettingUiEffect
+
+    data object NavigateToPersonalInfoPrivacy : SettingUiEffect
+}

--- a/app/src/main/java/com/poti/android/presentation/user/UserNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/UserNavigation.kt
@@ -5,10 +5,14 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navigation
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.user.account.navigation.accountSettingNavGraph
+import com.poti.android.presentation.user.address.navigation.addressManagementNavGraph
+import com.poti.android.presentation.user.editprofile.navigation.editProfileNavGraph
 import com.poti.android.presentation.user.mypage.navigation.MyPageRoute
 import com.poti.android.presentation.user.mypage.navigation.myPageNavGraph
 import com.poti.android.presentation.user.profile.navigation.profileNavGraph
 import com.poti.android.presentation.user.setting.navigation.settingNavGraph
+import com.poti.android.presentation.user.withdrawal.navigation.withdrawalNavGraph
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -30,6 +34,22 @@ fun NavGraphBuilder.userNavGraph(
             onPopBackStack = navController::popBackStack,
         )
         settingNavGraph(
+            navController = navController,
+            paddingValues = paddingValues,
+        )
+        accountSettingNavGraph(
+            navController = navController,
+            paddingValues = paddingValues,
+        )
+        editProfileNavGraph(
+            navController = navController,
+            paddingValues = paddingValues,
+        )
+        addressManagementNavGraph(
+            navController = navController,
+            paddingValues = paddingValues,
+        )
+        withdrawalNavGraph(
             navController = navController,
             paddingValues = paddingValues,
         )

--- a/app/src/main/java/com/poti/android/presentation/user/UserNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/UserNavigation.kt
@@ -1,0 +1,32 @@
+package com.poti.android.presentation.user
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.navigation
+import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.user.mypage.navigation.MyPageRoute
+import com.poti.android.presentation.user.mypage.navigation.myPageNavGraph
+import com.poti.android.presentation.user.profile.navigation.profileNavGraph
+import kotlinx.serialization.Serializable
+
+@Serializable
+object UserGraph : Route
+
+fun NavGraphBuilder.userNavGraph(
+    navController: NavController,
+    paddingValues: PaddingValues,
+) {
+    navigation<UserGraph>(
+        startDestination = MyPageRoute.MyPage,
+    ) {
+        myPageNavGraph(
+            navController = navController,
+            paddingValues = paddingValues,
+        )
+        profileNavGraph(
+            paddingValues = paddingValues,
+            onPopBackStack = navController::popBackStack,
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/UserNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/UserNavigation.kt
@@ -8,6 +8,7 @@ import com.poti.android.core.navigation.Route
 import com.poti.android.presentation.user.mypage.navigation.MyPageRoute
 import com.poti.android.presentation.user.mypage.navigation.myPageNavGraph
 import com.poti.android.presentation.user.profile.navigation.profileNavGraph
+import com.poti.android.presentation.user.setting.navigation.settingNavGraph
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -27,6 +28,10 @@ fun NavGraphBuilder.userNavGraph(
         profileNavGraph(
             paddingValues = paddingValues,
             onPopBackStack = navController::popBackStack,
+        )
+        settingNavGraph(
+            navController = navController,
+            paddingValues = paddingValues,
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
@@ -8,36 +8,65 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
+import com.poti.android.core.common.extension.onSuccess
+import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiMenuButton
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.domain.model.auth.SocialType
+import com.poti.android.domain.model.user.UserAccount
+import com.poti.android.presentation.user.account.model.AccountSettingUiEffect
+import com.poti.android.presentation.user.account.model.AccountSettingUiIntent
 
 @Composable
 fun AccountSettingRoute(
     onPopBackStack: () -> Unit,
     onNavigateToWithdrawal: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: AccountSettingViewModel = hiltViewModel(),
 ) {
-    AccountSettingScreen(
-        onBackClick = onPopBackStack,
-        onWithdrawalClick = onNavigateToWithdrawal,
-        modifier = modifier,
-    )
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    HandleSideEffects(viewModel.sideEffect) { effect ->
+        when (effect) {
+            AccountSettingUiEffect.NavigateBack -> onPopBackStack()
+            AccountSettingUiEffect.NavigateToWithdrawal -> onNavigateToWithdrawal()
+        }
+    }
+
+    uiState.userAccountLoadState.onSuccess { userAccount ->
+        AccountSettingScreen(
+            userAccount = userAccount,
+            onBackClick = { viewModel.processIntent(AccountSettingUiIntent.OnBackClick) },
+            onLogoutClick = { viewModel.processIntent(AccountSettingUiIntent.OnLogoutClick) },
+            onWithdrawalClick = { viewModel.processIntent(AccountSettingUiIntent.OnWithdrawalClick) },
+            modifier = modifier,
+        )
+    }
 }
 
 @Composable
 private fun AccountSettingScreen(
+    userAccount: UserAccount,
     onBackClick: () -> Unit,
+    onLogoutClick: () -> Unit,
     onWithdrawalClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
+    val socialTypeText = when (userAccount.socialType) {
+        SocialType.KAKAO -> stringResource(R.string.social_type_kakao)
+        SocialType.GOOGLE -> stringResource(R.string.social_type_google)
+    }
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -58,21 +87,21 @@ private fun AccountSettingScreen(
                 text = stringResource(R.string.account_name),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
-                trailingText = "",
+                trailingText = userAccount.nickname,
             )
 
             PotiMenuButton(
                 text = stringResource(R.string.account_email),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
-                trailingText = "",
+                trailingText = userAccount.email,
             )
 
             PotiMenuButton(
                 text = stringResource(R.string.social_account),
                 onClick = {},
                 modifier = Modifier.padding(horizontal = 8.dp),
-                trailingText = "",
+                trailingText = socialTypeText,
             )
 
             PotiDivider(
@@ -82,7 +111,7 @@ private fun AccountSettingScreen(
 
             PotiMenuButton(
                 text = stringResource(R.string.account_logout),
-                onClick = {},
+                onClick = onLogoutClick,
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
 
@@ -99,7 +128,13 @@ private fun AccountSettingScreen(
 @Composable
 private fun AccountSettingScreenPreview() {
     AccountSettingScreen(
+        userAccount = UserAccount(
+            nickname = "포티공주",
+            email = "poti@example.com",
+            socialType = SocialType.KAKAO,
+        ),
         onBackClick = {},
+        onLogoutClick = {},
         onWithdrawalClick = {},
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
@@ -19,11 +19,22 @@ import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 
 @Composable
-fun AccountSettingRoute(modifier: Modifier = Modifier) {
+fun AccountSettingRoute(
+    onPopBackStack: () -> Unit,
+    onNavigateToWithdrawal: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AccountSettingScreen(
+        onBackClick = onPopBackStack,
+        onWithdrawalClick = onNavigateToWithdrawal,
+        modifier = modifier,
+    )
 }
 
 @Composable
-fun AccountSettingScreen(
+private fun AccountSettingScreen(
+    onBackClick: () -> Unit,
+    onWithdrawalClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -32,7 +43,7 @@ fun AccountSettingScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         PotiHeaderPage(
-            onNavigationClick = {},
+            onNavigationClick = onBackClick,
             title = stringResource(R.string.account_setting_title),
         )
 
@@ -77,7 +88,7 @@ fun AccountSettingScreen(
 
             PotiMenuButton(
                 text = stringResource(R.string.account_withdrawal_menu),
-                onClick = {},
+                onClick = onWithdrawalClick,
                 modifier = Modifier.padding(horizontal = 8.dp),
             )
         }
@@ -87,5 +98,8 @@ fun AccountSettingScreen(
 @Preview(showBackground = true)
 @Composable
 private fun AccountSettingScreenPreview() {
-    AccountSettingScreen()
+    AccountSettingScreen(
+        onBackClick = {},
+        onWithdrawalClick = {},
+    )
 }

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
-import com.poti.android.core.common.extension.onSuccess
+import com.poti.android.core.common.state.ApiState
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiMenuButton
 import com.poti.android.core.designsystem.component.display.PotiDivider
@@ -45,31 +45,23 @@ fun AccountSettingRoute(
         }
     }
 
-    uiState.userAccountLoadState.onSuccess { userAccount ->
-        AccountSettingScreen(
-            userAccount = userAccount,
-            onBackClick = { viewModel.processIntent(AccountSettingUiIntent.OnBackClick) },
-            onLogoutClick = { viewModel.processIntent(AccountSettingUiIntent.OnLogoutClick) },
-            onWithdrawalClick = { viewModel.processIntent(AccountSettingUiIntent.OnWithdrawalClick) },
-            modifier = modifier,
-        )
-    }
+    AccountSettingScreen(
+        userAccountLoadState = uiState.userAccountLoadState,
+        onBackClick = { viewModel.processIntent(AccountSettingUiIntent.OnBackClick) },
+        onLogoutClick = { viewModel.processIntent(AccountSettingUiIntent.OnLogoutClick) },
+        onWithdrawalClick = { viewModel.processIntent(AccountSettingUiIntent.OnWithdrawalClick) },
+        modifier = modifier,
+    )
 }
 
 @Composable
 private fun AccountSettingScreen(
-    userAccount: UserAccount,
+    userAccountLoadState: ApiState<UserAccount>,
     onBackClick: () -> Unit,
     onLogoutClick: () -> Unit,
     onWithdrawalClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val scrollState = rememberScrollState()
-    val socialTypeText = when (userAccount.socialType) {
-        SocialType.KAKAO -> stringResource(R.string.social_type_kakao)
-        SocialType.GOOGLE -> stringResource(R.string.social_type_google)
-    }
-
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -81,51 +73,72 @@ private fun AccountSettingScreen(
             containerColor = PotiTheme.colors.white,
         )
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(scrollState),
-        ) {
-            Spacer(modifier = Modifier.height(12.dp))
-
-            PotiMenuButton(
-                text = stringResource(R.string.account_name),
-                onClick = {},
-                modifier = Modifier.padding(horizontal = 8.dp),
-                trailingText = userAccount.nickname,
-            )
-
-            PotiMenuButton(
-                text = stringResource(R.string.account_email),
-                onClick = {},
-                modifier = Modifier.padding(horizontal = 8.dp),
-                trailingText = userAccount.email,
-            )
-
-            PotiMenuButton(
-                text = stringResource(R.string.social_account),
-                onClick = {},
-                modifier = Modifier.padding(horizontal = 8.dp),
-                trailingText = socialTypeText,
-            )
-
-            PotiDivider(
-                PotiDividerStyle.LARGE,
-                modifier = Modifier.padding(vertical = 8.dp),
-            )
-
-            PotiMenuButton(
-                text = stringResource(R.string.account_logout),
-                onClick = onLogoutClick,
-                modifier = Modifier.padding(horizontal = 8.dp),
-            )
-
-            PotiMenuButton(
-                text = stringResource(R.string.account_withdrawal_menu),
-                onClick = onWithdrawalClick,
-                modifier = Modifier.padding(horizontal = 8.dp),
+        if (userAccountLoadState is ApiState.Success) {
+            AccountSettingContent(
+                userAccount = userAccountLoadState.data,
+                onLogoutClick = onLogoutClick,
+                onWithdrawalClick = onWithdrawalClick,
             )
         }
+    }
+}
+
+@Composable
+private fun AccountSettingContent(
+    userAccount: UserAccount,
+    onLogoutClick: () -> Unit,
+    onWithdrawalClick: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val socialTypeText = when (userAccount.socialType) {
+        SocialType.KAKAO -> stringResource(R.string.social_type_kakao)
+        SocialType.GOOGLE -> stringResource(R.string.social_type_google)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState),
+    ) {
+        Spacer(modifier = Modifier.height(12.dp))
+
+        PotiMenuButton(
+            text = stringResource(R.string.account_name),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+            trailingText = userAccount.nickname,
+        )
+
+        PotiMenuButton(
+            text = stringResource(R.string.account_email),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+            trailingText = userAccount.email,
+        )
+
+        PotiMenuButton(
+            text = stringResource(R.string.social_account),
+            onClick = {},
+            modifier = Modifier.padding(horizontal = 8.dp),
+            trailingText = socialTypeText,
+        )
+
+        PotiDivider(
+            PotiDividerStyle.LARGE,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+
+        PotiMenuButton(
+            text = stringResource(R.string.account_logout),
+            onClick = onLogoutClick,
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
+
+        PotiMenuButton(
+            text = stringResource(R.string.account_withdrawal_menu),
+            onClick = onWithdrawalClick,
+            modifier = Modifier.padding(horizontal = 8.dp),
+        )
     }
 }
 
@@ -133,10 +146,12 @@ private fun AccountSettingScreen(
 @Composable
 private fun AccountSettingScreenPreview() {
     AccountSettingScreen(
-        userAccount = UserAccount(
-            nickname = "포티공주",
-            email = "poti@example.com",
-            socialType = SocialType.KAKAO,
+        userAccountLoadState = ApiState.Success(
+            UserAccount(
+                nickname = "포티공주",
+                email = "poti@example.com",
+                socialType = SocialType.KAKAO,
+            ),
         ),
         onBackClick = {},
         onLogoutClick = {},

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.user.account
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,6 +23,7 @@ import com.poti.android.core.designsystem.component.button.PotiMenuButton
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.auth.SocialType
 import com.poti.android.domain.model.user.UserAccount
 import com.poti.android.presentation.user.account.model.AccountSettingUiEffect
@@ -69,11 +71,14 @@ private fun AccountSettingScreen(
     }
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.white),
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,
             title = stringResource(R.string.account_setting_title),
+            containerColor = PotiTheme.colors.white,
         )
 
         Column(

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingViewModel.kt
@@ -29,18 +29,25 @@ class AccountSettingViewModel @Inject constructor(
         loadUserAccount()
     }
 
-    private fun loadUserAccount() = launchScope {
-        getUserAccountUseCase()
-            .onSuccess { userAccount ->
-                updateState {
-                    copy(userAccountLoadState = ApiState.Success(userAccount))
+    private fun loadUserAccount() {
+        updateState { copy(userAccountLoadState = ApiState.Loading) }
+        launchScope(
+            onError = { error ->
+                updateState { copy(userAccountLoadState = ApiState.Failure(error.message ?: "Failed")) }
+            },
+        ) {
+            getUserAccountUseCase()
+                .onSuccess { userAccount ->
+                    updateState {
+                        copy(userAccountLoadState = ApiState.Success(userAccount))
+                    }
                 }
-            }
-            .onFailure { throwable ->
-                updateState {
-                    copy(userAccountLoadState = ApiState.Failure(throwable.message ?: "Failed"))
+                .onFailure { throwable ->
+                    updateState {
+                        copy(userAccountLoadState = ApiState.Failure(throwable.message ?: "Failed"))
+                    }
                 }
-            }
+        }
     }
 
     private fun logout() {

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingViewModel.kt
@@ -2,6 +2,7 @@ package com.poti.android.presentation.user.account
 
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.auth.LogoutUseCase
 import com.poti.android.domain.usecase.user.GetUserAccountUseCase
 import com.poti.android.presentation.user.account.model.AccountSettingUiEffect
 import com.poti.android.presentation.user.account.model.AccountSettingUiIntent
@@ -12,6 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class AccountSettingViewModel @Inject constructor(
     private val getUserAccountUseCase: GetUserAccountUseCase,
+    private val logoutUseCase: LogoutUseCase,
 ) : BaseViewModel<AccountSettingUiState, AccountSettingUiIntent, AccountSettingUiEffect>(
         initialState = AccountSettingUiState(),
     ) {
@@ -19,8 +21,7 @@ class AccountSettingViewModel @Inject constructor(
         when (intent) {
             AccountSettingUiIntent.OnBackClick -> sendEffect(AccountSettingUiEffect.NavigateBack)
             AccountSettingUiIntent.OnWithdrawalClick -> sendEffect(AccountSettingUiEffect.NavigateToWithdrawal)
-            // TODO: 사용자가 직접 트리거하는 로그아웃 API/유즈케이스가 아직 없음
-            AccountSettingUiIntent.OnLogoutClick -> {}
+            AccountSettingUiIntent.OnLogoutClick -> logout()
         }
     }
 
@@ -40,5 +41,17 @@ class AccountSettingViewModel @Inject constructor(
                     copy(userAccountLoadState = ApiState.Failure(throwable.message ?: "Failed"))
                 }
             }
+    }
+
+    private fun logout() {
+        if (uiState.value.isLoggingOut) return
+
+        updateState { copy(isLoggingOut = true) }
+        launchScope(
+            onError = { updateState { copy(isLoggingOut = false) } },
+        ) {
+            logoutUseCase()
+                .onFailure { updateState { copy(isLoggingOut = false) } }
+        }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingViewModel.kt
@@ -1,0 +1,44 @@
+package com.poti.android.presentation.user.account
+
+import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.user.GetUserAccountUseCase
+import com.poti.android.presentation.user.account.model.AccountSettingUiEffect
+import com.poti.android.presentation.user.account.model.AccountSettingUiIntent
+import com.poti.android.presentation.user.account.model.AccountSettingUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AccountSettingViewModel @Inject constructor(
+    private val getUserAccountUseCase: GetUserAccountUseCase,
+) : BaseViewModel<AccountSettingUiState, AccountSettingUiIntent, AccountSettingUiEffect>(
+        initialState = AccountSettingUiState(),
+    ) {
+    override fun processIntent(intent: AccountSettingUiIntent) {
+        when (intent) {
+            AccountSettingUiIntent.OnBackClick -> sendEffect(AccountSettingUiEffect.NavigateBack)
+            AccountSettingUiIntent.OnWithdrawalClick -> sendEffect(AccountSettingUiEffect.NavigateToWithdrawal)
+            // TODO: 사용자가 직접 트리거하는 로그아웃 API/유즈케이스가 아직 없음
+            AccountSettingUiIntent.OnLogoutClick -> {}
+        }
+    }
+
+    init {
+        loadUserAccount()
+    }
+
+    private fun loadUserAccount() = launchScope {
+        getUserAccountUseCase()
+            .onSuccess { userAccount ->
+                updateState {
+                    copy(userAccountLoadState = ApiState.Success(userAccount))
+                }
+            }
+            .onFailure { throwable ->
+                updateState {
+                    copy(userAccountLoadState = ApiState.Failure(throwable.message ?: "Failed"))
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/AccountSettingViewModel.kt
@@ -58,6 +58,7 @@ class AccountSettingViewModel @Inject constructor(
             onError = { updateState { copy(isLoggingOut = false) } },
         ) {
             logoutUseCase()
+                .onSuccess { updateState { copy(isLoggingOut = false) } }
                 .onFailure { updateState { copy(isLoggingOut = false) } }
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/user/account/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/model/Contracts.kt
@@ -8,6 +8,7 @@ import com.poti.android.domain.model.user.UserAccount
 
 data class AccountSettingUiState(
     val userAccountLoadState: ApiState<UserAccount> = ApiState.Loading,
+    val isLoggingOut: Boolean = false,
 ) : UiState
 
 sealed interface AccountSettingUiIntent : UiIntent {

--- a/app/src/main/java/com/poti/android/presentation/user/account/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/model/Contracts.kt
@@ -1,0 +1,25 @@
+package com.poti.android.presentation.user.account.model
+
+import com.poti.android.core.base.UiEffect
+import com.poti.android.core.base.UiIntent
+import com.poti.android.core.base.UiState
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.model.user.UserAccount
+
+data class AccountSettingUiState(
+    val userAccountLoadState: ApiState<UserAccount> = ApiState.Loading,
+) : UiState
+
+sealed interface AccountSettingUiIntent : UiIntent {
+    data object OnBackClick : AccountSettingUiIntent
+
+    data object OnLogoutClick : AccountSettingUiIntent
+
+    data object OnWithdrawalClick : AccountSettingUiIntent
+}
+
+sealed interface AccountSettingUiEffect : UiEffect {
+    data object NavigateBack : AccountSettingUiEffect
+
+    data object NavigateToWithdrawal : AccountSettingUiEffect
+}

--- a/app/src/main/java/com/poti/android/presentation/user/account/navigation/AccountSettingNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/account/navigation/AccountSettingNavigation.kt
@@ -1,0 +1,34 @@
+package com.poti.android.presentation.user.account.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import com.poti.android.core.common.extension.slideComposable
+import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.user.account.AccountSettingRoute
+import com.poti.android.presentation.user.withdrawal.navigation.navigateToWithdrawal
+import kotlinx.serialization.Serializable
+
+sealed interface AccountSettingRoute : Route {
+    @Serializable
+    data object AccountSetting : AccountSettingRoute
+}
+
+fun NavController.navigateToAccountSetting() {
+    navigate(AccountSettingRoute.AccountSetting)
+}
+
+fun NavGraphBuilder.accountSettingNavGraph(
+    navController: NavController,
+    paddingValues: PaddingValues,
+) {
+    slideComposable<AccountSettingRoute.AccountSetting> {
+        AccountSettingRoute(
+            onPopBackStack = navController::popBackStack,
+            onNavigateToWithdrawal = navController::navigateToWithdrawal,
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
@@ -28,11 +28,19 @@ import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 
 @Composable
-fun AddressManagementRoute(modifier: Modifier = Modifier) {
+fun AddressManagementRoute(
+    onPopBackStack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AddressManagementScreen(
+        onBackClick = onPopBackStack,
+        modifier = modifier,
+    )
 }
 
 @Composable
-fun AddressManagementScreen(
+private fun AddressManagementScreen(
+    onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -41,7 +49,7 @@ fun AddressManagementScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         PotiHeaderPage(
-            onNavigationClick = {},
+            onNavigationClick = onBackClick,
             title = stringResource(R.string.address_management_title),
         )
 
@@ -132,5 +140,7 @@ fun AddressManagementScreen(
 @Preview(showBackground = true)
 @Composable
 private fun AddressManagementScreenPreview() {
-    AddressManagementScreen()
+    AddressManagementScreen(
+        onBackClick = {},
+    )
 }

--- a/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/address/AddressManagementScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.user.address
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -46,11 +47,14 @@ private fun AddressManagementScreen(
     val scrollState = rememberScrollState()
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.white),
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,
             title = stringResource(R.string.address_management_title),
+            containerColor = PotiTheme.colors.white,
         )
 
         Column(

--- a/app/src/main/java/com/poti/android/presentation/user/address/navigation/AddressManagementNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/address/navigation/AddressManagementNavigation.kt
@@ -1,0 +1,32 @@
+package com.poti.android.presentation.user.address.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import com.poti.android.core.common.extension.slideComposable
+import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.user.address.AddressManagementRoute
+import kotlinx.serialization.Serializable
+
+sealed interface AddressManagementRoute : Route {
+    @Serializable
+    data object AddressManagement : AddressManagementRoute
+}
+
+fun NavController.navigateToAddressManagement() {
+    navigate(AddressManagementRoute.AddressManagement)
+}
+
+fun NavGraphBuilder.addressManagementNavGraph(
+    navController: NavController,
+    paddingValues: PaddingValues,
+) {
+    slideComposable<AddressManagementRoute.AddressManagement> {
+        AddressManagementRoute(
+            onPopBackStack = navController::popBackStack,
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
@@ -124,7 +124,7 @@ private fun EditProfileScreen(
                 text = stringResource(R.string.action_button_save),
                 onClick = onSaveClick,
                 enabled = isSaveEnabled,
-                type = ActionButtonType.DEACTIVE_MAIN,
+                type = ActionButtonType.SECONDARY_MAIN,
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
                     .padding(top = 4.dp, bottom = 14.dp)

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
@@ -17,11 +17,19 @@ import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.presentation.user.component.EditableUserProfileImage
 
 @Composable
-fun EditProfileRoute(modifier: Modifier = Modifier) {
+fun EditProfileRoute(
+    onPopBackStack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    EditProfileScreen(
+        onBackClick = onPopBackStack,
+        modifier = modifier,
+    )
 }
 
 @Composable
-fun EditProfileScreen(
+private fun EditProfileScreen(
+    onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -30,7 +38,7 @@ fun EditProfileScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         PotiHeaderPage(
-            onNavigationClick = {},
+            onNavigationClick = onBackClick,
             title = stringResource(R.string.profile_management_title),
         )
 
@@ -61,5 +69,7 @@ fun EditProfileScreen(
 @Preview(showBackground = true)
 @Composable
 private fun EditProfileScreenPreview() {
-    EditProfileScreen()
+    EditProfileScreen(
+        onBackClick = {},
+    )
 }

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
@@ -1,38 +1,81 @@
 package com.poti.android.presentation.user.editprofile
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
+import com.poti.android.core.common.util.HandleSideEffects
+import com.poti.android.core.designsystem.component.button.ActionButtonType
+import com.poti.android.core.designsystem.component.button.PotiActionButton
 import com.poti.android.core.designsystem.component.field.PotiShortTextField
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.presentation.onboarding.model.ErrorText
 import com.poti.android.presentation.user.component.EditableUserProfileImage
+import com.poti.android.presentation.user.editprofile.model.EditProfileUiEffect
+import com.poti.android.presentation.user.editprofile.model.EditProfileUiIntent
 
 @Composable
 fun EditProfileRoute(
     onPopBackStack: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: EditProfileViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    HandleSideEffects(viewModel.sideEffect) { effect ->
+        when (effect) {
+            EditProfileUiEffect.NavigateBack -> onPopBackStack()
+        }
+    }
+
     EditProfileScreen(
-        onBackClick = onPopBackStack,
+        profileImageUrl = uiState.selectedImageUri?.toString() ?: uiState.profileImageUrl,
+        nickname = uiState.nickname,
+        nicknameError = uiState.nicknameError,
+        isSaveEnabled = uiState.isSaveEnabled,
+        onBackClick = { viewModel.processIntent(EditProfileUiIntent.OnBackClick) },
+        onProfileImageSelected = { uri -> viewModel.processIntent(EditProfileUiIntent.OnProfileImageSelected(uri)) },
+        onNicknameChange = { value -> viewModel.processIntent(EditProfileUiIntent.OnNicknameChange(value)) },
+        onSaveClick = { viewModel.processIntent(EditProfileUiIntent.OnSaveClick) },
         modifier = modifier,
     )
 }
 
 @Composable
 private fun EditProfileScreen(
+    profileImageUrl: String?,
+    nickname: String,
+    nicknameError: ErrorText?,
+    isSaveEnabled: Boolean,
     onBackClick: () -> Unit,
+    onProfileImageSelected: (Uri) -> Unit,
+    onNicknameChange: (String) -> Unit,
+    onSaveClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
+
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        uri?.let(onProfileImageSelected)
+    }
 
     Column(
         modifier = modifier.fillMaxSize(),
@@ -44,23 +87,48 @@ private fun EditProfileScreen(
 
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(scrollState),
+                .weight(1f)
+                .fillMaxWidth(),
         ) {
-            EditableUserProfileImage(
-                imageUrl = null,
-                onEditClick = {},
+            Column(
                 modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(top = 16.dp, bottom = 24.dp),
-            )
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(scrollState),
+            ) {
+                EditableUserProfileImage(
+                    imageUrl = profileImageUrl,
+                    onEditClick = {
+                        photoPickerLauncher.launch(
+                            PickVisualMediaRequest.Builder()
+                                .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                .build(),
+                        )
+                    },
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(top = 16.dp, bottom = 24.dp),
+                )
 
-            PotiShortTextField(
-                value = "",
-                onValueChanged = {},
-                label = stringResource(R.string.profile_nickname),
-                placeholder = stringResource(R.string.profile_nickname),
-                modifier = Modifier.padding(horizontal = 16.dp),
+                PotiShortTextField(
+                    value = nickname,
+                    onValueChanged = onNicknameChange,
+                    label = stringResource(R.string.profile_nickname),
+                    placeholder = stringResource(R.string.profile_nickname),
+                    error = nicknameError?.asString() ?: "",
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+
+            PotiActionButton(
+                text = stringResource(R.string.action_button_save),
+                onClick = onSaveClick,
+                enabled = isSaveEnabled,
+                type = ActionButtonType.DEACTIVE_MAIN,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 4.dp, bottom = 14.dp)
+                    .fillMaxWidth(),
             )
         }
     }
@@ -70,6 +138,13 @@ private fun EditProfileScreen(
 @Composable
 private fun EditProfileScreenPreview() {
     EditProfileScreen(
+        profileImageUrl = null,
+        nickname = "포티공주",
+        nicknameError = null,
+        isSaveEnabled = true,
         onBackClick = {},
+        onProfileImageSelected = {},
+        onNicknameChange = {},
+        onSaveClick = {},
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
@@ -47,7 +47,9 @@ fun EditProfileRoute(
     }
 
     EditProfileScreen(
-        profileImageUrl = uiState.selectedImageUri?.toString() ?: uiState.profileImageUrl,
+        profileImageUrl = uiState.selectedImageUri?.toString()
+            ?: uiState.savedProfileImageUri?.toString()
+            ?: uiState.profileImageUrl,
         nickname = uiState.nickname,
         nicknameError = uiState.nicknameError,
         isSaveEnabled = uiState.isSaveEnabled,

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileScreen.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,6 +26,7 @@ import com.poti.android.core.designsystem.component.button.ActionButtonType
 import com.poti.android.core.designsystem.component.button.PotiActionButton
 import com.poti.android.core.designsystem.component.field.PotiShortTextField
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
+import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.presentation.onboarding.model.ErrorText
 import com.poti.android.presentation.user.component.EditableUserProfileImage
 import com.poti.android.presentation.user.editprofile.model.EditProfileUiEffect
@@ -78,11 +80,14 @@ private fun EditProfileScreen(
     }
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.white),
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,
             title = stringResource(R.string.profile_management_title),
+            containerColor = PotiTheme.colors.white,
         )
 
         Column(

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
@@ -3,6 +3,7 @@ package com.poti.android.presentation.user.editprofile
 import com.poti.android.R
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.core.network.model.NetworkError
 import com.poti.android.domain.type.ImageUploadType
 import com.poti.android.domain.usecase.image.UploadImagesUseCase
 import com.poti.android.domain.usecase.user.CheckNicknameDuplicationUseCase
@@ -121,8 +122,19 @@ class EditProfileViewModel @Inject constructor(
                     )
                 }
             }
-            .onFailure {
-                updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_server)) }
+            .onFailure { error ->
+                if (error is NetworkError.BadRequest) {
+                    when (error.code) {
+                        40003 -> {
+                            updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
+                        }
+                        else -> {
+                            updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)) }
+                        }
+                    }
+                } else {
+                    updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_server)) }
+                }
             }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
@@ -92,35 +92,43 @@ class EditProfileViewModel @Inject constructor(
         }
     }
 
-    private fun handleSaveClick() = launchScope {
+    private fun handleSaveClick() {
         val currentState = uiState.value
+        if (currentState.saveState is ApiState.Loading) return
+
         updateState { copy(saveState = ApiState.Loading) }
 
-        val uploadedFileName = currentState.selectedImageUri?.let { uri ->
-            uploadImagesUseCase(
-                uploadType = ImageUploadType.PROFILE,
-                uriStrings = listOf(uri.toString()),
-            ).getOrElse { error ->
+        launchScope(
+            onError = { error ->
                 updateState { copy(saveState = ApiState.Failure(error.message ?: "Failed")) }
-                return@launchScope
-            }.first()
-        }
-
-        editProfileUseCase(
-            nickname = currentState.nickname,
-            profileImageUrl = uploadedFileName ?: currentState.profileImageUrl.orEmpty(),
-        ).onSuccess {
-            updateState {
-                copy(
-                    originalNickname = currentState.nickname,
-                    profileImageUrl = uploadedFileName ?: currentState.profileImageUrl,
-                    savedProfileImageUri = currentState.selectedImageUri ?: currentState.savedProfileImageUri,
-                    selectedImageUri = null,
-                    saveState = ApiState.Success(Unit),
-                )
+            },
+        ) {
+            val uploadedFileName = currentState.selectedImageUri?.let { uri ->
+                uploadImagesUseCase(
+                    uploadType = ImageUploadType.PROFILE,
+                    uriStrings = listOf(uri.toString()),
+                ).getOrElse { error ->
+                    updateState { copy(saveState = ApiState.Failure(error.message ?: "Failed")) }
+                    return@launchScope
+                }.first()
             }
-        }.onFailure { error ->
-            updateState { copy(saveState = ApiState.Failure(error.message ?: "Failed")) }
+
+            editProfileUseCase(
+                nickname = currentState.nickname,
+                profileImageUrl = uploadedFileName ?: currentState.profileImageUrl.orEmpty(),
+            ).onSuccess {
+                updateState {
+                    copy(
+                        originalNickname = currentState.nickname,
+                        profileImageUrl = uploadedFileName ?: currentState.profileImageUrl,
+                        savedProfileImageUri = currentState.selectedImageUri ?: currentState.savedProfileImageUri,
+                        selectedImageUri = null,
+                        saveState = ApiState.Success(Unit),
+                    )
+                }
+            }.onFailure { error ->
+                updateState { copy(saveState = ApiState.Failure(error.message ?: "Failed")) }
+            }
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
@@ -2,7 +2,11 @@ package com.poti.android.presentation.user.editprofile
 
 import com.poti.android.R
 import com.poti.android.core.base.BaseViewModel
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.type.ImageUploadType
+import com.poti.android.domain.usecase.image.UploadImagesUseCase
 import com.poti.android.domain.usecase.user.CheckNicknameDuplicationUseCase
+import com.poti.android.domain.usecase.user.EditProfileUseCase
 import com.poti.android.domain.usecase.user.GetUserMyPageUseCase
 import com.poti.android.presentation.onboarding.model.ErrorText
 import com.poti.android.presentation.user.editprofile.model.EditProfileUiEffect
@@ -18,6 +22,8 @@ private val NICKNAME_REGEX = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$".toRegex()
 class EditProfileViewModel @Inject constructor(
     private val getUserMyPageUseCase: GetUserMyPageUseCase,
     private val checkNicknameDuplicationUseCase: CheckNicknameDuplicationUseCase,
+    private val uploadImagesUseCase: UploadImagesUseCase,
+    private val editProfileUseCase: EditProfileUseCase,
 ) : BaseViewModel<EditProfileUiState, EditProfileUiIntent, EditProfileUiEffect>(
         initialState = EditProfileUiState(),
     ) {
@@ -28,8 +34,7 @@ class EditProfileViewModel @Inject constructor(
                 updateState { copy(selectedImageUri = intent.uri) }
             }
             is EditProfileUiIntent.OnNicknameChange -> handleNicknameChange(intent.value)
-            // TODO: 닉네임/프로필 이미지 저장 API가 아직 없어서 처리 불가
-            EditProfileUiIntent.OnSaveClick -> {}
+            EditProfileUiIntent.OnSaveClick -> handleSaveClick()
         }
     }
 
@@ -74,6 +79,31 @@ class EditProfileViewModel @Inject constructor(
 
         if (error == null && value.length >= 2 && value != originalNickname) {
             checkNicknameDuplication(value)
+        }
+    }
+
+    private fun handleSaveClick() = launchScope {
+        val currentState = uiState.value
+        updateState { copy(saveState = ApiState.Loading) }
+
+        val uploadedFileName = currentState.selectedImageUri?.let { uri ->
+            uploadImagesUseCase(
+                uploadType = ImageUploadType.PROFILE,
+                uriStrings = listOf(uri.toString()),
+            ).getOrElse { error ->
+                updateState { copy(saveState = ApiState.Failure(error.message ?: "Failed")) }
+                return@launchScope
+            }.first()
+        }
+
+        editProfileUseCase(
+            nickname = currentState.nickname,
+            profileImageUrl = uploadedFileName ?: currentState.profileImageUrl.orEmpty(),
+        ).onSuccess {
+            updateState { copy(saveState = ApiState.Success(Unit)) }
+            sendEffect(EditProfileUiEffect.NavigateBack)
+        }.onFailure { error ->
+            updateState { copy(saveState = ApiState.Failure(error.message ?: "Failed")) }
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
@@ -1,0 +1,99 @@
+package com.poti.android.presentation.user.editprofile
+
+import com.poti.android.R
+import com.poti.android.core.base.BaseViewModel
+import com.poti.android.domain.usecase.user.CheckNicknameDuplicationUseCase
+import com.poti.android.domain.usecase.user.GetUserMyPageUseCase
+import com.poti.android.presentation.onboarding.model.ErrorText
+import com.poti.android.presentation.user.editprofile.model.EditProfileUiEffect
+import com.poti.android.presentation.user.editprofile.model.EditProfileUiIntent
+import com.poti.android.presentation.user.editprofile.model.EditProfileUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import timber.log.Timber
+import javax.inject.Inject
+
+private val NICKNAME_REGEX = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$".toRegex()
+
+@HiltViewModel
+class EditProfileViewModel @Inject constructor(
+    private val getUserMyPageUseCase: GetUserMyPageUseCase,
+    private val checkNicknameDuplicationUseCase: CheckNicknameDuplicationUseCase,
+) : BaseViewModel<EditProfileUiState, EditProfileUiIntent, EditProfileUiEffect>(
+        initialState = EditProfileUiState(),
+    ) {
+    private var originalNickname: String = ""
+
+    override fun processIntent(intent: EditProfileUiIntent) {
+        when (intent) {
+            EditProfileUiIntent.OnBackClick -> sendEffect(EditProfileUiEffect.NavigateBack)
+            is EditProfileUiIntent.OnProfileImageSelected -> {
+                updateState { copy(selectedImageUri = intent.uri) }
+            }
+            is EditProfileUiIntent.OnNicknameChange -> handleNicknameChange(intent.value)
+            // TODO: 닉네임/프로필 이미지 저장 API가 아직 없어서 처리 불가
+            EditProfileUiIntent.OnSaveClick -> {}
+        }
+    }
+
+    init {
+        loadCurrentProfile()
+    }
+
+    private fun loadCurrentProfile() = launchScope {
+        getUserMyPageUseCase()
+            .onSuccess { userMyPage ->
+                originalNickname = userMyPage.nickname
+                updateState {
+                    copy(
+                        nickname = userMyPage.nickname,
+                        profileImageUrl = userMyPage.profileImageUrl,
+                        isNicknameValid = true,
+                    )
+                }
+            }
+            .onFailure { error ->
+                Timber.e(error, "내 프로필 조회 실패")
+            }
+    }
+
+    private fun handleNicknameChange(value: String) {
+        val hasSpecialChar = !value.matches(NICKNAME_REGEX)
+
+        val error: ErrorText? = when {
+            value.length < 2 && value.isNotEmpty() -> ErrorText.StringResource(R.string.onboarding_nickname_error_min_length)
+            hasSpecialChar -> ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)
+            else -> null
+        }
+
+        updateState {
+            copy(
+                nickname = value,
+                nicknameError = error,
+                isNicknameValid = value == originalNickname,
+            )
+        }
+
+        if (error == null && value.length >= 2 && value != originalNickname) {
+            checkNicknameDuplication(value)
+        }
+    }
+
+    private fun checkNicknameDuplication(nickname: String) = launchScope {
+        checkNicknameDuplicationUseCase(nickname)
+            .onSuccess { isDuplicated ->
+                if (isDuplicated) {
+                    updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
+                    return@onSuccess
+                }
+                updateState {
+                    copy(
+                        nicknameError = null,
+                        isNicknameValid = true,
+                    )
+                }
+            }
+            .onFailure {
+                updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_server)) }
+            }
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
@@ -51,6 +51,8 @@ class EditProfileViewModel @Inject constructor(
                         originalNickname = userMyPage.nickname,
                         nickname = userMyPage.nickname,
                         profileImageUrl = userMyPage.profileImageUrl,
+                        savedProfileImageUri = null,
+                        selectedImageUri = null,
                         isNicknameValid = true,
                     )
                 }
@@ -101,8 +103,15 @@ class EditProfileViewModel @Inject constructor(
             nickname = currentState.nickname,
             profileImageUrl = uploadedFileName ?: currentState.profileImageUrl.orEmpty(),
         ).onSuccess {
-            updateState { copy(saveState = ApiState.Success(Unit)) }
-            sendEffect(EditProfileUiEffect.NavigateBack)
+            updateState {
+                copy(
+                    originalNickname = currentState.nickname,
+                    profileImageUrl = uploadedFileName ?: currentState.profileImageUrl,
+                    savedProfileImageUri = currentState.selectedImageUri ?: currentState.savedProfileImageUri,
+                    selectedImageUri = null,
+                    saveState = ApiState.Success(Unit),
+                )
+            }
         }.onFailure { error ->
             updateState { copy(saveState = ApiState.Failure(error.message ?: "Failed")) }
         }

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.user.editprofile
 
+import androidx.lifecycle.viewModelScope
 import com.poti.android.R
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
@@ -14,6 +15,8 @@ import com.poti.android.presentation.user.editprofile.model.EditProfileUiEffect
 import com.poti.android.presentation.user.editprofile.model.EditProfileUiIntent
 import com.poti.android.presentation.user.editprofile.model.EditProfileUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -28,6 +31,8 @@ class EditProfileViewModel @Inject constructor(
 ) : BaseViewModel<EditProfileUiState, EditProfileUiIntent, EditProfileUiEffect>(
         initialState = EditProfileUiState(),
     ) {
+    private var nicknameCheckJob: Job? = null
+
     override fun processIntent(intent: EditProfileUiIntent) {
         when (intent) {
             EditProfileUiIntent.OnBackClick -> sendEffect(EditProfileUiEffect.NavigateBack)
@@ -63,6 +68,8 @@ class EditProfileViewModel @Inject constructor(
     }
 
     private fun handleNicknameChange(value: String) {
+        nicknameCheckJob?.cancel()
+
         val originalNickname = uiState.value.originalNickname
         val hasSpecialChar = !value.matches(NICKNAME_REGEX)
 
@@ -117,33 +124,39 @@ class EditProfileViewModel @Inject constructor(
         }
     }
 
-    private fun checkNicknameDuplication(nickname: String) = launchScope {
-        checkNicknameDuplicationUseCase(nickname)
-            .onSuccess { isDuplicated ->
-                if (isDuplicated) {
-                    updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
-                    return@onSuccess
-                }
-                updateState {
-                    copy(
-                        nicknameError = null,
-                        isNicknameValid = true,
-                    )
-                }
-            }
-            .onFailure { error ->
-                if (error is NetworkError.BadRequest) {
-                    when (error.code) {
-                        40003 -> {
-                            updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
-                        }
-                        else -> {
-                            updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)) }
-                        }
+    private fun checkNicknameDuplication(nickname: String) {
+        nicknameCheckJob = viewModelScope.launch {
+            checkNicknameDuplicationUseCase(nickname)
+                .onSuccess { isDuplicated ->
+                    if (uiState.value.nickname != nickname) return@onSuccess
+
+                    if (isDuplicated) {
+                        updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
+                        return@onSuccess
                     }
-                } else {
-                    updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_server)) }
+                    updateState {
+                        copy(
+                            nicknameError = null,
+                            isNicknameValid = true,
+                        )
+                    }
                 }
-            }
+                .onFailure { error ->
+                    if (uiState.value.nickname != nickname) return@onFailure
+
+                    if (error is NetworkError.BadRequest) {
+                        when (error.code) {
+                            40003 -> {
+                                updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
+                            }
+                            else -> {
+                                updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)) }
+                            }
+                        }
+                    } else {
+                        updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_server)) }
+                    }
+                }
+        }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
@@ -1,16 +1,14 @@
 package com.poti.android.presentation.user.editprofile
 
 import androidx.lifecycle.viewModelScope
-import com.poti.android.R
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
-import com.poti.android.core.network.model.NetworkError
+import com.poti.android.core.common.util.NicknameValidator
 import com.poti.android.domain.type.ImageUploadType
 import com.poti.android.domain.usecase.image.UploadImagesUseCase
 import com.poti.android.domain.usecase.user.CheckNicknameDuplicationUseCase
 import com.poti.android.domain.usecase.user.EditProfileUseCase
 import com.poti.android.domain.usecase.user.GetUserMyPageUseCase
-import com.poti.android.presentation.onboarding.model.ErrorText
 import com.poti.android.presentation.user.editprofile.model.EditProfileUiEffect
 import com.poti.android.presentation.user.editprofile.model.EditProfileUiIntent
 import com.poti.android.presentation.user.editprofile.model.EditProfileUiState
@@ -19,8 +17,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
-
-private val NICKNAME_REGEX = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$".toRegex()
 
 @HiltViewModel
 class EditProfileViewModel @Inject constructor(
@@ -71,13 +67,7 @@ class EditProfileViewModel @Inject constructor(
         nicknameCheckJob?.cancel()
 
         val originalNickname = uiState.value.originalNickname
-        val hasSpecialChar = !value.matches(NICKNAME_REGEX)
-
-        val error: ErrorText? = when {
-            value.length < 2 && value.isNotEmpty() -> ErrorText.StringResource(R.string.onboarding_nickname_error_min_length)
-            hasSpecialChar -> ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)
-            else -> null
-        }
+        val error = NicknameValidator.validateFormat(value)
 
         updateState {
             copy(
@@ -87,7 +77,7 @@ class EditProfileViewModel @Inject constructor(
             )
         }
 
-        if (error == null && value.length >= 2 && value != originalNickname) {
+        if (error == null && value.length >= NicknameValidator.MIN_LENGTH && value != originalNickname) {
             checkNicknameDuplication(value)
         }
     }
@@ -139,7 +129,7 @@ class EditProfileViewModel @Inject constructor(
                     if (uiState.value.nickname != nickname) return@onSuccess
 
                     if (isDuplicated) {
-                        updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
+                        updateState { copy(nicknameError = NicknameValidator.duplicateNicknameError()) }
                         return@onSuccess
                     }
                     updateState {
@@ -152,18 +142,7 @@ class EditProfileViewModel @Inject constructor(
                 .onFailure { error ->
                     if (uiState.value.nickname != nickname) return@onFailure
 
-                    if (error is NetworkError.BadRequest) {
-                        when (error.code) {
-                            40003 -> {
-                                updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_duplicate)) }
-                            }
-                            else -> {
-                                updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_special_characters)) }
-                            }
-                        }
-                    } else {
-                        updateState { copy(nicknameError = ErrorText.StringResource(R.string.onboarding_nickname_error_server)) }
-                    }
+                    updateState { copy(nicknameError = NicknameValidator.toDuplicationCheckError(error)) }
                 }
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/EditProfileViewModel.kt
@@ -21,8 +21,6 @@ class EditProfileViewModel @Inject constructor(
 ) : BaseViewModel<EditProfileUiState, EditProfileUiIntent, EditProfileUiEffect>(
         initialState = EditProfileUiState(),
     ) {
-    private var originalNickname: String = ""
-
     override fun processIntent(intent: EditProfileUiIntent) {
         when (intent) {
             EditProfileUiIntent.OnBackClick -> sendEffect(EditProfileUiEffect.NavigateBack)
@@ -42,9 +40,9 @@ class EditProfileViewModel @Inject constructor(
     private fun loadCurrentProfile() = launchScope {
         getUserMyPageUseCase()
             .onSuccess { userMyPage ->
-                originalNickname = userMyPage.nickname
                 updateState {
                     copy(
+                        originalNickname = userMyPage.nickname,
                         nickname = userMyPage.nickname,
                         profileImageUrl = userMyPage.profileImageUrl,
                         isNicknameValid = true,
@@ -57,6 +55,7 @@ class EditProfileViewModel @Inject constructor(
     }
 
     private fun handleNicknameChange(value: String) {
+        val originalNickname = uiState.value.originalNickname
         val hasSpecialChar = !value.matches(NICKNAME_REGEX)
 
         val error: ErrorText? = when {

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/model/Contracts.kt
@@ -8,6 +8,7 @@ import com.poti.android.core.common.state.ApiState
 import com.poti.android.presentation.onboarding.model.ErrorText
 
 data class EditProfileUiState(
+    val originalNickname: String = "",
     val profileImageUrl: String? = null,
     val selectedImageUri: Uri? = null,
     val nickname: String = "",
@@ -15,8 +16,11 @@ data class EditProfileUiState(
     val isNicknameValid: Boolean = false,
     val saveState: ApiState<Unit> = ApiState.Init,
 ) : UiState {
+    val isModified: Boolean
+        get() = nickname != originalNickname || selectedImageUri != null
+
     val isSaveEnabled: Boolean
-        get() = isNicknameValid && nickname.isNotBlank()
+        get() = isNicknameValid && isModified
 }
 
 sealed interface EditProfileUiIntent : UiIntent {

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/model/Contracts.kt
@@ -5,12 +5,13 @@ import com.poti.android.core.base.UiEffect
 import com.poti.android.core.base.UiIntent
 import com.poti.android.core.base.UiState
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.presentation.onboarding.model.ErrorText
 
 data class EditProfileUiState(
     val profileImageUrl: String? = null,
     val selectedImageUri: Uri? = null,
     val nickname: String = "",
-    val nicknameError: String? = null,
+    val nicknameError: ErrorText? = null,
     val isNicknameValid: Boolean = false,
     val saveState: ApiState<Unit> = ApiState.Init,
 ) : UiState {

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/model/Contracts.kt
@@ -1,0 +1,33 @@
+package com.poti.android.presentation.user.editprofile.model
+
+import android.net.Uri
+import com.poti.android.core.base.UiEffect
+import com.poti.android.core.base.UiIntent
+import com.poti.android.core.base.UiState
+import com.poti.android.core.common.state.ApiState
+
+data class EditProfileUiState(
+    val profileImageUrl: String? = null,
+    val selectedImageUri: Uri? = null,
+    val nickname: String = "",
+    val nicknameError: String? = null,
+    val isNicknameValid: Boolean = false,
+    val saveState: ApiState<Unit> = ApiState.Init,
+) : UiState {
+    val isSaveEnabled: Boolean
+        get() = isNicknameValid && nickname.isNotBlank()
+}
+
+sealed interface EditProfileUiIntent : UiIntent {
+    data object OnBackClick : EditProfileUiIntent
+
+    data class OnProfileImageSelected(val uri: Uri) : EditProfileUiIntent
+
+    data class OnNicknameChange(val value: String) : EditProfileUiIntent
+
+    data object OnSaveClick : EditProfileUiIntent
+}
+
+sealed interface EditProfileUiEffect : UiEffect {
+    data object NavigateBack : EditProfileUiEffect
+}

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/model/Contracts.kt
@@ -10,6 +10,7 @@ import com.poti.android.presentation.onboarding.model.ErrorText
 data class EditProfileUiState(
     val originalNickname: String = "",
     val profileImageUrl: String? = null,
+    val savedProfileImageUri: Uri? = null,
     val selectedImageUri: Uri? = null,
     val nickname: String = "",
     val nicknameError: ErrorText? = null,
@@ -20,7 +21,7 @@ data class EditProfileUiState(
         get() = nickname != originalNickname || selectedImageUri != null
 
     val isSaveEnabled: Boolean
-        get() = isNicknameValid && isModified
+        get() = isNicknameValid && isModified && saveState !is ApiState.Loading
 }
 
 sealed interface EditProfileUiIntent : UiIntent {

--- a/app/src/main/java/com/poti/android/presentation/user/editprofile/navigation/EditProfileNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/editprofile/navigation/EditProfileNavigation.kt
@@ -1,0 +1,32 @@
+package com.poti.android.presentation.user.editprofile.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import com.poti.android.core.common.extension.slideComposable
+import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.user.editprofile.EditProfileRoute
+import kotlinx.serialization.Serializable
+
+sealed interface EditProfileRoute : Route {
+    @Serializable
+    data object EditProfile : EditProfileRoute
+}
+
+fun NavController.navigateToEditProfile() {
+    navigate(EditProfileRoute.EditProfile)
+}
+
+fun NavGraphBuilder.editProfileNavGraph(
+    navController: NavController,
+    paddingValues: PaddingValues,
+) {
+    slideComposable<EditProfileRoute.EditProfile> {
+        EditProfileRoute(
+            onPopBackStack = navController::popBackStack,
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/favoriteartist/FavoriteArtistScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
+import com.poti.android.core.common.constant.ExternalLinks
 import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.state.ApiState
@@ -45,7 +46,6 @@ fun FavoriteArtistRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val uriHandler = LocalUriHandler.current
-    val inquiryUrl = stringResource(R.string.user_inquiry_url)
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
@@ -61,7 +61,7 @@ fun FavoriteArtistRoute(
             viewModel.processIntent(FavoriteArtistUiIntent.OnArtistSelect(artistId))
         },
         onSaveClick = { viewModel.processIntent(FavoriteArtistUiIntent.OnSaveClick) },
-        onInquiryClick = { uriHandler.openUri(inquiryUrl) },
+        onInquiryClick = { uriHandler.openUri(ExternalLinks.INQUIRY) },
         modifier = modifier,
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
+import com.poti.android.core.common.constant.ExternalLinks
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPrimary
@@ -51,7 +52,6 @@ fun MyPageRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val uriHandler = LocalUriHandler.current
-    val inquiryUrl = stringResource(R.string.user_inquiry_url)
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.processIntent(MyPageUiIntent.OnResume)
@@ -73,7 +73,7 @@ fun MyPageRoute(
         MyPageScreen(
             userMyPage = userMyPage,
             onArtistClick = { viewModel.processIntent(MyPageUiIntent.OnArtistClick) },
-            onInquiryClick = { uriHandler.openUri(inquiryUrl) },
+            onInquiryClick = { uriHandler.openUri(ExternalLinks.INQUIRY) },
             onSettingClick = onNavigateToSetting,
             onHistoryClick = { mode, type ->
                 viewModel.processIntent(

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -40,6 +40,7 @@ import com.poti.android.presentation.user.mypage.model.MyPageUiIntent
 @Composable
 fun MyPageRoute(
     onNavigateToHistoryList: (HistoryMode, HistorySummaryType) -> Unit,
+    onNavigateToSetting: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
@@ -57,6 +58,7 @@ fun MyPageRoute(
         MyPageScreen(
             userMyPage = userMyPage,
             onArtistClick = {},
+            onSettingClick = onNavigateToSetting,
             onHistoryClick = { mode, type ->
                 viewModel.processIntent(
                     MyPageUiIntent.OnHistoryClick(mode, type),
@@ -71,6 +73,7 @@ fun MyPageRoute(
 private fun MyPageScreen(
     userMyPage: UserMyPage,
     onArtistClick: () -> Unit,
+    onSettingClick: () -> Unit,
     onHistoryClick: (HistoryMode, HistorySummaryType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -83,7 +86,7 @@ private fun MyPageScreen(
         PotiHeaderPrimary(
             title = stringResource(R.string.user_my_page_title),
             firstIconRes = R.drawable.ic_setting,
-            onFirstIconClick = {},
+            onFirstIconClick = onSettingClick,
             secondIconRes = R.drawable.ic_alarm,
             onSecondIconClick = {},
             containerColor = PotiTheme.colors.gray100,
@@ -184,6 +187,7 @@ private fun ProfileScreenPreview() {
                 ),
             ),
             onArtistClick = {},
+            onSettingClick = {},
             onHistoryClick = { _, _ -> },
             modifier = Modifier,
         )
@@ -216,6 +220,7 @@ private fun ProfileScreenPreview2() {
                 ),
             ),
             onArtistClick = {},
+            onSettingClick = {},
             onHistoryClick = { _, _ -> },
             modifier = Modifier,
         )

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import com.poti.android.core.navigation.Route
 import com.poti.android.presentation.history.navigation.navigateToHistoryList
 import com.poti.android.presentation.user.mypage.MyPageRoute
+import com.poti.android.presentation.user.setting.navigation.navigateToSetting
 import kotlinx.serialization.Serializable
 
 sealed interface MyPageRoute : Route {
@@ -27,6 +28,7 @@ fun NavGraphBuilder.myPageNavGraph(
     composable<MyPageRoute.MyPage> {
         MyPageRoute(
             onNavigateToHistoryList = navController::navigateToHistoryList,
+            onNavigateToSetting = navController::navigateToSetting,
             modifier = Modifier.padding(paddingValues),
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/user/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/SettingScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
+import com.poti.android.core.common.constant.ExternalLinks
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiMenuButton
 import com.poti.android.core.designsystem.component.display.PotiDivider
@@ -32,11 +34,11 @@ fun SettingRoute(
     onNavigateToProfileManagement: () -> Unit,
     onNavigateToAddressManagement: () -> Unit,
     onNavigateToAlarmSetting: () -> Unit,
-    onNavigateToPersonalInfoPrivacy: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SettingViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uriHandler = LocalUriHandler.current
 
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
@@ -45,7 +47,7 @@ fun SettingRoute(
             SettingUiEffect.NavigateToProfileManagement -> onNavigateToProfileManagement()
             SettingUiEffect.NavigateToAddressManagement -> onNavigateToAddressManagement()
             SettingUiEffect.NavigateToAlarmSetting -> onNavigateToAlarmSetting()
-            SettingUiEffect.NavigateToPersonalInfoPrivacy -> onNavigateToPersonalInfoPrivacy()
+            SettingUiEffect.NavigateToPersonalInfoPrivacy -> uriHandler.openUri(ExternalLinks.TERMS)
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/user/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/SettingScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.user.setting
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -74,11 +75,14 @@ private fun SettingScreen(
     val scrollState = rememberScrollState()
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.white),
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,
             title = stringResource(R.string.setting_title),
+            containerColor = PotiTheme.colors.white,
         )
 
         Column(

--- a/app/src/main/java/com/poti/android/presentation/user/setting/SettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/SettingScreen.kt
@@ -1,4 +1,4 @@
-package com.poti.android.presentation.setting
+package com.poti.android.presentation.user.setting
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,8 +21,8 @@ import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
-import com.poti.android.presentation.setting.model.SettingUiEffect
-import com.poti.android.presentation.setting.model.SettingUiIntent
+import com.poti.android.presentation.user.setting.model.SettingUiEffect
+import com.poti.android.presentation.user.setting.model.SettingUiIntent
 
 @Composable
 fun SettingRoute(

--- a/app/src/main/java/com/poti/android/presentation/user/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/SettingViewModel.kt
@@ -1,10 +1,10 @@
-package com.poti.android.presentation.setting
+package com.poti.android.presentation.user.setting
 
 import com.poti.android.BuildConfig
 import com.poti.android.core.base.BaseViewModel
-import com.poti.android.presentation.setting.model.SettingUiEffect
-import com.poti.android.presentation.setting.model.SettingUiIntent
-import com.poti.android.presentation.setting.model.SettingUiState
+import com.poti.android.presentation.user.setting.model.SettingUiEffect
+import com.poti.android.presentation.user.setting.model.SettingUiIntent
+import com.poti.android.presentation.user.setting.model.SettingUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 

--- a/app/src/main/java/com/poti/android/presentation/user/setting/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/model/Contracts.kt
@@ -1,4 +1,4 @@
-package com.poti.android.presentation.setting.model
+package com.poti.android.presentation.user.setting.model
 
 import com.poti.android.core.base.UiEffect
 import com.poti.android.core.base.UiIntent

--- a/app/src/main/java/com/poti/android/presentation/user/setting/navigation/SettingNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/navigation/SettingNavigation.kt
@@ -7,6 +7,9 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import com.poti.android.core.common.extension.slideComposable
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.user.account.navigation.navigateToAccountSetting
+import com.poti.android.presentation.user.address.navigation.navigateToAddressManagement
+import com.poti.android.presentation.user.editprofile.navigation.navigateToEditProfile
 import com.poti.android.presentation.user.setting.SettingRoute
 import kotlinx.serialization.Serializable
 
@@ -26,9 +29,9 @@ fun NavGraphBuilder.settingNavGraph(
     slideComposable<SettingRoute.Setting> {
         SettingRoute(
             onPopBackStack = navController::popBackStack,
-            onNavigateToAccount = {},
-            onNavigateToProfileManagement = {},
-            onNavigateToAddressManagement = {},
+            onNavigateToAccount = navController::navigateToAccountSetting,
+            onNavigateToProfileManagement = navController::navigateToEditProfile,
+            onNavigateToAddressManagement = navController::navigateToAddressManagement,
             onNavigateToAlarmSetting = {},
             onNavigateToPersonalInfoPrivacy = {},
             modifier = Modifier.padding(paddingValues),

--- a/app/src/main/java/com/poti/android/presentation/user/setting/navigation/SettingNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/navigation/SettingNavigation.kt
@@ -33,7 +33,6 @@ fun NavGraphBuilder.settingNavGraph(
             onNavigateToProfileManagement = navController::navigateToEditProfile,
             onNavigateToAddressManagement = navController::navigateToAddressManagement,
             onNavigateToAlarmSetting = {},
-            onNavigateToPersonalInfoPrivacy = {},
             modifier = Modifier.padding(paddingValues),
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/user/setting/navigation/SettingNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/navigation/SettingNavigation.kt
@@ -1,0 +1,37 @@
+package com.poti.android.presentation.user.setting.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import com.poti.android.core.common.extension.slideComposable
+import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.user.setting.SettingRoute
+import kotlinx.serialization.Serializable
+
+sealed interface SettingRoute : Route {
+    @Serializable
+    data object Setting : SettingRoute
+}
+
+fun NavController.navigateToSetting() {
+    navigate(SettingRoute.Setting)
+}
+
+fun NavGraphBuilder.settingNavGraph(
+    navController: NavController,
+    paddingValues: PaddingValues,
+) {
+    slideComposable<SettingRoute.Setting> {
+        SettingRoute(
+            onPopBackStack = navController::popBackStack,
+            onNavigateToAccount = {},
+            onNavigateToProfileManagement = {},
+            onNavigateToAddressManagement = {},
+            onNavigateToAlarmSetting = {},
+            onNavigateToPersonalInfoPrivacy = {},
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/setting/navigation/SettingNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/setting/navigation/SettingNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import com.poti.android.core.common.extension.slideComposable
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.alarm.navigation.navigateToAlarmSetting
 import com.poti.android.presentation.user.account.navigation.navigateToAccountSetting
 import com.poti.android.presentation.user.address.navigation.navigateToAddressManagement
 import com.poti.android.presentation.user.editprofile.navigation.navigateToEditProfile
@@ -32,7 +33,7 @@ fun NavGraphBuilder.settingNavGraph(
             onNavigateToAccount = navController::navigateToAccountSetting,
             onNavigateToProfileManagement = navController::navigateToEditProfile,
             onNavigateToAddressManagement = navController::navigateToAddressManagement,
-            onNavigateToAlarmSetting = {},
+            onNavigateToAlarmSetting = navController::navigateToAlarmSetting,
             modifier = Modifier.padding(paddingValues),
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/WithdrawalScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/WithdrawalScreen.kt
@@ -22,11 +22,19 @@ import com.poti.android.core.designsystem.theme.PotiTheme
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
-fun WithdrawalRoute(modifier: Modifier = Modifier) {
+fun WithdrawalRoute(
+    onPopBackStack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    WithdrawalScreen(
+        onBackClick = onPopBackStack,
+        modifier = modifier,
+    )
 }
 
 @Composable
-fun WithdrawalScreen(
+private fun WithdrawalScreen(
+    onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -35,7 +43,7 @@ fun WithdrawalScreen(
         modifier = modifier.fillMaxSize(),
     ) {
         PotiHeaderPage(
-            onNavigationClick = {},
+            onNavigationClick = onBackClick,
             title = stringResource(R.string.withdrawal_title),
         )
 
@@ -81,5 +89,7 @@ fun WithdrawalScreen(
 @Preview(showBackground = true)
 @Composable
 private fun WithdrawalScreenPreview() {
-    WithdrawalScreen()
+    WithdrawalScreen(
+        onBackClick = {},
+    )
 }

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/WithdrawalScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/WithdrawalScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.user.withdrawal
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -40,11 +41,14 @@ private fun WithdrawalScreen(
     val scrollState = rememberScrollState()
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.white),
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,
             title = stringResource(R.string.withdrawal_title),
+            containerColor = PotiTheme.colors.white,
         )
 
         Column(

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/navigation/WithdrawalNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/navigation/WithdrawalNavigation.kt
@@ -1,0 +1,32 @@
+package com.poti.android.presentation.user.withdrawal.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import com.poti.android.core.common.extension.slideComposable
+import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.user.withdrawal.WithdrawalRoute
+import kotlinx.serialization.Serializable
+
+sealed interface WithdrawalRoute : Route {
+    @Serializable
+    data object Withdrawal : WithdrawalRoute
+}
+
+fun NavController.navigateToWithdrawal() {
+    navigate(WithdrawalRoute.Withdrawal)
+}
+
+fun NavGraphBuilder.withdrawalNavGraph(
+    navController: NavController,
+    paddingValues: PaddingValues,
+) {
+    slideComposable<WithdrawalRoute.Withdrawal> {
+        WithdrawalRoute(
+            onPopBackStack = navController::popBackStack,
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,7 +256,6 @@
     <string name="user_select_favorite_artist">나의 최애 선택</string>
     <string name="user_inquiry_description">궁금한 점이나 건의사항이 있다면 알려주세요</string>
     <string name="user_inquiry_action">문의하기</string>
-    <string name="user_inquiry_url" translatable="false">https://poti-support.notion.site/3c4909fac41b80f4b881e8a5850d6574</string>
 
     <!-- Favorite Artist -->
     <string name="favorite_artist_title">나의 최애 선택</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,8 @@
     <string name="account_name">이름</string>
     <string name="account_email">이메일</string>
     <string name="social_account">연결된 소셜 계정</string>
+    <string name="social_type_kakao">카카오</string>
+    <string name="social_type_google">구글</string>
 
     <string name="account_logout">로그아웃</string>
     <string name="account_withdrawal_menu">회원탈퇴</string>

--- a/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
@@ -194,6 +194,8 @@ class LoginViewModelTest {
         override suspend fun saveOnboardingState(isCompleted: Boolean): Result<Unit> =
             Result.success(Unit)
 
+        override suspend fun logout(): Result<Unit> = Result.success(Unit)
+
         override suspend fun withdrawal(): Result<Unit> = Result.success(Unit)
     }
 

--- a/app/src/test/java/com/poti/android/presentation/user/account/AccountSettingViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/user/account/AccountSettingViewModelTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -54,7 +53,7 @@ class AccountSettingViewModelTest {
             advanceUntilIdle()
 
             assertEquals(1, authRepository.logoutCallCount)
-            assertTrue(viewModel.uiState.value.isLoggingOut)
+            assertFalse(viewModel.uiState.value.isLoggingOut)
         }
 
     @Test

--- a/app/src/test/java/com/poti/android/presentation/user/account/AccountSettingViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/user/account/AccountSettingViewModelTest.kt
@@ -1,0 +1,106 @@
+package com.poti.android.presentation.user.account
+
+import com.poti.android.MainDispatcherRule
+import com.poti.android.domain.model.auth.AuthState
+import com.poti.android.domain.model.auth.SocialType
+import com.poti.android.domain.model.auth.UserAuth
+import com.poti.android.domain.model.user.UserAccount
+import com.poti.android.domain.repository.AuthRepository
+import com.poti.android.domain.repository.UserRepository
+import com.poti.android.domain.usecase.auth.LogoutUseCase
+import com.poti.android.domain.usecase.user.GetUserAccountUseCase
+import com.poti.android.presentation.user.account.model.AccountSettingUiIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountSettingViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var authRepository: FakeAuthRepository
+    private lateinit var viewModel: AccountSettingViewModel
+
+    @Before
+    fun setUp() {
+        val userRepository = mock(UserRepository::class.java)
+        runBlocking {
+            `when`(userRepository.getUserAccount()).thenReturn(Result.success(USER_ACCOUNT))
+        }
+        authRepository = FakeAuthRepository()
+        viewModel = AccountSettingViewModel(
+            getUserAccountUseCase = GetUserAccountUseCase(userRepository),
+            logoutUseCase = LogoutUseCase(authRepository),
+        )
+    }
+
+    @Test
+    fun `requests logout only once when logout is clicked repeatedly`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            viewModel.processIntent(AccountSettingUiIntent.OnLogoutClick)
+            viewModel.processIntent(AccountSettingUiIntent.OnLogoutClick)
+            advanceUntilIdle()
+
+            assertEquals(1, authRepository.logoutCallCount)
+            assertTrue(viewModel.uiState.value.isLoggingOut)
+        }
+
+    @Test
+    fun `allows logout retry when logout fails`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            authRepository.logoutResult = Result.failure(IllegalStateException("logout failed"))
+
+            viewModel.processIntent(AccountSettingUiIntent.OnLogoutClick)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isLoggingOut)
+
+            viewModel.processIntent(AccountSettingUiIntent.OnLogoutClick)
+            advanceUntilIdle()
+
+            assertEquals(2, authRepository.logoutCallCount)
+        }
+
+    private class FakeAuthRepository : AuthRepository {
+        var logoutResult: Result<Unit> = Result.success(Unit)
+        var logoutCallCount: Int = 0
+            private set
+
+        override fun observeAuthState(): Flow<AuthState> = emptyFlow()
+
+        override suspend fun login(
+            socialType: SocialType,
+            token: String,
+        ): Result<UserAuth> = error("Not used")
+
+        override suspend fun saveOnboardingState(isCompleted: Boolean): Result<Unit> =
+            error("Not used")
+
+        override suspend fun logout(): Result<Unit> {
+            logoutCallCount += 1
+            return logoutResult
+        }
+
+        override suspend fun withdrawal(): Result<Unit> = error("Not used")
+    }
+
+    private companion object {
+        val USER_ACCOUNT = UserAccount(
+            nickname = "poti",
+            email = "poti@example.com",
+            socialType = SocialType.KAKAO,
+        )
+    }
+}

--- a/app/src/test/java/com/poti/android/presentation/user/editprofile/EditProfileViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/user/editprofile/EditProfileViewModelTest.kt
@@ -1,0 +1,202 @@
+package com.poti.android.presentation.user.editprofile
+
+import com.poti.android.MainDispatcherRule
+import com.poti.android.R
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.model.user.HistorySummary
+import com.poti.android.domain.model.user.UserAccount
+import com.poti.android.domain.model.user.UserMyPage
+import com.poti.android.domain.model.user.UserProfile
+import com.poti.android.domain.repository.FileUploadRepository
+import com.poti.android.domain.repository.ImageRepository
+import com.poti.android.domain.repository.UserRepository
+import com.poti.android.domain.usecase.image.UploadImagesUseCase
+import com.poti.android.domain.usecase.user.CheckNicknameDuplicationUseCase
+import com.poti.android.domain.usecase.user.EditProfileUseCase
+import com.poti.android.domain.usecase.user.GetUserMyPageUseCase
+import com.poti.android.presentation.onboarding.model.ErrorText
+import com.poti.android.presentation.user.editprofile.model.EditProfileUiIntent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditProfileViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var userRepository: FakeUserRepository
+    private lateinit var imageRepository: ImageRepository
+    private lateinit var fileUploadRepository: FileUploadRepository
+    private lateinit var viewModel: EditProfileViewModel
+
+    @Before
+    fun setUp() {
+        userRepository = FakeUserRepository()
+        imageRepository = mock(ImageRepository::class.java)
+        fileUploadRepository = mock(FileUploadRepository::class.java)
+        viewModel = EditProfileViewModel(
+            getUserMyPageUseCase = GetUserMyPageUseCase(userRepository),
+            checkNicknameDuplicationUseCase = CheckNicknameDuplicationUseCase(userRepository),
+            uploadImagesUseCase = UploadImagesUseCase(imageRepository, fileUploadRepository),
+            editProfileUseCase = EditProfileUseCase(userRepository),
+        )
+    }
+
+    @Test
+    fun `ignores an older nickname result that completes after the latest result`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            advanceUntilIdle()
+            val olderResult = userRepository.prepareNicknameResult("이전닉네임")
+            val latestResult = userRepository.prepareNicknameResult("최신닉네임")
+
+            viewModel.processIntent(EditProfileUiIntent.OnNicknameChange("이전닉네임"))
+            runCurrent()
+            viewModel.processIntent(EditProfileUiIntent.OnNicknameChange("최신닉네임"))
+            runCurrent()
+
+            latestResult.complete(Result.success(true))
+            runCurrent()
+            olderResult.complete(Result.success(false))
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals("최신닉네임", state.nickname)
+            assertFalse(state.isNicknameValid)
+            assertEquals(
+                R.string.onboarding_nickname_error_duplicate,
+                (state.nicknameError as ErrorText.StringResource).resId,
+            )
+        }
+
+    @Test
+    fun `patches profile only once when save intent is sent consecutively`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            advanceUntilIdle()
+            makeNicknameValid("새닉네임")
+            val patchResult = CompletableDeferred<Result<Unit>>()
+            userRepository.patchProfileResult = patchResult
+
+            viewModel.processIntent(EditProfileUiIntent.OnSaveClick)
+            viewModel.processIntent(EditProfileUiIntent.OnSaveClick)
+            runCurrent()
+
+            assertEquals(1, userRepository.patchProfileCallCount)
+            assertEquals(ApiState.Loading, viewModel.uiState.value.saveState)
+
+            patchResult.complete(Result.success(Unit))
+            advanceUntilIdle()
+
+            assertEquals(1, userRepository.patchProfileCallCount)
+            assertEquals(ApiState.Success(Unit), viewModel.uiState.value.saveState)
+            assertEquals("새닉네임", userRepository.lastPatchedNickname)
+            assertEquals(PROFILE_IMAGE_URL, userRepository.lastPatchedProfileImageUrl)
+            verifyNoInteractions(imageRepository, fileUploadRepository)
+        }
+
+    @Test
+    fun `allows save retry after profile patch fails`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            advanceUntilIdle()
+            makeNicknameValid("재시도닉네임")
+            userRepository.patchResults.add(Result.failure(IllegalStateException("patch failed")))
+            userRepository.patchResults.add(Result.success(Unit))
+
+            viewModel.processIntent(EditProfileUiIntent.OnSaveClick)
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.saveState is ApiState.Failure)
+
+            viewModel.processIntent(EditProfileUiIntent.OnSaveClick)
+            advanceUntilIdle()
+
+            assertEquals(2, userRepository.patchProfileCallCount)
+            assertEquals(ApiState.Success(Unit), viewModel.uiState.value.saveState)
+        }
+
+    private suspend fun TestScope.makeNicknameValid(nickname: String) {
+        userRepository.prepareNicknameResult(nickname).complete(Result.success(false))
+        viewModel.processIntent(EditProfileUiIntent.OnNicknameChange(nickname))
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.isNicknameValid)
+    }
+
+    private class FakeUserRepository : UserRepository {
+        private val nicknameResults = mutableMapOf<String, CompletableDeferred<Result<Boolean>>>()
+
+        val patchResults = ArrayDeque<Result<Unit>>()
+        var patchProfileResult: CompletableDeferred<Result<Unit>>? = null
+        var patchProfileCallCount = 0
+            private set
+        var lastPatchedNickname: String? = null
+            private set
+        var lastPatchedProfileImageUrl: String? = null
+            private set
+
+        fun prepareNicknameResult(nickname: String): CompletableDeferred<Result<Boolean>> =
+            CompletableDeferred<Result<Boolean>>().also { nicknameResults[nickname] = it }
+
+        override suspend fun postNicknameDuplicate(nickname: String): Result<Boolean> {
+            val result = nicknameResults.getValue(nickname)
+            return try {
+                result.await()
+            } catch (cancellation: CancellationException) {
+                withContext(NonCancellable) { result.await() }
+            }
+        }
+
+        override suspend fun getUserMyPage(): Result<UserMyPage> = Result.success(USER_MY_PAGE)
+
+        override suspend fun patchProfile(
+            nickname: String,
+            profileImageUrl: String,
+        ): Result<Unit> {
+            patchProfileCallCount += 1
+            lastPatchedNickname = nickname
+            lastPatchedProfileImageUrl = profileImageUrl
+            return patchProfileResult?.await() ?: patchResults.removeFirstOrNull() ?: Result.success(Unit)
+        }
+
+        override suspend fun patchOnboarding(
+            nickname: String,
+            favoriteArtistId: Long?,
+        ): Result<Unit> = error("Not used")
+
+        override suspend fun patchFavoriteArtist(artistId: Long): Result<Unit> = error("Not used")
+
+        override suspend fun getUserProfile(userId: Long): Result<UserProfile> = error("Not used")
+
+        override suspend fun getUserAccount(): Result<UserAccount> = error("Not used")
+    }
+
+    private companion object {
+        const val PROFILE_IMAGE_URL = "https://cdn.poti.kr/profiles/profile.jpg"
+
+        val USER_MY_PAGE = UserMyPage(
+            nickname = "기존닉네임",
+            email = "poti@example.com",
+            profileImageUrl = PROFILE_IMAGE_URL,
+            ratingAvg = "4.8",
+            activityMessage = "최근 3일 이내 활동",
+            joinedAt = "2026-07-28",
+            hasFavoriteArtist = true,
+            favoriteArtistName = "IVE",
+            participationSummary = HistorySummary(inProgress = 1, completed = 2),
+            recruitSummary = HistorySummary(inProgress = 3, completed = 4),
+        )
+    }
+}


### PR DESCRIPTION
## Related issue 🛠️
- closed #190

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 설정 화면 및 사용자 관련 화면 내비게이션을 연결했습니다.
    - 내 계정
    - 내 프로필 관리
    - 내 주소 관리
    - 회원 탈퇴
    - 알림 설정
- 내 계정 정보 조회 API를 연동했습니다.
    - 닉네임, 이메일, 연결된 소셜 계정 표시
    - 조회 상태와 관계없이 헤더 및 뒤로가기 유지
- 로그아웃 API를 연동하고 연속 클릭 시 중복 요청을 방지했습니다.
- 프로필 수정 API를 연동했습니다.
    - 닉네임 중복 확인 및 유효성 검사
    - Presigned URL을 이용한 프로필 이미지 업로드
    - 닉네임 및 프로필 이미지 저장
    - 저장 중 중복 요청 방지
- 닉네임 중복 확인 요청을 취소하고 최신 입력의 응답만 반영하도록 개선했습니다.
- 설정 화면의 이용 약관과 문의하기 외부 링크를 연결했습니다.
- 하단 내비게이션 진입 경로에 따라 히스토리 화면의 내비게이션 바 노출 여부를 구분했습니다.
- 설정 관련 화면과 알림 설정 화면에 흰색 배경을 적용했습니다.
- 개발 환경별 네트워크 로그 레벨을 분리했습니다.
    - dev debug: BODY
    - prod debug: BASIC
    - release: NONE
- HTTP 오류 응답의 상태 코드, 서버 코드, 메시지 및 응답 본문을 디버그 로그에서 확인할 수 있도록 추가했습니다.
- 계정 설정 및 프로필 수정 ViewModel 단위 테스트를 추가했습니다.

## Screenshot 📸

| 설정 화면 | 로그아웃 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/d806905d-7018-401d-baf0-4ddec0ba5921" width="250" /> | <video src="https://github.com/user-attachments/assets/b5f6e11d-8d5e-40f6-ac8d-629dc606d46f" width="250" /> |

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢

- 닉네임을 연속으로 변경할 경우 이전 중복 확인 요청을 취소하고, 현재 입력과 일치하는 응답만 반영합니다.
- 저장 Intent가 연속으로 전달되어도 이미지 업로드와 프로필 수정 요청은 한 번만 실행됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계정 설정에서 닉네임·이메일·소셜 로그인 정보를 확인하고 로그아웃할 수 있습니다.
  * 프로필 이미지와 닉네임을 편집하고 저장할 수 있습니다.
  * 설정, 계정, 프로필, 주소 관리, 알림 설정, 회원 탈퇴 화면 간 이동을 지원합니다.
  * 문의 및 이용약관 링크를 제공합니다.
* **개선**
  * 로그아웃과 프로필 저장 실패 후 재시도할 수 있습니다.
  * 기록 화면 진입과 화면 배경·헤더 디자인을 개선했습니다.
  * 닉네임 입력 검증과 중복 확인을 일관되게 개선했습니다.
* **버그 수정**
  * 잘못된 기록 화면 경로로 인한 오류를 완화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->