### PR TITLE
[Feat/#202] 게스트 모드 지원

### DIFF
--- a/app/src/main/java/com/poti/android/data/mapper/home/GoodsCategoryMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/home/GoodsCategoryMapper.kt
@@ -7,7 +7,7 @@ import com.poti.android.domain.model.party.ProductCategory
 
 fun GoodsCategoryResponseDto.toDomain(): ProductCategory =
     ProductCategory(
-        nickname = nickname,
+        nickname = nickname.orEmpty(),
         mainArtist = mainArtist,
         mainArtistId = mainArtistId,
         groupItems = groupItems?.map { it.toDomain() }.orEmpty(),

--- a/app/src/main/java/com/poti/android/data/mapper/home/HomeMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/home/HomeMapper.kt
@@ -9,7 +9,7 @@ import com.poti.android.domain.model.home.GroupItem
 import com.poti.android.domain.model.home.HomeContent
 
 fun HomeResponseDto.toDomain(): HomeContent = HomeContent(
-    nickname = nickname,
+    nickname = nickname.orEmpty(),
     mainArtist = mainArtist,
     mainArtistId = mainArtistId,
     myGroupItems = myGroupItems.orEmpty().map { it.toDomain() },

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/home/GoodsCategoryResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/home/GoodsCategoryResponseDto.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GoodsCategoryResponseDto(
     @SerialName("nickname")
-    val nickname: String,
+    val nickname: String?,
     @SerialName("mainArtist")
     val mainArtist: String?,
     @SerialName("mainArtistId")

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/home/HomeResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/home/HomeResponseDto.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class HomeResponseDto(
     @SerialName("nickname")
-    val nickname: String,
+    val nickname: String?,
     @SerialName("mainArtist")
     val mainArtist: String?,
     @SerialName("mainArtistId")

--- a/app/src/main/java/com/poti/android/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/AuthRepositoryImpl.kt
@@ -52,6 +52,7 @@ class AuthRepositoryImpl @Inject constructor(
                     authTokenStore.saveTokens(it.accessToken, it.refreshToken)
                     preferenceDataSource.saveSocialType(socialType)
                     preferenceDataSource.saveOnboardingState(!it.isNewUser)
+                    authSessionManager.exitGuest()
                 }
             },
             real = {
@@ -67,6 +68,7 @@ class AuthRepositoryImpl @Inject constructor(
                             authTokenStore.saveTokens(accessToken, refreshToken)
                             preferenceDataSource.saveSocialType(socialType)
                             preferenceDataSource.saveOnboardingState(!isNewUser)
+                            authSessionManager.exitGuest()
                         }
                         .toDomain()
                 }.onSuccess { syncFcmToken() }
@@ -90,6 +92,7 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun logout(): Result<Unit> = suspendRunCatching {
         deleteFcmToken()
         authTokenStore.clearAll()
+        authSessionManager.exitGuest()
         authSessionManager.triggerLogout()
     }
 
@@ -108,6 +111,7 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun withdrawal(reason: String): Result<Unit> = executeWithUiMock(
         mock = {
             authTokenStore.clearAll()
+            authSessionManager.exitGuest()
             authSessionManager.triggerLogout()
         },
         real = { withdrawalFromRemote(reason = reason) },
@@ -138,6 +142,7 @@ class AuthRepositoryImpl @Inject constructor(
             authTokenStore.clearAll()
             withdrawalLocalDataCleaner.clearCachesInBackground()
         } finally {
+            authSessionManager.exitGuest()
             authSessionManager.triggerLogout()
         }
     }

--- a/app/src/main/java/com/poti/android/domain/manager/AuthSessionManager.kt
+++ b/app/src/main/java/com/poti/android/domain/manager/AuthSessionManager.kt
@@ -41,4 +41,8 @@ class AuthSessionManager @Inject constructor() {
 
     fun consumePendingReturnDeepLink(): String? =
         pendingReturnDeepLink.also { pendingReturnDeepLink = null }
+
+    fun clearPendingReturnDeepLink() {
+        pendingReturnDeepLink = null
+    }
 }

--- a/app/src/main/java/com/poti/android/domain/manager/AuthSessionManager.kt
+++ b/app/src/main/java/com/poti/android/domain/manager/AuthSessionManager.kt
@@ -2,7 +2,10 @@ package com.poti.android.domain.manager
 
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -15,7 +18,19 @@ class AuthSessionManager @Inject constructor() {
     )
     val logoutEvent = _logoutEvent.asSharedFlow()
 
+    // 게스트(로그인 없이 둘러보기) 세션 상태. 영속화하지 않고 프로세스 생존 동안만 유지한다.
+    private val _isGuest = MutableStateFlow(false)
+    val isGuest: StateFlow<Boolean> = _isGuest.asStateFlow()
+
     fun triggerLogout() {
         _logoutEvent.tryEmit(Unit)
+    }
+
+    fun enterGuest() {
+        _isGuest.value = true
+    }
+
+    fun exitGuest() {
+        _isGuest.value = false
     }
 }

--- a/app/src/main/java/com/poti/android/domain/manager/AuthSessionManager.kt
+++ b/app/src/main/java/com/poti/android/domain/manager/AuthSessionManager.kt
@@ -21,6 +21,8 @@ class AuthSessionManager @Inject constructor() {
     private val _isGuest = MutableStateFlow(false)
     val isGuest: StateFlow<Boolean> = _isGuest.asStateFlow()
 
+    private var pendingReturnDeepLink: String? = null
+
     fun triggerLogout() {
         _logoutEvent.tryEmit(Unit)
     }
@@ -32,4 +34,11 @@ class AuthSessionManager @Inject constructor() {
     fun exitGuest() {
         _isGuest.value = false
     }
+
+    fun setPendingReturnDeepLink(deepLink: String) {
+        pendingReturnDeepLink = deepLink
+    }
+
+    fun consumePendingReturnDeepLink(): String? =
+        pendingReturnDeepLink.also { pendingReturnDeepLink = null }
 }

--- a/app/src/main/java/com/poti/android/domain/manager/AuthSessionManager.kt
+++ b/app/src/main/java/com/poti/android/domain/manager/AuthSessionManager.kt
@@ -18,7 +18,6 @@ class AuthSessionManager @Inject constructor() {
     )
     val logoutEvent = _logoutEvent.asSharedFlow()
 
-    // 게스트(로그인 없이 둘러보기) 세션 상태. 영속화하지 않고 프로세스 생존 동안만 유지한다.
     private val _isGuest = MutableStateFlow(false)
     val isGuest: StateFlow<Boolean> = _isGuest.asStateFlow()
 

--- a/app/src/main/java/com/poti/android/domain/usecase/auth/ClearPendingReturnDeepLinkUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/auth/ClearPendingReturnDeepLinkUseCase.kt
@@ -1,0 +1,10 @@
+package com.poti.android.domain.usecase.auth
+
+import com.poti.android.domain.manager.AuthSessionManager
+import javax.inject.Inject
+
+class ClearPendingReturnDeepLinkUseCase @Inject constructor(
+    private val authSessionManager: AuthSessionManager,
+) {
+    operator fun invoke() = authSessionManager.clearPendingReturnDeepLink()
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/auth/EnterGuestModeUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/auth/EnterGuestModeUseCase.kt
@@ -1,0 +1,10 @@
+package com.poti.android.domain.usecase.auth
+
+import com.poti.android.domain.manager.AuthSessionManager
+import javax.inject.Inject
+
+class EnterGuestModeUseCase @Inject constructor(
+    private val authSessionManager: AuthSessionManager,
+) {
+    operator fun invoke() = authSessionManager.enterGuest()
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/auth/ExitGuestModeUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/auth/ExitGuestModeUseCase.kt
@@ -1,0 +1,10 @@
+package com.poti.android.domain.usecase.auth
+
+import com.poti.android.domain.manager.AuthSessionManager
+import javax.inject.Inject
+
+class ExitGuestModeUseCase @Inject constructor(
+    private val authSessionManager: AuthSessionManager,
+) {
+    operator fun invoke() = authSessionManager.exitGuest()
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/auth/IsGuestUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/auth/IsGuestUseCase.kt
@@ -1,0 +1,10 @@
+package com.poti.android.domain.usecase.auth
+
+import com.poti.android.domain.manager.AuthSessionManager
+import javax.inject.Inject
+
+class IsGuestUseCase @Inject constructor(
+    private val authSessionManager: AuthSessionManager,
+) {
+    operator fun invoke(): Boolean = authSessionManager.isGuest.value
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/auth/ObserveGuestStateUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/auth/ObserveGuestStateUseCase.kt
@@ -1,0 +1,11 @@
+package com.poti.android.domain.usecase.auth
+
+import com.poti.android.domain.manager.AuthSessionManager
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveGuestStateUseCase @Inject constructor(
+    private val authSessionManager: AuthSessionManager,
+) {
+    operator fun invoke(): Flow<Boolean> = authSessionManager.isGuest
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/auth/SetPendingReturnDeepLinkUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/auth/SetPendingReturnDeepLinkUseCase.kt
@@ -1,0 +1,10 @@
+package com.poti.android.domain.usecase.auth
+
+import com.poti.android.domain.manager.AuthSessionManager
+import javax.inject.Inject
+
+class SetPendingReturnDeepLinkUseCase @Inject constructor(
+    private val authSessionManager: AuthSessionManager,
+) {
+    operator fun invoke(deepLink: String) = authSessionManager.setPendingReturnDeepLink(deepLink)
+}

--- a/app/src/main/java/com/poti/android/domain/usecase/user/SaveOnboardingUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/user/SaveOnboardingUseCase.kt
@@ -1,13 +1,17 @@
 package com.poti.android.domain.usecase.user
 
+import com.poti.android.domain.repository.AuthRepository
 import com.poti.android.domain.repository.UserRepository
 import javax.inject.Inject
 
 class SaveOnboardingUseCase @Inject constructor(
     private val userRepository: UserRepository,
+    private val authRepository: AuthRepository,
 ) {
     suspend operator fun invoke(
         nickname: String,
         favoriteArtistId: Long?,
-    ): Result<Unit> = userRepository.patchOnboarding(nickname, favoriteArtistId)
+    ): Result<Unit> =
+        userRepository.patchOnboarding(nickname, favoriteArtistId)
+            .mapCatching { authRepository.saveOnboardingState(isCompleted = true).getOrThrow() }
 }

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginScreen.kt
@@ -1,6 +1,7 @@
 package com.poti.android.presentation.auth
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -97,7 +98,9 @@ private fun LoginScreen(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.white),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(modifier = Modifier.height(267.dp))

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,6 +28,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
 import com.poti.android.core.auth.SocialLoginLauncher
 import com.poti.android.core.auth.SocialLoginResult
+import com.poti.android.core.common.extension.noRippleClickable
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.auth.SocialType
 import com.poti.android.presentation.auth.component.LoginButton
@@ -38,6 +40,7 @@ import kotlin.coroutines.cancellation.CancellationException
 fun LoginRoute(
     onNavigateToOnboarding: () -> Unit,
     onNavigateToHome: () -> Unit,
+    onBrowseAsGuest: () -> Unit,
     socialLoginLauncher: SocialLoginLauncher,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = hiltViewModel(),
@@ -79,6 +82,7 @@ fun LoginRoute(
         onGoogleClick = {
             viewModel.processIntent(LoginIntent.OnSocialLoginClick(SocialType.GOOGLE))
         },
+        onBrowseAsGuestClick = onBrowseAsGuest,
         modifier = modifier,
     )
 }
@@ -88,6 +92,7 @@ private fun LoginScreen(
     isLoginInProgress: Boolean,
     onKakaoClick: () -> Unit,
     onGoogleClick: () -> Unit,
+    onBrowseAsGuestClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -131,7 +136,18 @@ private fun LoginScreen(
             )
         }
 
-        Spacer(modifier = Modifier.height(162.dp))
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = stringResource(R.string.login_browse_as_guest),
+            style = PotiTheme.typography.body14m,
+            color = PotiTheme.colors.gray800,
+            modifier = Modifier
+                .noRippleClickable { if (!isLoginInProgress) onBrowseAsGuestClick() }
+                .padding(10.dp),
+        )
+
+        Spacer(modifier = Modifier.height(102.dp))
     }
 }
 
@@ -143,6 +159,7 @@ private fun LoginScreenPreview() {
             isLoginInProgress = false,
             onKakaoClick = {},
             onGoogleClick = {},
+            onBrowseAsGuestClick = {},
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginScreen.kt
@@ -40,7 +40,6 @@ import kotlin.coroutines.cancellation.CancellationException
 fun LoginRoute(
     onNavigateToOnboarding: () -> Unit,
     onNavigateToHome: () -> Unit,
-    onBrowseAsGuest: () -> Unit,
     socialLoginLauncher: SocialLoginLauncher,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = hiltViewModel(),
@@ -82,7 +81,9 @@ fun LoginRoute(
         onGoogleClick = {
             viewModel.processIntent(LoginIntent.OnSocialLoginClick(SocialType.GOOGLE))
         },
-        onBrowseAsGuestClick = onBrowseAsGuest,
+        onBrowseAsGuestClick = {
+            viewModel.processIntent(LoginIntent.OnBrowseAsGuestClick)
+        },
         modifier = modifier,
     )
 }

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.poti.android.presentation.auth
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -41,12 +42,19 @@ import kotlin.coroutines.cancellation.CancellationException
 fun LoginRoute(
     onNavigateToOnboarding: () -> Unit,
     onNavigateToHome: () -> Unit,
+    canNavigateBack: Boolean,
+    onNavigateBack: () -> Unit,
     socialLoginLauncher: SocialLoginLauncher,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    BackHandler(enabled = canNavigateBack) {
+        viewModel.onLoginCancelled()
+        onNavigateBack()
+    }
 
     LaunchedEffect(viewModel.sideEffect) {
         viewModel.sideEffect.collect { effect ->

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
@@ -34,6 +34,7 @@ class LoginViewModel @Inject constructor(
     private fun enterGuestMode() {
         if (!uiState.value.phase.canStartLogin) return
 
+        updateState { copy(phase = LoginPhase.SUCCESS) }
         enterGuestModeUseCase()
         sendEffect(LoginEffect.NavigateToHome)
     }

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
@@ -41,6 +41,7 @@ class LoginViewModel @Inject constructor(
         if (!uiState.value.phase.canStartLogin) return
 
         updateState { copy(phase = LoginPhase.SUCCESS) }
+        clearPendingReturnDeepLinkUseCase()
         enterGuestModeUseCase()
         sendEffect(LoginEffect.NavigateToHome)
     }

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.poti.android.presentation.auth
 import com.poti.android.core.auth.SocialLoginResult
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.domain.model.auth.SocialType
+import com.poti.android.domain.usecase.auth.ClearPendingReturnDeepLinkUseCase
 import com.poti.android.domain.usecase.auth.EnterGuestModeUseCase
 import com.poti.android.domain.usecase.auth.LoginUseCase
 import com.poti.android.presentation.auth.model.LoginEffect
@@ -17,7 +18,12 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
     private val enterGuestModeUseCase: EnterGuestModeUseCase,
+    private val clearPendingReturnDeepLinkUseCase: ClearPendingReturnDeepLinkUseCase,
 ) : BaseViewModel<LoginState, LoginIntent, LoginEffect>(LoginState()) {
+    fun onLoginCancelled() {
+        clearPendingReturnDeepLinkUseCase()
+    }
+
     override fun processIntent(intent: LoginIntent) {
         when (intent) {
             is LoginIntent.OnSocialLoginClick -> {

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
@@ -40,7 +40,6 @@ class LoginViewModel @Inject constructor(
     private fun enterGuestMode() {
         if (!uiState.value.phase.canStartLogin) return
 
-        updateState { copy(phase = LoginPhase.SUCCESS) }
         clearPendingReturnDeepLinkUseCase()
         enterGuestModeUseCase()
         sendEffect(LoginEffect.NavigateToHome)

--- a/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.poti.android.presentation.auth
 import com.poti.android.core.auth.SocialLoginResult
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.domain.model.auth.SocialType
+import com.poti.android.domain.usecase.auth.EnterGuestModeUseCase
 import com.poti.android.domain.usecase.auth.LoginUseCase
 import com.poti.android.presentation.auth.model.LoginEffect
 import com.poti.android.presentation.auth.model.LoginIntent
@@ -15,6 +16,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
+    private val enterGuestModeUseCase: EnterGuestModeUseCase,
 ) : BaseViewModel<LoginState, LoginIntent, LoginEffect>(LoginState()) {
     override fun processIntent(intent: LoginIntent) {
         when (intent) {
@@ -25,7 +27,15 @@ class LoginViewModel @Inject constructor(
             }
             is LoginIntent.OnSocialLoginResult -> handleSocialLoginResult(intent)
             LoginIntent.OnSocialLoginAborted -> finishLogin()
+            LoginIntent.OnBrowseAsGuestClick -> enterGuestMode()
         }
+    }
+
+    private fun enterGuestMode() {
+        if (!uiState.value.phase.canStartLogin) return
+
+        enterGuestModeUseCase()
+        sendEffect(LoginEffect.NavigateToHome)
     }
 
     private fun handleSocialLoginResult(intent: LoginIntent.OnSocialLoginResult) {

--- a/app/src/main/java/com/poti/android/presentation/auth/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/model/Contracts.kt
@@ -19,6 +19,8 @@ sealed interface LoginIntent : UiIntent {
     ) : LoginIntent
 
     data object OnSocialLoginAborted : LoginIntent
+
+    data object OnBrowseAsGuestClick : LoginIntent
 }
 
 sealed interface LoginEffect : UiEffect {

--- a/app/src/main/java/com/poti/android/presentation/auth/navigation/AuthNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/navigation/AuthNavigation.kt
@@ -23,7 +23,6 @@ fun NavGraphBuilder.authNavGraph(
         LoginRoute(
             onNavigateToOnboarding = navController::navigateToOnboardingGuide,
             onNavigateToHome = onNavigateToHome,
-            onBrowseAsGuest = {},
             socialLoginLauncher = socialLoginLauncher,
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/auth/navigation/AuthNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/navigation/AuthNavigation.kt
@@ -16,7 +16,6 @@ sealed interface AuthRoute : Route {
 
 fun NavController.navigateToLogin() {
     navigate(AuthRoute.Login) {
-        popUpTo(0) { inclusive = true }
         launchSingleTop = true
     }
 }
@@ -30,6 +29,8 @@ fun NavGraphBuilder.authNavGraph(
         LoginRoute(
             onNavigateToOnboarding = navController::navigateToOnboardingGuide,
             onNavigateToHome = onNavigateToHome,
+            canNavigateBack = navController.previousBackStackEntry != null,
+            onNavigateBack = { navController.popBackStack() },
             socialLoginLauncher = socialLoginLauncher,
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/auth/navigation/AuthNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/navigation/AuthNavigation.kt
@@ -14,6 +14,13 @@ sealed interface AuthRoute : Route {
     data object Login : AuthRoute
 }
 
+fun NavController.navigateToLogin() {
+    navigate(AuthRoute.Login) {
+        popUpTo(0) { inclusive = true }
+        launchSingleTop = true
+    }
+}
+
 fun NavGraphBuilder.authNavGraph(
     navController: NavController,
     onNavigateToHome: () -> Unit,

--- a/app/src/main/java/com/poti/android/presentation/auth/navigation/AuthNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/auth/navigation/AuthNavigation.kt
@@ -23,6 +23,7 @@ fun NavGraphBuilder.authNavGraph(
         LoginRoute(
             onNavigateToOnboarding = navController::navigateToOnboardingGuide,
             onNavigateToHome = onNavigateToHome,
+            onBrowseAsGuest = {},
             socialLoginLauncher = socialLoginLauncher,
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
@@ -75,6 +75,7 @@ class MainActivity : ComponentActivity() {
             val onAuthCompleted = {
                 mainNavigator.navigateToHome()
                 consumeDeepLink(mainNavigator.navController)
+                consumePendingReturnDeepLink(mainNavigator.navController)
             }
 
             PotiTheme {
@@ -120,6 +121,11 @@ class MainActivity : ComponentActivity() {
     private fun consumeDeepLink(navController: NavHostController) {
         val uri = pendingDeepLink ?: return
         pendingDeepLink = null
+        navController.navigateToDeepLink(uri)
+    }
+
+    private fun consumePendingReturnDeepLink(navController: NavHostController) {
+        val uri = authSessionManager.consumePendingReturnDeepLink()?.toUri() ?: return
         navController.navigateToDeepLink(uri)
     }
 

--- a/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
@@ -104,7 +104,10 @@ class MainActivity : ComponentActivity() {
         val uri = intent.resolveDeepLink() ?: return
         intent.data = null
 
-        if (viewModel.startDestination.value == PartyGraph) {
+        if (
+            viewModel.startDestination.value == PartyGraph ||
+            authSessionManager.isGuest.value
+        ) {
             navController?.navigateToDeepLink(uri)
         } else {
             pendingDeepLink = uri

--- a/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
@@ -24,7 +24,6 @@ import com.poti.android.core.auth.SocialLoginLauncher
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.core.share.KakaoShareManager
 import com.poti.android.domain.manager.AuthSessionManager
-import com.poti.android.presentation.party.PartyGraph
 import dagger.hilt.android.AndroidEntryPoint
 import jakarta.inject.Inject
 import kotlinx.coroutines.launch
@@ -33,7 +32,7 @@ import timber.log.Timber
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val viewModel: MainViewModel by viewModels()
-    private var navController: NavHostController? = null
+    private var mainNavigator: MainNavigator? = null
     private var pendingDeepLink: Uri? by mutableStateOf(null)
 
     @Inject
@@ -70,7 +69,7 @@ class MainActivity : ComponentActivity() {
             val mainNavigator: MainNavigator = rememberPotiNavigator()
             val targetDestination by viewModel.startDestination.collectAsStateWithLifecycle()
 
-            navController = mainNavigator.navController
+            this.mainNavigator = mainNavigator
 
             val onAuthCompleted = {
                 mainNavigator.navigateToHome()
@@ -85,9 +84,7 @@ class MainActivity : ComponentActivity() {
                         navigator = mainNavigator,
                         socialLoginLauncher = socialLoginLauncher,
                         onSplashFinished = {
-                            if (destination == PartyGraph) {
-                                consumeDeepLink(mainNavigator.navController)
-                            }
+                            processPendingDeepLink(mainNavigator)
                         },
                         onLoginSuccess = onAuthCompleted,
                         onOnboardingFinished = onAuthCompleted,
@@ -104,14 +101,13 @@ class MainActivity : ComponentActivity() {
         val uri = intent.resolveDeepLink() ?: return
         intent.data = null
 
-        if (
-            viewModel.startDestination.value == PartyGraph ||
-            authSessionManager.isGuest.value
-        ) {
-            navController?.navigateToDeepLink(uri)
-        } else {
+        val navigator = mainNavigator
+        if (navigator == null) {
             pendingDeepLink = uri
+            return
         }
+
+        processDeepLink(uri, navigator)
     }
 
     private fun Intent.resolveDeepLink(): Uri? {
@@ -121,21 +117,53 @@ class MainActivity : ComponentActivity() {
         return uri.getQueryParameter(KakaoShareManager.PARAM_DEEP_LINK)?.toUri()
     }
 
+    private fun processPendingDeepLink(navigator: MainNavigator) {
+        val uri = pendingDeepLink ?: return
+        processDeepLink(uri, navigator)
+    }
+
+    private fun processDeepLink(
+        uri: Uri,
+        navigator: MainNavigator,
+    ) {
+        when (viewModel.getDeepLinkEntryMode()) {
+            DeepLinkEntryMode.DEFER -> pendingDeepLink = uri
+            DeepLinkEntryMode.MEMBER -> navigateToDeepLink(uri, navigator.navController)
+            DeepLinkEntryMode.GUEST -> {
+                viewModel.enterGuestMode()
+                navigator.navigateToHome()
+                navigateToDeepLink(uri, navigator.navController)
+            }
+        }
+    }
+
     private fun consumeDeepLink(navController: NavHostController) {
         val uri = pendingDeepLink ?: return
-        pendingDeepLink = null
-        navController.navigateToDeepLink(uri)
+        navigateToDeepLink(uri, navController)
+    }
+
+    private fun navigateToDeepLink(
+        uri: Uri,
+        navController: NavHostController,
+    ) {
+        if (navController.navigateToDeepLink(uri)) {
+            if (pendingDeepLink == uri) pendingDeepLink = null
+        } else {
+            pendingDeepLink = uri
+        }
     }
 
     private fun consumePendingReturnDeepLink(navController: NavHostController) {
-        val uri = authSessionManager.consumePendingReturnDeepLink()?.toUri() ?: return
-        navController.navigateToDeepLink(uri)
+        val deepLink = authSessionManager.consumePendingReturnDeepLink() ?: return
+        if (!navController.navigateToDeepLink(deepLink.toUri())) {
+            authSessionManager.setPendingReturnDeepLink(deepLink)
+        }
     }
 
-    private fun NavHostController.navigateToDeepLink(uri: Uri) {
+    private fun NavHostController.navigateToDeepLink(uri: Uri): Boolean =
         runCatching { navigate(uri) }
             .onFailure { Timber.w(it, "Unhandled deep link: $uri") }
-    }
+            .isSuccess
 
     private fun requestNotificationPermission() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return

--- a/app/src/main/java/com/poti/android/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainScreen.kt
@@ -3,26 +3,59 @@ package com.poti.android.presentation.main
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.poti.android.R
 import com.poti.android.core.auth.SocialLoginLauncher
+import com.poti.android.core.designsystem.component.modal.PotiSmallModal
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.auth.navigation.navigateToLogin
 
 @Composable
 fun MainScreen(
     targetDestination: Route,
     socialLoginLauncher: SocialLoginLauncher,
     navigator: MainNavigator = rememberPotiNavigator(),
+    viewModel: MainViewModel = hiltViewModel(),
     onSplashFinished: () -> Unit = {},
     onLoginSuccess: () -> Unit = {},
     onOnboardingFinished: () -> Unit = {},
 ) {
+    var showLoginRequiredDialog by remember { mutableStateOf(false) }
+
+    if (showLoginRequiredDialog) {
+        PotiSmallModal(
+            onDismissRequest = { showLoginRequiredDialog = false },
+            title = stringResource(R.string.login_required_title),
+            text = stringResource(R.string.login_required_history),
+            dismissBtnText = stringResource(R.string.login_required_dismiss),
+            confirmBtnText = stringResource(R.string.login_required_confirm),
+            onDismissBtnClick = { showLoginRequiredDialog = false },
+            onConfirmBtnClick = {
+                showLoginRequiredDialog = false
+                navigator.navController.navigateToLogin()
+            },
+        )
+    }
+
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         bottomBar = {
             MainBottomBar(
                 visible = navigator.shouldShowBottomBar(),
                 currentTab = navigator.currentTab,
-                onTabSelected = { navigator.navigate(it) },
+                onTabSelected = { tab ->
+                    if (tab == MainTab.HISTORY && viewModel.isGuest()) {
+                        showLoginRequiredDialog = true
+                    } else {
+                        navigator.navigate(tab)
+                    }
+                },
             )
         },
     ) { innerPadding ->

--- a/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
@@ -2,6 +2,8 @@ package com.poti.android.presentation.main
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.poti.android.domain.model.auth.AuthState
+import com.poti.android.domain.usecase.auth.EnterGuestModeUseCase
 import com.poti.android.domain.usecase.auth.IsGuestUseCase
 import com.poti.android.domain.usecase.auth.ObserveAuthStateUseCase
 import com.poti.android.presentation.auth.navigation.AuthRoute
@@ -16,10 +18,21 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     observeAuthStateUseCase: ObserveAuthStateUseCase,
     private val isGuestUseCase: IsGuestUseCase,
+    private val enterGuestModeUseCase: EnterGuestModeUseCase,
 ) : ViewModel() {
     fun isGuest(): Boolean = isGuestUseCase()
 
-    val startDestination = observeAuthStateUseCase()
+    private val authState = observeAuthStateUseCase()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = AuthState(
+                accessToken = null,
+                isOnboardingFinished = false,
+            ),
+        )
+
+    val startDestination = authState
         .map { authState ->
             when {
                 !authState.isInitialized -> null
@@ -32,4 +45,21 @@ class MainViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = null,
         )
+
+    internal fun getDeepLinkEntryMode(): DeepLinkEntryMode = authState.value.toDeepLinkEntryMode()
+
+    internal fun enterGuestMode() = enterGuestModeUseCase()
+}
+
+internal enum class DeepLinkEntryMode {
+    DEFER,
+    MEMBER,
+    GUEST,
+}
+
+internal fun AuthState.toDeepLinkEntryMode(): DeepLinkEntryMode = when {
+    !isInitialized -> DeepLinkEntryMode.DEFER
+    !accessToken.isNullOrBlank() && !isOnboardingFinished -> DeepLinkEntryMode.DEFER
+    !accessToken.isNullOrBlank() -> DeepLinkEntryMode.MEMBER
+    else -> DeepLinkEntryMode.GUEST
 }

--- a/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
@@ -2,6 +2,7 @@ package com.poti.android.presentation.main
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.poti.android.domain.usecase.auth.IsGuestUseCase
 import com.poti.android.domain.usecase.auth.ObserveAuthStateUseCase
 import com.poti.android.presentation.auth.navigation.AuthRoute
 import com.poti.android.presentation.party.PartyGraph
@@ -14,7 +15,10 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(
     observeAuthStateUseCase: ObserveAuthStateUseCase,
+    private val isGuestUseCase: IsGuestUseCase,
 ) : ViewModel() {
+    fun isGuest(): Boolean = isGuestUseCase()
+
     val startDestination = observeAuthStateUseCase()
         .map { authState ->
             when {

--- a/app/src/main/java/com/poti/android/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/onboarding/OnboardingViewModel.kt
@@ -114,13 +114,17 @@ class OnboardingViewModel @Inject constructor(
 
     private fun handleSkipClick() = launchScope {
         saveOnboardingUseCase(uiState.value.nickname, null)
-            .onSuccess { }
-        updateState {
-            copy(
-                selectedArtistId = null,
-                isButtonVisible = false,
-            )
-        }
-        sendEffect(OnboardingUiEffect.NavigateToHome)
+            .onSuccess {
+                updateState {
+                    copy(
+                        selectedArtistId = null,
+                        isButtonVisible = false,
+                    )
+                }
+                sendEffect(OnboardingUiEffect.NavigateToHome)
+            }
+            .onFailure { error ->
+                Timber.e(error, "온보딩 건너뛰기 저장 실패")
+            }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
@@ -29,6 +29,7 @@ import com.poti.android.core.common.extension.shareTextToX
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
+import com.poti.android.core.designsystem.component.modal.PotiSmallModal
 import com.poti.android.core.designsystem.component.navigation.PotiBottomButton
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
@@ -53,6 +54,7 @@ fun PartyDetailRoute(
     onNavigateToJoin: () -> Unit,
     onNavigateToProfile: (Long) -> Unit,
     onReload: (Long) -> Unit,
+    onNavigateToLogin: () -> Unit,
     viewModel: PartyDetailViewModel,
     modifier: Modifier = Modifier,
 ) {
@@ -70,7 +72,20 @@ fun PartyDetailRoute(
             is PartyDetailEffect.ShareToKakao -> KakaoShareManager.sharePartyDetail(context, effect.content)
             is PartyDetailEffect.ShareToX -> context.shareTextToX(effect.shareText)
             is PartyDetailEffect.CopyLink -> context.copyToClipboard(effect.link)
+            PartyDetailEffect.NavigateToLogin -> onNavigateToLogin()
         }
+    }
+
+    if (uiState.showLoginRequiredDialog) {
+        PotiSmallModal(
+            onDismissRequest = { viewModel.processIntent(PartyDetailIntent.OnLoginRequiredDismiss) },
+            title = stringResource(R.string.login_required_title),
+            text = stringResource(R.string.login_required_join),
+            dismissBtnText = stringResource(R.string.login_required_dismiss),
+            confirmBtnText = stringResource(R.string.login_required_confirm),
+            onDismissBtnClick = { viewModel.processIntent(PartyDetailIntent.OnLoginRequiredDismiss) },
+            onConfirmBtnClick = { viewModel.processIntent(PartyDetailIntent.OnLoginRequiredConfirm) },
+        )
     }
 
     if (uiState.showJoinBottomSheet) {

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
@@ -20,6 +20,7 @@ import com.poti.android.domain.model.party.PartyJoinInfo
 import com.poti.android.domain.model.party.PartyJoinOption
 import com.poti.android.domain.usecase.artist.GetMembersUseCase
 import com.poti.android.domain.usecase.auth.IsGuestUseCase
+import com.poti.android.domain.usecase.auth.SetPendingReturnDeepLinkUseCase
 import com.poti.android.domain.usecase.party.GetPartyDetailUseCase
 import com.poti.android.domain.usecase.party.GetPartyJoinOptionsUseCase
 import com.poti.android.domain.usecase.party.JoinPartyUseCase
@@ -48,6 +49,7 @@ class PartyDetailViewModel @Inject constructor(
     private val getMyAddressUseCase: GetMyAddressUseCase,
     private val saveMyAddressUseCase: SaveMyAddressUseCase,
     private val isGuestUseCase: IsGuestUseCase,
+    private val setPendingReturnDeepLinkUseCase: SetPendingReturnDeepLinkUseCase,
     @ApplicationScope private val applicationScope: CoroutineScope,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<PartyDetailUiState, PartyDetailIntent, PartyDetailEffect>(
@@ -139,6 +141,7 @@ class PartyDetailViewModel @Inject constructor(
 
     private fun handleLoginRequiredConfirm() {
         updateState { copy(showLoginRequiredDialog = false) }
+        setPendingReturnDeepLinkUseCase(partyDetailDeepLink(partyId))
         sendEffect(NavigateToLogin)
     }
 

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
@@ -19,6 +19,7 @@ import com.poti.android.domain.model.party.PartyDetail
 import com.poti.android.domain.model.party.PartyJoinInfo
 import com.poti.android.domain.model.party.PartyJoinOption
 import com.poti.android.domain.usecase.artist.GetMembersUseCase
+import com.poti.android.domain.usecase.auth.IsGuestUseCase
 import com.poti.android.domain.usecase.party.GetPartyDetailUseCase
 import com.poti.android.domain.usecase.party.GetPartyJoinOptionsUseCase
 import com.poti.android.domain.usecase.party.JoinPartyUseCase
@@ -46,6 +47,7 @@ class PartyDetailViewModel @Inject constructor(
     private val joinPartyUseCase: JoinPartyUseCase,
     private val getMyAddressUseCase: GetMyAddressUseCase,
     private val saveMyAddressUseCase: SaveMyAddressUseCase,
+    private val isGuestUseCase: IsGuestUseCase,
     @ApplicationScope private val applicationScope: CoroutineScope,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<PartyDetailUiState, PartyDetailIntent, PartyDetailEffect>(
@@ -123,12 +125,21 @@ class PartyDetailViewModel @Inject constructor(
             }
 
             PartyDetailIntent.OnDismissShareBottomSheet -> closeShareBottomSheet()
+
+            PartyDetailIntent.OnLoginRequiredConfirm -> handleLoginRequiredConfirm()
+
+            PartyDetailIntent.OnLoginRequiredDismiss -> updateState { copy(showLoginRequiredDialog = false) }
         }
     }
 
     private fun String.toArtistDisplayName(): String {
         val name = trim()
         return name.replace(ENGLISH_NAME_REGEX, "").trim().ifBlank { name }
+    }
+
+    private fun handleLoginRequiredConfirm() {
+        updateState { copy(showLoginRequiredDialog = false) }
+        sendEffect(NavigateToLogin)
     }
 
     private fun handleKakaoShare() {
@@ -220,6 +231,11 @@ class PartyDetailViewModel @Inject constructor(
     }
 
     private fun handleDetailJoin() {
+        if (isGuestUseCase()) {
+            updateState { copy(showLoginRequiredDialog = true) }
+            return
+        }
+
         updateState { copy(showJoinBottomSheet = true) }
         fetchPartyJoinOption()
         fetchMyAddress()

--- a/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
@@ -40,6 +40,7 @@ data class PartyDetailUiState(
     val isJoinSuccessDialogVisible: Boolean = false,
     val showShareBottomSheet: Boolean = false,
     val artistMembers: ImmutableList<Member> = persistentListOf(),
+    val showLoginRequiredDialog: Boolean = false,
 ) : UiState {
     val isDetailJoinEnable: Boolean
         get() = partyDetail.getSuccessDataOrNull()?.status == PartyStatusType.RECRUITING
@@ -139,6 +140,10 @@ sealed interface PartyDetailIntent : UiIntent {
     data object OnKakaoShareClick : PartyDetailIntent
 
     data object OnXShareClick : PartyDetailIntent
+
+    data object OnLoginRequiredConfirm : PartyDetailIntent
+
+    data object OnLoginRequiredDismiss : PartyDetailIntent
 }
 
 sealed interface PartyDetailEffect : UiEffect {
@@ -157,4 +162,6 @@ sealed interface PartyDetailEffect : UiEffect {
     data class ShareToKakao(val content: PartyShareContent) : PartyDetailEffect
 
     data class ShareToX(val shareText: String) : PartyDetailEffect
+
+    data object NavigateToLogin : PartyDetailEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/navigation/PartyDetailNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/navigation/PartyDetailNavigation.kt
@@ -11,6 +11,7 @@ import com.poti.android.BuildConfig
 import com.poti.android.core.common.extension.sharedViewModel
 import com.poti.android.core.common.extension.slideComposable
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.auth.navigation.navigateToLogin
 import com.poti.android.presentation.party.create.navigation.PartyCreateRoute
 import com.poti.android.presentation.party.detail.PartyDetailRoute
 import com.poti.android.presentation.party.detail.PartyJoinRoute
@@ -73,6 +74,7 @@ fun NavGraphBuilder.partyDetailNavGraph(
                 onNavigateToJoin = navController::navigateToPartyJoin,
                 onNavigateToProfile = navController::navigateToProfile,
                 onReload = navController::reloadPartyDetail,
+                onNavigateToLogin = navController::navigateToLogin,
                 viewModel = entry.sharedViewModel(navController),
                 modifier = Modifier.padding(paddingValues),
             )

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -21,6 +22,7 @@ import com.poti.android.R
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiFloatingButton
+import com.poti.android.core.designsystem.component.modal.PotiSmallModal
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPrimary
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.data.mock.UiMockData
@@ -37,6 +39,7 @@ fun HomeRoute(
     onNavigateToPartyCreate: () -> Unit,
     onNavigateToGoodsPartyList: (Long, String) -> Unit,
     onNavigateToProductCategory: (Long?, Boolean) -> Unit,
+    onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
@@ -50,7 +53,20 @@ fun HomeRoute(
             is HomeUiEffect.NavigateToMyArtistCategory -> onNavigateToProductCategory(effect.artistId, true)
             HomeUiEffect.NavigateToOtherProductCategory -> onNavigateToProductCategory(null, false)
             HomeUiEffect.NavigateToAlarmList -> onNavigateToAlarmList()
+            HomeUiEffect.NavigateToLogin -> onNavigateToLogin()
         }
+    }
+
+    if (uiState.showLoginRequiredDialog) {
+        PotiSmallModal(
+            onDismissRequest = { viewModel.processIntent(HomeUiIntent.OnLoginRequiredDismiss) },
+            title = stringResource(R.string.login_required_title),
+            text = stringResource(R.string.login_required_create),
+            dismissBtnText = stringResource(R.string.login_required_dismiss),
+            confirmBtnText = stringResource(R.string.login_required_confirm),
+            onDismissBtnClick = { viewModel.processIntent(HomeUiIntent.OnLoginRequiredDismiss) },
+            onConfirmBtnClick = { viewModel.processIntent(HomeUiIntent.OnLoginRequiredConfirm) },
+        )
     }
 
     uiState.homeContentLoadState.onSuccess { homeContent ->

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeScreen.kt
@@ -109,7 +109,12 @@ private fun HomeScreen(
 
                 HomeGoodsSection(
                     artistId = homeContent.mainArtistId,
-                    title = R.string.home_recommend_goods,
+                    // TODO: [천민재] 임시 문구 사용 중
+                    title = if (homeContent.nickname.isBlank()) {
+                        R.string.home_recommend_goods_guest
+                    } else {
+                        R.string.home_recommend_goods
+                    },
                     nickname = homeContent.nickname,
                     groupItems = homeContent.myGroupItems,
                     onMoreClick = onMyArtistCategoryClick,

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
@@ -27,7 +27,9 @@ class HomeViewModel @Inject constructor(
             is HomeUiIntent.OnProductCardClick -> sendEffect(NavigateToGoodsPartyList(intent.artistId, intent.title))
             HomeUiIntent.LoadHomeContent -> loadHomeContent()
             HomeUiIntent.OnOtherProductCategoryClick -> sendEffect(NavigateToOtherProductCategory)
-            HomeUiIntent.OnAlarmClick -> sendEffect(NavigateToAlarmList)
+            HomeUiIntent.OnAlarmClick -> {
+                if (!isGuestUseCase()) sendEffect(NavigateToAlarmList)
+            }
             HomeUiIntent.OnLoginRequiredConfirm -> handleLoginRequiredConfirm()
             HomeUiIntent.OnLoginRequiredDismiss -> updateState { copy(showLoginRequiredDialog = false) }
         }

--- a/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.poti.android.presentation.party.home
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.extension.getSuccessDataOrNull
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.auth.IsGuestUseCase
 import com.poti.android.domain.usecase.home.GetHomeContentUseCase
 import com.poti.android.presentation.party.home.model.HomeUiEffect
 import com.poti.android.presentation.party.home.model.HomeUiEffect.*
@@ -14,19 +15,35 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val getHomeContentUseCase: GetHomeContentUseCase,
+    private val isGuestUseCase: IsGuestUseCase,
 ) : BaseViewModel<HomeUiState, HomeUiIntent, HomeUiEffect>(
         initialState = HomeUiState(),
     ) {
     override fun processIntent(intent: HomeUiIntent) {
         when (intent) {
             HomeUiIntent.OnSearchClick -> sendEffect(NavigateToPartySearch)
-            HomeUiIntent.OnFloatingClick -> sendEffect(NavigateToPartyCreate)
+            HomeUiIntent.OnFloatingClick -> handleFloatingClick()
             is HomeUiIntent.OnMyArtistCategoryClick -> sendEffect(NavigateToMyArtistCategory(if (uiState.value.artistIdToNull) null else intent.artistId))
             is HomeUiIntent.OnProductCardClick -> sendEffect(NavigateToGoodsPartyList(intent.artistId, intent.title))
             HomeUiIntent.LoadHomeContent -> loadHomeContent()
             HomeUiIntent.OnOtherProductCategoryClick -> sendEffect(NavigateToOtherProductCategory)
             HomeUiIntent.OnAlarmClick -> sendEffect(NavigateToAlarmList)
+            HomeUiIntent.OnLoginRequiredConfirm -> handleLoginRequiredConfirm()
+            HomeUiIntent.OnLoginRequiredDismiss -> updateState { copy(showLoginRequiredDialog = false) }
         }
+    }
+
+    private fun handleFloatingClick() {
+        if (isGuestUseCase()) {
+            updateState { copy(showLoginRequiredDialog = true) }
+        } else {
+            sendEffect(NavigateToPartyCreate)
+        }
+    }
+
+    private fun handleLoginRequiredConfirm() {
+        updateState { copy(showLoginRequiredDialog = false) }
+        sendEffect(NavigateToLogin)
     }
 
     init {

--- a/app/src/main/java/com/poti/android/presentation/party/home/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/model/Contracts.kt
@@ -9,6 +9,7 @@ import com.poti.android.domain.model.home.HomeContent
 data class HomeUiState(
     val homeContentLoadState: ApiState<HomeContent> = ApiState.Loading,
     val artistIdToNull: Boolean = false,
+    val showLoginRequiredDialog: Boolean = false,
 ) : UiState
 
 sealed interface HomeUiIntent : UiIntent {
@@ -25,6 +26,10 @@ sealed interface HomeUiIntent : UiIntent {
     data object LoadHomeContent : HomeUiIntent
 
     data object OnAlarmClick : HomeUiIntent
+
+    data object OnLoginRequiredConfirm : HomeUiIntent
+
+    data object OnLoginRequiredDismiss : HomeUiIntent
 }
 
 sealed interface HomeUiEffect : UiEffect {
@@ -39,4 +44,6 @@ sealed interface HomeUiEffect : UiEffect {
     data class NavigateToGoodsPartyList(val artistId: Long, val title: String) : HomeUiEffect
 
     data object NavigateToAlarmList : HomeUiEffect
+
+    data object NavigateToLogin : HomeUiEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/party/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/home/navigation/HomeNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.poti.android.core.navigation.Route
 import com.poti.android.presentation.alarm.navigation.navigateToAlarmList
+import com.poti.android.presentation.auth.navigation.navigateToLogin
 import com.poti.android.presentation.party.create.navigation.navigateToPartyCreate
 import com.poti.android.presentation.party.home.HomeRoute
 import com.poti.android.presentation.party.product.navigation.navigateToProductCategory
@@ -31,6 +32,7 @@ fun NavGraphBuilder.homeNavGraph(
             onNavigateToAlarmList = navController::navigateToAlarmList,
             onNavigateToGoodsPartyList = navController::navigateToProductPartyList,
             onNavigateToProductCategory = navController::navigateToProductCategory,
+            onNavigateToLogin = navController::navigateToLogin,
             modifier = Modifier.padding(paddingValues),
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/party/product/navigation/ProductNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/navigation/ProductNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.toRoute
 import com.poti.android.core.common.extension.slideComposable
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.auth.navigation.navigateToLogin
 import com.poti.android.presentation.party.create.navigation.navigateToPartyCreate
 import com.poti.android.presentation.party.detail.navigation.navigateToPartyDetail
 import com.poti.android.presentation.party.product.partylist.ProductPartyListRoute
@@ -54,6 +55,7 @@ fun NavGraphBuilder.productNavGraph(
             onPopBackStack = navController::popBackStack,
             onNavigateToPartyCreate = navController::navigateToPartyCreate,
             onNavigateToProductPartyList = navController::navigateToProductPartyList,
+            onNavigateToLogin = navController::navigateToLogin,
             modifier = Modifier.padding(paddingValues),
         )
     }
@@ -65,6 +67,7 @@ fun NavGraphBuilder.productNavGraph(
             onPopBackStack = onPopBackStack,
             onNavigateToPartyCreate = navController::navigateToPartyCreate,
             onNavigateToPartyDetail = navController::navigateToPartyDetail,
+            onNavigateToLogin = navController::navigateToLogin,
             modifier = Modifier.padding(paddingValues),
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListScreen.kt
@@ -29,6 +29,7 @@ import com.poti.android.core.common.extension.getSuccessDataOrNull
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiFloatingButton
 import com.poti.android.core.designsystem.component.button.PotiSmallButton
+import com.poti.android.core.designsystem.component.modal.PotiSmallModal
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.domain.model.party.PartySummary
@@ -49,6 +50,7 @@ fun ProductPartyListRoute(
     onPopBackStack: () -> Unit,
     onNavigateToPartyCreate: (Long, String, String) -> Unit,
     onNavigateToPartyDetail: (Long) -> Unit,
+    onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ProductPartyListViewModel = hiltViewModel(),
 ) {
@@ -59,7 +61,20 @@ fun ProductPartyListRoute(
             ProductPartyListUiEffect.NavigateBack -> onPopBackStack()
             is ProductPartyListUiEffect.NavigateToPartyCreate -> onNavigateToPartyCreate(artistId, effect.artistName, effect.productName)
             is ProductPartyListUiEffect.NavigateToPartyDetail -> onNavigateToPartyDetail(effect.partyId)
+            ProductPartyListUiEffect.NavigateToLogin -> onNavigateToLogin()
         }
+    }
+
+    if (uiState.showLoginRequiredDialog) {
+        PotiSmallModal(
+            onDismissRequest = { viewModel.processIntent(ProductPartyListUiIntent.OnLoginRequiredDismiss) },
+            title = stringResource(R.string.login_required_title),
+            text = stringResource(R.string.login_required_create),
+            dismissBtnText = stringResource(R.string.login_required_dismiss),
+            confirmBtnText = stringResource(R.string.login_required_confirm),
+            onDismissBtnClick = { viewModel.processIntent(ProductPartyListUiIntent.OnLoginRequiredDismiss) },
+            onConfirmBtnClick = { viewModel.processIntent(ProductPartyListUiIntent.OnLoginRequiredConfirm) },
+        )
     }
 
     if (uiState.isMemberFilterBottomSheetVisible) {

--- a/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/partylist/ProductPartyListViewModel.kt
@@ -6,6 +6,7 @@ import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
 import com.poti.android.domain.model.artist.Member
 import com.poti.android.domain.usecase.artist.GetMembersUseCase
+import com.poti.android.domain.usecase.auth.IsGuestUseCase
 import com.poti.android.domain.usecase.party.GetProductPartyListUseCase
 import com.poti.android.presentation.party.product.navigation.ProductRoute
 import com.poti.android.presentation.party.product.partylist.model.ProductPartyListUiEffect
@@ -22,6 +23,7 @@ private const val PARTY_PAGE_SIZE = 10
 class ProductPartyListViewModel @Inject constructor(
     private val getMembersUseCase: GetMembersUseCase,
     private val getProductPartyListUseCase: GetProductPartyListUseCase,
+    private val isGuestUseCase: IsGuestUseCase,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<ProductPartyListUiState, ProductPartyListUiIntent, ProductPartyListUiEffect>(
         initialState = ProductPartyListUiState(),
@@ -39,12 +41,7 @@ class ProductPartyListViewModel @Inject constructor(
             ProductPartyListUiIntent.LoadProductPartyList -> loadPartyList()
             ProductPartyListUiIntent.LoadNextProductPartyList -> loadPartyList(reset = false)
             ProductPartyListUiIntent.OnBackClick -> sendEffect(ProductPartyListUiEffect.NavigateBack)
-            ProductPartyListUiIntent.OnFloatingClick -> sendEffect(
-                ProductPartyListUiEffect.NavigateToPartyCreate(
-                    artistName = uiState.value.cachedSubTitle,
-                    productName = title,
-                ),
-            )
+            ProductPartyListUiIntent.OnFloatingClick -> handleFloatingClick()
 
             is ProductPartyListUiIntent.OnPartyClick -> sendEffect(ProductPartyListUiEffect.NavigateToPartyDetail(intent.partyId))
             ProductPartyListUiIntent.OnMemberFilterClick -> {
@@ -78,7 +75,28 @@ class ProductPartyListViewModel @Inject constructor(
                     clearSelectedMembers()
                 }
             }
+
+            ProductPartyListUiIntent.OnLoginRequiredConfirm -> handleLoginRequiredConfirm()
+            ProductPartyListUiIntent.OnLoginRequiredDismiss -> updateState { copy(showLoginRequiredDialog = false) }
         }
+    }
+
+    private fun handleFloatingClick() {
+        if (isGuestUseCase()) {
+            updateState { copy(showLoginRequiredDialog = true) }
+        } else {
+            sendEffect(
+                ProductPartyListUiEffect.NavigateToPartyCreate(
+                    artistName = uiState.value.cachedSubTitle,
+                    productName = title,
+                ),
+            )
+        }
+    }
+
+    private fun handleLoginRequiredConfirm() {
+        updateState { copy(showLoginRequiredDialog = false) }
+        sendEffect(ProductPartyListUiEffect.NavigateToLogin)
     }
 
     private fun loadPartyList(reset: Boolean = true) = launchScope {

--- a/app/src/main/java/com/poti/android/presentation/party/product/partylist/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/partylist/model/Contracts.kt
@@ -29,6 +29,7 @@ data class ProductPartyListUiState(
     val isSortFilterBottomSheetVisible: Boolean = false,
     val bottomSheetSelectedMembers: ImmutableList<Member> = persistentListOf(),
     val isMemberBottomSheetToucehd: Boolean = false,
+    val showLoginRequiredDialog: Boolean = false,
 ) : UiState {
     val memberFilterText: String
         @Composable get() = when {
@@ -81,6 +82,10 @@ sealed interface ProductPartyListUiIntent : UiIntent {
     data object OnMemberFilterDone : ProductPartyListUiIntent
 
     data object OnMemberFilterRefresh : ProductPartyListUiIntent
+
+    data object OnLoginRequiredConfirm : ProductPartyListUiIntent
+
+    data object OnLoginRequiredDismiss : ProductPartyListUiIntent
 }
 
 sealed interface ProductPartyListUiEffect : UiEffect {
@@ -89,4 +94,6 @@ sealed interface ProductPartyListUiEffect : UiEffect {
     data class NavigateToPartyCreate(val artistName: String, val productName: String) : ProductPartyListUiEffect
 
     data class NavigateToPartyDetail(val partyId: Long) : ProductPartyListUiEffect
+
+    data object NavigateToLogin : ProductPartyListUiEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
@@ -59,8 +59,13 @@ fun ProductCategoryRoute(
 
     uiState.productCategoryLoadState.onSuccess { goodsCategory ->
         ProductCategoryScreen(
-            title = if (viewModel.isMyArtist) stringResource(R.string.home_recommend_goods, goodsCategory.nickname) else stringResource(R.string.home_other_goods),
-            isMyArtsit = viewModel.isMyArtist,
+            title = when {
+                !viewModel.isMyArtist -> stringResource(R.string.home_other_goods)
+                // TODO: [천민재] home 화면과 동일한 임시 문자열
+                goodsCategory.nickname.isBlank() -> stringResource(R.string.home_recommend_goods_guest)
+                else -> stringResource(R.string.home_recommend_goods, goodsCategory.nickname)
+            },
+            isMyArtist = viewModel.isMyArtist,
             productCategory = goodsCategory,
             selectedSortType = uiState.selectedSortType,
             isSortBottomSheetVisible = uiState.isSortBottomSheetVisible,
@@ -81,7 +86,7 @@ fun ProductCategoryRoute(
 @Composable
 private fun ProductCategoryScreen(
     title: String,
-    isMyArtsit: Boolean,
+    isMyArtist: Boolean,
     productCategory: ProductCategory,
     selectedSortType: ProductSortType,
     isSortBottomSheetVisible: Boolean,
@@ -142,7 +147,7 @@ private fun ProductCategoryScreen(
                 ),
             ) {
                 item {
-                    if (isMyArtsit) {
+                    if (isMyArtist) {
                         PotiSmallButton(
                             text = stringResource(selectedSortType.displayRes),
                             onClick = onSortFilterClick,
@@ -190,7 +195,7 @@ private fun ProductCategoryScreenPreview() {
     PotiTheme {
         ProductCategoryScreen(
             title = "",
-            isMyArtsit = false,
+            isMyArtist = false,
             productCategory = UiMockData.productCategory,
             selectedSortType = ProductSortType.LATEST,
             isSortBottomSheetVisible = false,

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryScreen.kt
@@ -28,6 +28,7 @@ import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiFloatingButton
 import com.poti.android.core.designsystem.component.button.PotiSmallButton
+import com.poti.android.core.designsystem.component.modal.PotiSmallModal
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.data.mock.UiMockData
@@ -44,6 +45,7 @@ fun ProductCategoryRoute(
     onPopBackStack: () -> Unit,
     onNavigateToPartyCreate: (Long?) -> Unit,
     onNavigateToProductPartyList: (Long, String) -> Unit,
+    onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ProductCategoryViewModel = hiltViewModel(),
 ) {
@@ -54,7 +56,20 @@ fun ProductCategoryRoute(
             ProductCategoryUiEffect.NavigateBack -> onPopBackStack()
             is ProductCategoryUiEffect.NavigateToPartyCreate -> onNavigateToPartyCreate(artistId)
             is ProductCategoryUiEffect.NavigateToProductPartyList -> onNavigateToProductPartyList(effect.artistId, effect.title)
+            ProductCategoryUiEffect.NavigateToLogin -> onNavigateToLogin()
         }
+    }
+
+    if (uiState.showLoginRequiredDialog) {
+        PotiSmallModal(
+            onDismissRequest = { viewModel.processIntent(ProductCategoryUiIntent.OnLoginRequiredDismiss) },
+            title = stringResource(R.string.login_required_title),
+            text = stringResource(R.string.login_required_create),
+            dismissBtnText = stringResource(R.string.login_required_dismiss),
+            confirmBtnText = stringResource(R.string.login_required_confirm),
+            onDismissBtnClick = { viewModel.processIntent(ProductCategoryUiIntent.OnLoginRequiredDismiss) },
+            onConfirmBtnClick = { viewModel.processIntent(ProductCategoryUiIntent.OnLoginRequiredConfirm) },
+        )
     }
 
     uiState.productCategoryLoadState.onSuccess { goodsCategory ->

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/ProductCategoryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.auth.IsGuestUseCase
 import com.poti.android.domain.usecase.home.GetGoodsCategoryListUseCase
 import com.poti.android.presentation.party.product.navigation.ProductRoute.ProductCategory
 import com.poti.android.presentation.party.product.productcategory.model.ProductCategoryUiEffect
@@ -18,6 +19,7 @@ private const val PRODUCT_CATEGORY_PAGE_SIZE = 10
 @HiltViewModel
 class ProductCategoryViewModel @Inject constructor(
     private val getGoodsCategoryListUseCase: GetGoodsCategoryListUseCase,
+    private val isGuestUseCase: IsGuestUseCase,
     savedStateHandle: SavedStateHandle,
 ) :
     BaseViewModel<ProductCategoryUiState, ProductCategoryUiIntent, ProductCategoryUiEffect>(
@@ -30,7 +32,7 @@ class ProductCategoryViewModel @Inject constructor(
         override fun processIntent(intent: ProductCategoryUiIntent) {
             when (intent) {
                 ProductCategoryUiIntent.OnBackClick -> sendEffect(ProductCategoryUiEffect.NavigateBack)
-                ProductCategoryUiIntent.OnFloatingClick -> sendEffect(ProductCategoryUiEffect.NavigateToPartyCreate)
+                ProductCategoryUiIntent.OnFloatingClick -> handleFloatingClick()
                 ProductCategoryUiIntent.OnSortFilterClick -> updateState { copy(isSortBottomSheetVisible = true) }
                 is ProductCategoryUiIntent.OnSortSelected -> {
                     updateState {
@@ -45,7 +47,22 @@ class ProductCategoryViewModel @Inject constructor(
                 ProductCategoryUiIntent.OnLoadNextPage -> loadGoodsCategoryList(reset = false)
                 ProductCategoryUiIntent.OnSortDismiss -> updateState { copy(isSortBottomSheetVisible = false) }
                 is ProductCategoryUiIntent.OnCardClick -> sendEffect(ProductCategoryUiEffect.NavigateToProductPartyList(intent.artistId, intent.title))
+                ProductCategoryUiIntent.OnLoginRequiredConfirm -> handleLoginRequiredConfirm()
+                ProductCategoryUiIntent.OnLoginRequiredDismiss -> updateState { copy(showLoginRequiredDialog = false) }
             }
+        }
+
+        private fun handleFloatingClick() {
+            if (isGuestUseCase()) {
+                updateState { copy(showLoginRequiredDialog = true) }
+            } else {
+                sendEffect(ProductCategoryUiEffect.NavigateToPartyCreate)
+            }
+        }
+
+        private fun handleLoginRequiredConfirm() {
+            updateState { copy(showLoginRequiredDialog = false) }
+            sendEffect(ProductCategoryUiEffect.NavigateToLogin)
         }
 
         init {

--- a/app/src/main/java/com/poti/android/presentation/party/product/productcategory/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/product/productcategory/model/Contracts.kt
@@ -13,6 +13,7 @@ data class ProductCategoryUiState(
     val nextProductCategoryPage: Int = 0,
     val isSortBottomSheetVisible: Boolean = false,
     val selectedSortType: ProductSortType = ProductSortType.HOT,
+    val showLoginRequiredDialog: Boolean = false,
 ) : UiState
 
 sealed interface ProductCategoryUiIntent : UiIntent {
@@ -29,6 +30,10 @@ sealed interface ProductCategoryUiIntent : UiIntent {
     data object OnSortDismiss : ProductCategoryUiIntent
 
     data class OnCardClick(val artistId: Long, val title: String) : ProductCategoryUiIntent
+
+    data object OnLoginRequiredConfirm : ProductCategoryUiIntent
+
+    data object OnLoginRequiredDismiss : ProductCategoryUiIntent
 }
 
 sealed interface ProductCategoryUiEffect : UiEffect {
@@ -37,4 +42,6 @@ sealed interface ProductCategoryUiEffect : UiEffect {
     data object NavigateToPartyCreate : ProductCategoryUiEffect
 
     data class NavigateToProductPartyList(val artistId: Long, val title: String) : ProductCategoryUiEffect
+
+    data object NavigateToLogin : ProductCategoryUiEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -39,6 +39,7 @@ import com.poti.android.presentation.user.component.InquirySection
 import com.poti.android.presentation.user.component.RatingBadge
 import com.poti.android.presentation.user.component.UserInfo
 import com.poti.android.presentation.user.component.UserProfile
+import com.poti.android.presentation.user.mypage.component.GuestMyPageContent
 import com.poti.android.presentation.user.mypage.model.MyPageUiEffect
 import com.poti.android.presentation.user.mypage.model.MyPageUiIntent
 
@@ -47,6 +48,7 @@ fun MyPageRoute(
     onNavigateToHistoryList: (HistoryMode, HistorySummaryType) -> Unit,
     onNavigateToFavoriteArtist: (String?) -> Unit,
     onNavigateToSetting: () -> Unit,
+    onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
@@ -66,7 +68,18 @@ fun MyPageRoute(
             is MyPageUiEffect.NavigateToFavoriteArtist -> {
                 onNavigateToFavoriteArtist(effect.favoriteArtistName)
             }
+
+            MyPageUiEffect.NavigateToLogin -> onNavigateToLogin()
         }
+    }
+
+    if (uiState.isGuest) {
+        GuestMyPageScreen(
+            onSettingClick = onNavigateToSetting,
+            onLoginClick = { viewModel.processIntent(MyPageUiIntent.OnLoginClick) },
+            modifier = modifier,
+        )
+        return
     }
 
     uiState.userMyPageLoadState.onSuccess { userMyPage ->
@@ -81,6 +94,38 @@ fun MyPageRoute(
                 )
             },
             modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun GuestMyPageScreen(
+    onSettingClick: () -> Unit,
+    onLoginClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(PotiTheme.colors.gray100),
+    ) {
+        PotiHeaderPrimary(
+            title = stringResource(R.string.user_my_page_title),
+            firstIconRes = R.drawable.ic_setting,
+            onFirstIconClick = onSettingClick,
+            secondIconRes = R.drawable.ic_alarm,
+            onSecondIconClick = {},
+            containerColor = PotiTheme.colors.gray100,
+        )
+
+        GuestMyPageContent(
+            onLoginClick = onLoginClick,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(PotiTheme.colors.white),
         )
     }
 }
@@ -218,32 +263,11 @@ private fun ProfileScreenPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun ProfileScreenPreview2() {
+private fun GuestMyPageScreenPreview() {
     PotiTheme {
-        MyPageScreen(
-            userMyPage = UserMyPage(
-                nickname = "분철의 악마",
-                email = "akkma@app.jam",
-                profileImageUrl = "",
-                ratingAvg = "4.8",
-                activityMessage = "최근 3일 이내 활동",
-                joinedAt = "2025-12-28",
-                hasFavoriteArtist = true,
-                favoriteArtistName = null,
-                participationSummary = HistorySummary(
-                    inProgress = 3,
-                    completed = 9,
-                ),
-                recruitSummary = HistorySummary(
-                    inProgress = 2,
-                    completed = 5,
-                ),
-            ),
-            onArtistClick = {},
-            onInquiryClick = {},
+        GuestMyPageScreen(
             onSettingClick = {},
-            onHistoryClick = { _, _ -> },
-            modifier = Modifier,
+            onLoginClick = {},
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageScreen.kt
@@ -75,7 +75,6 @@ fun MyPageRoute(
 
     if (uiState.isGuest) {
         GuestMyPageScreen(
-            onSettingClick = onNavigateToSetting,
             onLoginClick = { viewModel.processIntent(MyPageUiIntent.OnLoginClick) },
             modifier = modifier,
         )
@@ -100,7 +99,6 @@ fun MyPageRoute(
 
 @Composable
 private fun GuestMyPageScreen(
-    onSettingClick: () -> Unit,
     onLoginClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -112,7 +110,7 @@ private fun GuestMyPageScreen(
         PotiHeaderPrimary(
             title = stringResource(R.string.user_my_page_title),
             firstIconRes = R.drawable.ic_setting,
-            onFirstIconClick = onSettingClick,
+            onFirstIconClick = {},
             secondIconRes = R.drawable.ic_alarm,
             onSecondIconClick = {},
             containerColor = PotiTheme.colors.gray100,
@@ -266,7 +264,6 @@ private fun ProfileScreenPreview() {
 private fun GuestMyPageScreenPreview() {
     PotiTheme {
         GuestMyPageScreen(
-            onSettingClick = {},
             onLoginClick = {},
         )
     }

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/MyPageViewModel.kt
@@ -2,6 +2,7 @@ package com.poti.android.presentation.user.mypage
 
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.auth.IsGuestUseCase
 import com.poti.android.domain.usecase.user.GetUserMyPageUseCase
 import com.poti.android.presentation.user.mypage.model.MyPageUiEffect
 import com.poti.android.presentation.user.mypage.model.MyPageUiEffect.*
@@ -13,6 +14,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getUserMyPageUseCase: GetUserMyPageUseCase,
+    private val isGuestUseCase: IsGuestUseCase,
 ) : BaseViewModel<MyPageUiState, MyPageUiIntent, MyPageUiEffect>(
         initialState = MyPageUiState(),
     ) {
@@ -20,6 +22,7 @@ class MyPageViewModel @Inject constructor(
         when (intent) {
             MyPageUiIntent.OnArtistClick -> handleArtistClick()
             MyPageUiIntent.OnResume -> loadUserMyPage()
+            MyPageUiIntent.OnLoginClick -> sendEffect(NavigateToLogin)
             is MyPageUiIntent.OnHistoryClick -> {
                 sendEffect(
                     NavigateToHistoryList(
@@ -42,6 +45,11 @@ class MyPageViewModel @Inject constructor(
     }
 
     private fun loadUserMyPage() = launchScope {
+        if (isGuestUseCase()) {
+            updateState { copy(isGuest = true) }
+            return@launchScope
+        }
+
         getUserMyPageUseCase()
             .onSuccess { userMyPage ->
                 updateState {

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/component/GuestMyPageContent.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/component/GuestMyPageContent.kt
@@ -1,0 +1,63 @@
+package com.poti.android.presentation.user.mypage.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.theme.PotiTheme
+import com.poti.android.presentation.user.component.BadgeButton
+
+@Composable
+fun GuestMyPageContent(
+    onLoginClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Image(
+            painter = painterResource(R.drawable.img_basic_profile),
+            contentDescription = null,
+            modifier = Modifier
+                .size(98.dp)
+                .clip(CircleShape),
+        )
+
+        Text(
+            text = stringResource(R.string.user_guest_description),
+            modifier = Modifier.padding(top = 12.dp),
+            color = PotiTheme.colors.black,
+            style = PotiTheme.typography.body16sb,
+            textAlign = TextAlign.Center,
+        )
+
+        BadgeButton(
+            bias = stringResource(R.string.user_guest_login),
+            onClick = onLoginClick,
+            modifier = Modifier.padding(top = 24.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFAFAFC)
+@Composable
+private fun GuestMyPageContentPreview() {
+    PotiTheme {
+        GuestMyPageContent(onLoginClick = {})
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/model/Contracts.kt
@@ -10,12 +10,15 @@ import com.poti.android.presentation.user.component.HistorySummaryType
 
 data class MyPageUiState(
     val userMyPageLoadState: ApiState<UserMyPage> = ApiState.Loading,
+    val isGuest: Boolean = false,
 ) : UiState
 
 sealed interface MyPageUiIntent : UiIntent {
     data object OnArtistClick : MyPageUiIntent
 
     data object OnResume : MyPageUiIntent
+
+    data object OnLoginClick : MyPageUiIntent
 
     data class OnHistoryClick(
         val mode: HistoryMode,
@@ -32,4 +35,6 @@ sealed interface MyPageUiEffect : UiEffect {
         val mode: HistoryMode,
         val tab: HistorySummaryType,
     ) : MyPageUiEffect
+
+    data object NavigateToLogin : MyPageUiEffect
 }

--- a/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/mypage/navigation/MyPageNavigation.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.composable
 import com.poti.android.core.common.extension.slideComposable
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.core.navigation.Route
+import com.poti.android.presentation.auth.navigation.navigateToLogin
 import com.poti.android.presentation.history.navigation.navigateToHistoryList
 import com.poti.android.presentation.user.favoriteartist.FavoriteArtistRoute
 import com.poti.android.presentation.user.mypage.MyPageRoute
@@ -44,6 +45,7 @@ fun NavGraphBuilder.myPageNavGraph(
             onNavigateToHistoryList = navController::navigateToHistoryList,
             onNavigateToSetting = navController::navigateToSetting,
             onNavigateToFavoriteArtist = navController::navigateToFavoriteArtist,
+            onNavigateToLogin = navController::navigateToLogin,
             modifier = Modifier
                 .fillMaxSize()
                 .background(PotiTheme.colors.gray100)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
 
     <!-- LoginScreen -->
     <string name="login_poti_description">굿즈 분철을 더 간편하게</string>
+    <string name="login_browse_as_guest">로그인 없이 둘러보기</string>
 
     <!-- Onboarding -->
     <string name="onboarding_guide_label">공동구매부터 분철 정산까지\n한 번에 관리해요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,6 +275,8 @@
     <string name="user_select_favorite_artist">나의 최애 선택</string>
     <string name="user_inquiry_description">궁금한 점이나 건의사항이 있다면 알려주세요</string>
     <string name="user_inquiry_action">문의하기</string>
+    <string name="user_guest_description">로그인하고 원하는 분철에\n참여해보세요!</string>
+    <string name="user_guest_login">로그인</string>
 
     <!-- Favorite Artist -->
     <string name="favorite_artist_title">나의 최애 선택</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,8 +55,7 @@
     <string name="login_required_join">분철에 참여하려면 로그인이 필요해요</string>
     <string name="login_required_create">분철을 등록하려면 로그인이 필요해요</string>
     <string name="login_required_dismiss">다음에 하기</string>
-    <!-- TODO(디자인 확인): 참여/모집 공통 우측 버튼 문구. 현재 Figma 기준 "계속 작성하기" -->
-    <string name="login_required_confirm">계속 작성하기</string>
+    <string name="login_required_confirm">로그인하기</string>
 
     <!-- Onboarding -->
     <string name="onboarding_guide_label">공동구매부터 분철 정산까지\n한 번에 관리해요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,14 @@
     <string name="login_poti_description">굿즈 분철을 더 간편하게</string>
     <string name="login_browse_as_guest">로그인 없이 둘러보기</string>
 
+    <!-- 게스트 로그인 유도 모달 -->
+    <string name="login_required_title">로그인 후 이용 가능해요</string>
+    <string name="login_required_join">분철에 참여하려면 로그인이 필요해요</string>
+    <string name="login_required_create">분철을 등록하려면 로그인이 필요해요</string>
+    <string name="login_required_dismiss">다음에 하기</string>
+    <!-- TODO(디자인 확인): 참여/모집 공통 우측 버튼 문구. 현재 Figma 기준 "계속 작성하기" -->
+    <string name="login_required_confirm">계속 작성하기</string>
+
     <!-- Onboarding -->
     <string name="onboarding_guide_label">공동구매부터 분철 정산까지\n한 번에 관리해요</string>
     <string name="onboarding_nickname_label">포티에서 사용할 닉네임을\n입력해주세요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="login_required_title">로그인 후 이용 가능해요</string>
     <string name="login_required_join">분철에 참여하려면 로그인이 필요해요</string>
     <string name="login_required_create">분철을 등록하려면 로그인이 필요해요</string>
+    <string name="login_required_history">분철 내역을 보려면 로그인이 필요해요</string>
     <string name="login_required_dismiss">다음에 하기</string>
     <string name="login_required_confirm">로그인하기</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -281,6 +281,8 @@
 
     <!-- Home -->
     <string name="home_recommend_goods">%1$s님을 위한 추천 굿즈</string>
+    <!-- TODO(디자인 확인): 게스트(비로그인) 추천 굿즈 섹션 제목. 임시 문구 -->
+    <string name="home_recommend_goods_guest">추천 굿즈</string>
     <string name="home_other_goods">다른 굿즈 구경하기</string>
     <string name="home_more">더보기</string>
 

--- a/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/poti/android/data/network/TokenAuthenticatorTest.kt
@@ -135,6 +135,21 @@ class TokenAuthenticatorTest {
     }
 
     @Test
+    fun `keeps guest session without reissue or logout when no token is stored`() {
+        `when`(authTokenStore.cachedTokenPair).thenReturn(null)
+
+        val retriedRequest = tokenAuthenticator.authenticate(
+            route = null,
+            response = unauthorizedResponse(withAuthorizationHeader = false),
+        )
+
+        assertNull(retriedRequest)
+        verifyNoInteractions(authRemoteDataSource)
+        verify(authTokenStore, never()).clearCachedTokens()
+        verify(authSessionManager, never()).triggerLogout()
+    }
+
+    @Test
     fun `does not reissue when response already has an authentication retry`() {
         val retriedRequest = tokenAuthenticator.authenticate(
             route = null,
@@ -234,11 +249,16 @@ class TokenAuthenticatorTest {
     private fun unauthorizedResponse(
         requestUrl: String = PARTY_URL,
         previousResponse: Response? = null,
+        withAuthorizationHeader: Boolean = true,
     ): Response = Response.Builder()
         .request(
             Request.Builder()
                 .url(requestUrl)
-                .header(AUTHORIZATION_HEADER, "Bearer $OLD_ACCESS_TOKEN")
+                .apply {
+                    if (withAuthorizationHeader) {
+                        header(AUTHORIZATION_HEADER, "Bearer $OLD_ACCESS_TOKEN")
+                    }
+                }
                 .build(),
         )
         .protocol(Protocol.HTTP_1_1)

--- a/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
@@ -64,12 +64,14 @@ class LoginViewModelTest {
     fun `enters guest mode and navigates to home once when browse is clicked repeatedly`() =
         runTest(mainDispatcherRule.testDispatcher) {
             val effects = collectEffects()
+            authSessionManager.setPendingReturnDeepLink("poti://party/1")
 
             viewModel.processIntent(LoginIntent.OnBrowseAsGuestClick)
             viewModel.processIntent(LoginIntent.OnBrowseAsGuestClick)
             advanceUntilIdle()
 
             assertTrue(authSessionManager.isGuest.value)
+            assertEquals(null, authSessionManager.consumePendingReturnDeepLink())
             assertEquals(LoginPhase.SUCCESS, viewModel.uiState.value.phase)
             assertEquals(listOf(LoginEffect.NavigateToHome), effects)
         }

--- a/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
@@ -61,19 +61,17 @@ class LoginViewModelTest {
         }
 
     @Test
-    fun `enters guest mode and navigates to home once when browse is clicked repeatedly`() =
+    fun `enters guest mode and clears pending deep link and navigates to home when browse is clicked`() =
         runTest(mainDispatcherRule.testDispatcher) {
             val effects = collectEffects()
             authSessionManager.setPendingReturnDeepLink("poti://party/1")
 
             viewModel.processIntent(LoginIntent.OnBrowseAsGuestClick)
-            viewModel.processIntent(LoginIntent.OnBrowseAsGuestClick)
             advanceUntilIdle()
 
             assertTrue(authSessionManager.isGuest.value)
             assertEquals(null, authSessionManager.consumePendingReturnDeepLink())
-            assertEquals(LoginPhase.SUCCESS, viewModel.uiState.value.phase)
-            assertEquals(listOf(LoginEffect.NavigateToHome), effects)
+            assertEquals(LoginEffect.NavigateToHome, effects.first())
         }
 
     @Test

--- a/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
@@ -2,11 +2,13 @@ package com.poti.android.presentation.auth
 
 import com.poti.android.MainDispatcherRule
 import com.poti.android.core.auth.SocialLoginResult
+import com.poti.android.domain.manager.AuthSessionManager
 import com.poti.android.domain.model.auth.AuthState
 import com.poti.android.domain.model.auth.SocialType
 import com.poti.android.domain.model.auth.UserAuth
 import com.poti.android.domain.model.auth.WithdrawalReason
 import com.poti.android.domain.repository.AuthRepository
+import com.poti.android.domain.usecase.auth.EnterGuestModeUseCase
 import com.poti.android.domain.usecase.auth.LoginUseCase
 import com.poti.android.presentation.auth.model.LoginEffect
 import com.poti.android.presentation.auth.model.LoginIntent
@@ -35,7 +37,10 @@ class LoginViewModelTest {
     @Before
     fun setUp() {
         authRepository = FakeAuthRepository()
-        viewModel = LoginViewModel(LoginUseCase(authRepository))
+        viewModel = LoginViewModel(
+            loginUseCase = LoginUseCase(authRepository),
+            enterGuestModeUseCase = EnterGuestModeUseCase(AuthSessionManager()),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
@@ -8,6 +8,7 @@ import com.poti.android.domain.model.auth.SocialType
 import com.poti.android.domain.model.auth.UserAuth
 import com.poti.android.domain.model.auth.WithdrawalReason
 import com.poti.android.domain.repository.AuthRepository
+import com.poti.android.domain.usecase.auth.ClearPendingReturnDeepLinkUseCase
 import com.poti.android.domain.usecase.auth.EnterGuestModeUseCase
 import com.poti.android.domain.usecase.auth.LoginUseCase
 import com.poti.android.presentation.auth.model.LoginEffect
@@ -42,6 +43,7 @@ class LoginViewModelTest {
         viewModel = LoginViewModel(
             loginUseCase = LoginUseCase(authRepository),
             enterGuestModeUseCase = EnterGuestModeUseCase(authSessionManager),
+            clearPendingReturnDeepLinkUseCase = ClearPendingReturnDeepLinkUseCase(authSessionManager),
         )
     }
 

--- a/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/auth/LoginViewModelTest.kt
@@ -32,14 +32,16 @@ class LoginViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private lateinit var authRepository: FakeAuthRepository
+    private lateinit var authSessionManager: AuthSessionManager
     private lateinit var viewModel: LoginViewModel
 
     @Before
     fun setUp() {
         authRepository = FakeAuthRepository()
+        authSessionManager = AuthSessionManager()
         viewModel = LoginViewModel(
             loginUseCase = LoginUseCase(authRepository),
-            enterGuestModeUseCase = EnterGuestModeUseCase(AuthSessionManager()),
+            enterGuestModeUseCase = EnterGuestModeUseCase(authSessionManager),
         )
     }
 
@@ -54,6 +56,20 @@ class LoginViewModelTest {
 
             assertEquals(listOf(LoginEffect.LaunchSocialLogin(SocialType.KAKAO)), effects)
             assertEquals(LoginPhase.SOCIAL_LOGIN, viewModel.uiState.value.phase)
+        }
+
+    @Test
+    fun `enters guest mode and navigates to home once when browse is clicked repeatedly`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val effects = collectEffects()
+
+            viewModel.processIntent(LoginIntent.OnBrowseAsGuestClick)
+            viewModel.processIntent(LoginIntent.OnBrowseAsGuestClick)
+            advanceUntilIdle()
+
+            assertTrue(authSessionManager.isGuest.value)
+            assertEquals(LoginPhase.SUCCESS, viewModel.uiState.value.phase)
+            assertEquals(listOf(LoginEffect.NavigateToHome), effects)
         }
 
     @Test

--- a/app/src/test/java/com/poti/android/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/main/MainViewModelTest.kt
@@ -1,0 +1,42 @@
+package com.poti.android.presentation.main
+
+import com.poti.android.domain.model.auth.AuthState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MainViewModelTest {
+    @Test
+    fun `deep link entry mode follows authentication and onboarding state`() {
+        assertEquals(
+            DeepLinkEntryMode.DEFER,
+            AuthState(
+                accessToken = null,
+                isOnboardingFinished = false,
+            ).toDeepLinkEntryMode(),
+        )
+        assertEquals(
+            DeepLinkEntryMode.DEFER,
+            AuthState(
+                accessToken = "access-token",
+                isOnboardingFinished = false,
+                isInitialized = true,
+            ).toDeepLinkEntryMode(),
+        )
+        assertEquals(
+            DeepLinkEntryMode.MEMBER,
+            AuthState(
+                accessToken = "access-token",
+                isOnboardingFinished = true,
+                isInitialized = true,
+            ).toDeepLinkEntryMode(),
+        )
+        assertEquals(
+            DeepLinkEntryMode.GUEST,
+            AuthState(
+                accessToken = null,
+                isOnboardingFinished = false,
+                isInitialized = true,
+            ).toDeepLinkEntryMode(),
+        )
+    }
+}


### PR DESCRIPTION
## Related issue 🛠️
- closed #202

## Work Description ✏️
- 로그인 상태와 분리된 인메모리 게스트 세션을 추가했습니다.
- 분철 등록, 참여에 로그인 게이팅을 적용하고, 참여 로그인 완료 후 직전 분철 상세페이지로 복귀하도록 연결했습니다.
- 게스트 홈 응답의 nullable 필드와 토큰 없는 401 응답을 안전하게 처리하고, 비로그인 마이페이지를 추가했습니다.

## Screenshot 📸

<!-- 녹화 첨부 -->

| 게스트 진입: 둘러보기 → 최애 스킵 → 홈, 굿즈/배너 표시 & 추천/다른 굿즈 더보기 | 모집 버튼 게스트 처리: + 버튼 -> 모달 -> 로그인 이동 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/30994c14-aa62-4d91-8716-a0a93b92ada0" controls width="600"></video> | <video src="https://github.com/user-attachments/assets/4692cf2e-528c-4897-916c-5e304b8bac17" controls width="600"></video> |

| 게스트 상태에서 분철 참여 + 복귀: 참여하기 -> 모달 -> 로그인 -> 직전 분철로 복귀 | 비로그인 마이페이지: 마이 탭 -> 게스트 뷰 -> 로그인 이동 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/29d106d0-646e-4241-9ea8-6ae1bd0017fb" controls width="600"></video> | <video src="https://github.com/user-attachments/assets/c3566cf9-0af1-49f6-bb4a-7339d657dfa9" controls width="600"></video> |

| 세션 전환: 로그인 후 게스트 -> 회원 전환 |
| --- |
| <video src="https://github.com/user-attachments/assets/e135ccde-1ea1-4a29-a7d2-df16bd14e6dc" controls width="600"></video> |


## Uncompleted Tasks 😅
- [ ] 게스트에서 홈화면 바텀바의 분철내역 접근 시 정책은 기획 확인 후 후속 이슈로 진행합니다.
- [ ] 게스트 알림, 설정 접근 정책은 기획 확인 후 후속 이슈로 진행합니다.

## To Reviewers 📢
- 게스트 상태는 영속화하지 않으며, 앱 프로세스 종료 후에는 로그인 화면부터 시작합니다.
- 게스트 상태에서 모집 참여 시도, 로그인에 성공하면, 직전 상세페이지로 복귀합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 로그인 없이 게스트로 앱을 둘러볼 수 있습니다.
  - 게스트용 마이페이지와 로그인 유도 버튼을 제공합니다.
  - 상품 참여·생성 및 이용 기록 확인 시 로그인 안내 모달을 표시합니다.
  - 로그인 후 원래 접근하려던 화면으로 돌아갈 수 있습니다.
  - 공유 링크를 게스트 상태에서도 바로 확인할 수 있습니다.
  - 파티 공유 옵션을 한곳에서 선택할 수 있습니다.

- **개선**
  - 게스트 상태에 맞는 안내 문구와 추천 상품 제목을 표시합니다.
  - 닉네임이 없어도 화면이 안정적으로 표시됩니다.
  - 온보딩 완료 상태가 안정적으로 저장됩니다.

- **버그 수정**
  - 게스트 인증 오류 시 불필요한 로그아웃이나 토큰 갱신을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->