### PR TITLE
[Fix/#210] PotiListRadioItem 레이아웃 수정

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable

--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -81,7 +82,7 @@ fun PotiListRadioItem(
 @Preview(showBackground = true)
 @Composable
 private fun PotiListRadioPreview() {
-    var selected by remember { mutableStateOf(1) }
+    var selected by remember { mutableIntStateOf(1) }
 
     PotiTheme {
         PotiListRadio(

--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
@@ -63,6 +63,7 @@ fun PotiListRadioItem(
                 indication = null,
                 onClick = onClick,
             )
+            .heightIn(48.dp)
             .padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/display/PotiListRadio.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Text
@@ -61,7 +63,7 @@ fun PotiListRadioItem(
                 indication = null,
                 onClick = onClick,
             )
-            .padding(vertical = 16.dp),
+            .padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {


### PR DESCRIPTION
## Related issue 🛠️
- closed #210

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- PotiListRadioItem vertical padding 값이 `16.dp`로 되어 있어 `12.dp`로 수정했습니다.
- 최소 높이 `48dp` 설정했습니다.

## Screenshot 📸

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/8596579d-5291-413d-9f5b-6a58fae5bac2" width="250" /> | <video src="https://github.com/user-attachments/assets/292b2d12-53fb-4434-b0f2-cc2e281f33f1" width="250" /> |

## Uncompleted Tasks 😅
- [x] N/A

## To Reviewers 📢
피그마 잘보자^^

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 라디오 목록 항목의 세로 여백을 조정해 더욱 간결하게 표시되도록 개선했습니다.
  - 항목에 최소 높이를 적용해 터치 영역과 표시 일관성을 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->