### PR TITLE
[Feat/#204] 알람 권한 허용 플로우 추가

### DIFF
--- a/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
+++ b/app/src/main/java/com/poti/android/core/common/extension/ContextExt.kt
@@ -5,6 +5,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.provider.Settings
 import android.widget.Toast
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
@@ -53,4 +54,12 @@ fun Context.shareTextToX(text: String) {
     runCatching { startActivity(appIntent) }
         .recoverCatching { startActivity(webIntent) }
         .onFailure { Timber.e(it, "X 공유 실패") }
+}
+
+fun Context.openSystemNotificationSetting() {
+    val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+        .putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+
+    runCatching { startActivity(intent) }
+        .onFailure { Timber.w(it, "Unable to open system notification setting") }
 }

--- a/app/src/main/java/com/poti/android/core/designsystem/component/modal/PotiPermissionModal.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/modal/PotiPermissionModal.kt
@@ -1,0 +1,56 @@
+package com.poti.android.core.designsystem.component.modal
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.poti.android.R
+import com.poti.android.core.designsystem.theme.PotiTheme
+
+@Composable
+fun PotiPermissionModal(
+    onDismiss: () -> Unit,
+    onAllowClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PotiLargeModal(
+        onDismissRequest = onDismiss,
+        title = stringResource(R.string.alarm_permission_modal_title),
+        text = stringResource(R.string.alarm_permission_modal_text),
+        btnText = stringResource(R.string.alarm_permission_modal_button),
+        onBtnClick = onAllowClick,
+        subBtnText = stringResource(R.string.alarm_permission_modal_sub_button),
+        onSubBtnClick = onDismiss,
+        dismissOnClickOutside = false,
+        topSlot = {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_alarm),
+                contentDescription = null,
+                tint = PotiTheme.colors.poti600,
+                modifier = Modifier.size(48.dp),
+            )
+
+            Spacer(Modifier.height(12.dp))
+        },
+        content = { Spacer(Modifier.height(24.dp)) },
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun PotiPermissionModalPreview() {
+    PotiTheme {
+        PotiPermissionModal(
+            onDismiss = {},
+            onAllowClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/poti/android/core/permission/PermissionManager.kt
+++ b/app/src/main/java/com/poti/android/core/permission/PermissionManager.kt
@@ -1,0 +1,85 @@
+package com.poti.android.core.permission
+
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationManagerCompat
+import com.poti.android.core.permission.datasource.PermissionDataSource
+import com.poti.android.domain.usecase.auth.IsGuestUseCase
+import com.poti.android.domain.usecase.notification.GetNotificationSettingUseCase
+import com.poti.android.domain.usecase.notification.UpdateNotificationSettingUseCase
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PermissionManager @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val isGuestUseCase: IsGuestUseCase,
+    private val getNotificationSettingUseCase: GetNotificationSettingUseCase,
+    private val updateNotificationSettingUseCase: UpdateNotificationSettingUseCase,
+    private val permissionDataSource: PermissionDataSource,
+) {
+    private var isServerNotificationEnabled = false
+    private var hasPendingServerEnable = false
+
+    fun isSystemNotificationGranted(): Boolean =
+        NotificationManagerCompat.from(context).areNotificationsEnabled()
+
+    suspend fun shouldShowPermissionModal(): Boolean {
+        if (isGuestUseCase()) return false
+
+        hasPendingServerEnable = false
+
+        val setting = getNotificationSettingUseCase().getOrNull() ?: return false
+        isServerNotificationEnabled = setting.isTradeEnabled || setting.isEventEnabled
+
+        return !isSystemNotificationGranted() || !isServerNotificationEnabled
+    }
+
+    suspend fun requestNotificationPermission(shouldShowRationale: Boolean): PermissionRequestRoute {
+        hasPendingServerEnable = !isServerNotificationEnabled
+
+        if (isSystemNotificationGranted()) {
+            enableAllNotifications()
+            return PermissionRequestRoute.AlreadyGranted
+        }
+
+        if (!canShowSystemPermissionDialog(shouldShowRationale)) {
+            return PermissionRequestRoute.SystemSetting
+        }
+
+        permissionDataSource.markSystemPermissionDialogShown()
+
+        return PermissionRequestRoute.SystemDialog
+    }
+
+    suspend fun syncSystemPermissionToServer() {
+        if (!isSystemNotificationGranted() || !hasPendingServerEnable) return
+
+        enableAllNotifications()
+    }
+
+    private suspend fun canShowSystemPermissionDialog(shouldShowRationale: Boolean): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+
+        return !permissionDataSource.hasShownSystemPermissionDialog() || shouldShowRationale
+    }
+
+    private suspend fun enableAllNotifications() {
+        updateNotificationSettingUseCase(
+            isTradeEnabled = true,
+            isEventEnabled = true,
+        ).onSuccess {
+            isServerNotificationEnabled = true
+            hasPendingServerEnable = false
+        }
+    }
+}
+
+sealed interface PermissionRequestRoute {
+    data object SystemDialog : PermissionRequestRoute
+
+    data object SystemSetting : PermissionRequestRoute
+
+    data object AlreadyGranted : PermissionRequestRoute
+}

--- a/app/src/main/java/com/poti/android/core/permission/PermissionManager.kt
+++ b/app/src/main/java/com/poti/android/core/permission/PermissionManager.kt
@@ -30,10 +30,12 @@ class PermissionManager @Inject constructor(
 
         hasPendingServerEnable = false
 
+        if (!isSystemNotificationGranted()) return true
+
         val setting = getNotificationSettingUseCase().getOrNull() ?: return false
         isServerNotificationEnabled = setting.isTradeEnabled || setting.isEventEnabled
 
-        return !isSystemNotificationGranted() || !isServerNotificationEnabled
+        return !isServerNotificationEnabled
     }
 
     suspend fun requestNotificationPermission(shouldShowRationale: Boolean): PermissionRequestRoute {

--- a/app/src/main/java/com/poti/android/core/permission/PermissionManager.kt
+++ b/app/src/main/java/com/poti/android/core/permission/PermissionManager.kt
@@ -53,6 +53,15 @@ class PermissionManager @Inject constructor(
         return PermissionRequestRoute.SystemDialog
     }
 
+    suspend fun applySystemPermissionDialogResult(isGranted: Boolean) {
+        if (!isGranted) {
+            hasPendingServerEnable = false
+            return
+        }
+
+        syncSystemPermissionToServer()
+    }
+
     suspend fun syncSystemPermissionToServer() {
         if (!isSystemNotificationGranted() || !hasPendingServerEnable) return
 

--- a/app/src/main/java/com/poti/android/core/permission/PermissionManager.kt
+++ b/app/src/main/java/com/poti/android/core/permission/PermissionManager.kt
@@ -55,18 +55,16 @@ class PermissionManager @Inject constructor(
         return PermissionRequestRoute.SystemDialog
     }
 
-    suspend fun applySystemPermissionDialogResult(isGranted: Boolean) {
-        if (!isGranted) {
-            hasPendingServerEnable = false
-            return
-        }
+    fun applySystemPermissionDialogResult(isGranted: Boolean) {
+        if (isGranted) return
 
-        syncSystemPermissionToServer()
+        hasPendingServerEnable = false
     }
 
     suspend fun syncSystemPermissionToServer() {
         if (!isSystemNotificationGranted() || !hasPendingServerEnable) return
 
+        hasPendingServerEnable = false
         enableAllNotifications()
     }
 

--- a/app/src/main/java/com/poti/android/core/permission/datasource/PermissionDataSource.kt
+++ b/app/src/main/java/com/poti/android/core/permission/datasource/PermissionDataSource.kt
@@ -1,0 +1,39 @@
+package com.poti.android.core.permission.datasource
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import com.poti.android.core.common.util.suspendRunCatching
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.permissionDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "permission_prefs",
+)
+
+@Singleton
+class PermissionDataSource @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    suspend fun hasShownSystemPermissionDialog(): Boolean = suspendRunCatching {
+        context.permissionDataStore.data.first()[HAS_SHOWN_SYSTEM_PERMISSION_DIALOG_KEY] == true
+    }.getOrDefault(true)
+
+    suspend fun markSystemPermissionDialogShown() {
+        suspendRunCatching {
+            context.permissionDataStore.edit { prefs ->
+                prefs[HAS_SHOWN_SYSTEM_PERMISSION_DIALOG_KEY] = true
+            }
+        }
+    }
+
+    private companion object {
+        val HAS_SHOWN_SYSTEM_PERMISSION_DIALOG_KEY =
+            booleanPreferencesKey("HAS_SHOWN_SYSTEM_PERMISSION_DIALOG")
+    }
+}

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
@@ -5,21 +5,14 @@ import android.content.Intent
 import android.provider.Settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -29,7 +22,7 @@ import com.poti.android.R
 import com.poti.android.core.common.extension.toast
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiMenuToggle
-import com.poti.android.core.designsystem.component.modal.PotiLargeModal
+import com.poti.android.core.designsystem.component.modal.PotiPermissionModal
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiEffect
@@ -60,33 +53,15 @@ fun AlarmSettingRoute(
     HandleSideEffects(viewModel.sideEffect) { effect ->
         when (effect) {
             AlarmSettingUiEffect.NavigateBack -> onPopBackStack()
-            AlarmSettingUiEffect.OpenSystemNotificationSetting ->
-                context.openSystemNotificationSetting()
+            AlarmSettingUiEffect.OpenSystemNotificationSetting -> context.openSystemNotificationSetting()
             is AlarmSettingUiEffect.ShowToast -> context.toast(context.getString(effect.messageRes))
         }
     }
 
     if (uiState.showModal) {
-        PotiLargeModal(
-            onDismissRequest = { viewModel.processIntent(AlarmSettingUiIntent.OnModalClose) },
-            title = stringResource(R.string.alarm_setting_permission_modal_title),
-            text = stringResource(R.string.alarm_setting_permission_modal_text),
-            btnText = stringResource(R.string.alarm_setting_permission_modal_button),
-            onBtnClick = { viewModel.processIntent(AlarmSettingUiIntent.OnAllowSystemAlarm) },
-            subBtnText = stringResource(R.string.alarm_setting_permission_modal_sub_button),
-            onSubBtnClick = { viewModel.processIntent(AlarmSettingUiIntent.OnModalClose) },
-            dismissOnClickOutside = false,
-            topSlot = {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_alarm),
-                    contentDescription = null,
-                    tint = PotiTheme.colors.poti600,
-                    modifier = Modifier.size(48.dp),
-                )
-
-                Spacer(Modifier.height(12.dp))
-            },
-            content = { Spacer(Modifier.height(24.dp)) },
+        PotiPermissionModal(
+            onDismiss = { viewModel.processIntent(AlarmSettingUiIntent.OnModalClose) },
+            onAllowClick = { viewModel.processIntent(AlarmSettingUiIntent.OnAllowSystemAlarm) },
         )
     }
 

--- a/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/alarm/setting/AlarmSettingScreen.kt
@@ -1,8 +1,5 @@
 package com.poti.android.presentation.alarm.setting
 
-import android.content.Context
-import android.content.Intent
-import android.provider.Settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,6 +16,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
+import com.poti.android.core.common.extension.openSystemNotificationSetting
 import com.poti.android.core.common.extension.toast
 import com.poti.android.core.common.util.HandleSideEffects
 import com.poti.android.core.designsystem.component.button.PotiMenuToggle
@@ -28,7 +26,6 @@ import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiEffect
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiIntent
 import com.poti.android.presentation.alarm.setting.model.AlarmSettingUiState
-import timber.log.Timber
 
 @Composable
 fun AlarmSettingRoute(
@@ -86,14 +83,6 @@ fun AlarmSettingRoute(
         },
         modifier = modifier,
     )
-}
-
-private fun Context.openSystemNotificationSetting() {
-    val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
-        .putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
-
-    runCatching { startActivity(intent) }
-        .onFailure { Timber.w(it, "Unable to open system notification setting") }
 }
 
 @Composable

--- a/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
@@ -1,20 +1,15 @@
 package com.poti.android.presentation.main
 
-import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -41,9 +36,6 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var socialLoginLauncher: SocialLoginLauncher
 
-    private val requestNotificationPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
@@ -59,8 +51,6 @@ class MainActivity : ComponentActivity() {
         }
 
         enableEdgeToEdge()
-
-        requestNotificationPermission()
 
         pendingDeepLink = intent?.resolveDeepLink()
         intent?.data = null
@@ -164,19 +154,6 @@ class MainActivity : ComponentActivity() {
         runCatching { navigate(uri) }
             .onFailure { Timber.w(it, "Unhandled deep link: $uri") }
             .isSuccess
-
-    private fun requestNotificationPermission() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
-
-        val isGranted = ContextCompat.checkSelfPermission(
-            this,
-            Manifest.permission.POST_NOTIFICATIONS,
-        ) == PackageManager.PERMISSION_GRANTED
-
-        if (!isGranted) {
-            requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-        }
-    }
 
     private fun handleLogoutNavigation() {
         val intent = Intent(this, MainActivity::class.java).apply {

--- a/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainActivity.kt
@@ -65,6 +65,7 @@ class MainActivity : ComponentActivity() {
                 mainNavigator.navigateToHome()
                 consumeDeepLink(mainNavigator.navController)
                 consumePendingReturnDeepLink(mainNavigator.navController)
+                viewModel.checkNotificationPermission()
             }
 
             PotiTheme {

--- a/app/src/main/java/com/poti/android/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainScreen.kt
@@ -48,7 +48,7 @@ fun MainScreen(
 
     val systemPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
-    ) { viewModel.syncSystemNotificationPermission() }
+    ) { isGranted -> viewModel.applySystemPermissionDialogResult(isGranted) }
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.syncSystemNotificationPermission()

--- a/app/src/main/java/com/poti/android/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainScreen.kt
@@ -1,5 +1,9 @@
 package com.poti.android.presentation.main
 
+import android.Manifest
+import androidx.activity.compose.LocalActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -8,12 +12,21 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.core.app.ActivityCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
 import com.poti.android.core.auth.SocialLoginLauncher
+import com.poti.android.core.common.extension.openSystemNotificationSetting
+import com.poti.android.core.common.util.HandleSideEffects
+import com.poti.android.core.designsystem.component.modal.PotiPermissionModal
 import com.poti.android.core.designsystem.component.modal.PotiSmallModal
 import com.poti.android.core.navigation.Route
+import com.poti.android.core.permission.PermissionRequestRoute
 import com.poti.android.presentation.auth.navigation.navigateToLogin
 
 @Composable
@@ -27,6 +40,43 @@ fun MainScreen(
     onOnboardingFinished: () -> Unit = {},
 ) {
     var showLoginRequiredDialog by remember { mutableStateOf(false) }
+    val showPermissionModal by viewModel.showPermissionModal.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val activity = LocalActivity.current
+
+    val systemPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { viewModel.syncSystemNotificationPermission() }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.syncSystemNotificationPermission()
+    }
+
+    HandleSideEffects(viewModel.permissionRequestRoute) { route ->
+        when (route) {
+            PermissionRequestRoute.SystemDialog ->
+                systemPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+
+            PermissionRequestRoute.SystemSetting -> context.openSystemNotificationSetting()
+            PermissionRequestRoute.AlreadyGranted -> Unit
+        }
+    }
+
+    if (showPermissionModal) {
+        PotiPermissionModal(
+            onDismiss = { viewModel.dismissPermissionModal() },
+            onAllowClick = {
+                viewModel.allowNotificationPermission(
+                    shouldShowRationale = activity?.let {
+                        ActivityCompat.shouldShowRequestPermissionRationale(
+                            it,
+                            Manifest.permission.POST_NOTIFICATIONS,
+                        )
+                    } == true,
+                )
+            },
+        )
+    }
 
     if (showLoginRequiredDialog) {
         PotiSmallModal(

--- a/app/src/main/java/com/poti/android/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainScreen.kt
@@ -1,6 +1,7 @@
 package com.poti.android.presentation.main
 
 import android.Manifest
+import android.annotation.SuppressLint
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -29,6 +30,7 @@ import com.poti.android.core.navigation.Route
 import com.poti.android.core.permission.PermissionRequestRoute
 import com.poti.android.presentation.auth.navigation.navigateToLogin
 
+@SuppressLint("InlinedApi")
 @Composable
 fun MainScreen(
     targetDestination: Route,

--- a/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
@@ -2,6 +2,8 @@ package com.poti.android.presentation.main
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.poti.android.core.permission.PermissionManager
+import com.poti.android.core.permission.PermissionRequestRoute
 import com.poti.android.domain.model.auth.AuthState
 import com.poti.android.domain.usecase.auth.EnterGuestModeUseCase
 import com.poti.android.domain.usecase.auth.IsGuestUseCase
@@ -9,9 +11,16 @@ import com.poti.android.domain.usecase.auth.ObserveAuthStateUseCase
 import com.poti.android.presentation.auth.navigation.AuthRoute
 import com.poti.android.presentation.party.PartyGraph
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,7 +28,14 @@ class MainViewModel @Inject constructor(
     observeAuthStateUseCase: ObserveAuthStateUseCase,
     private val isGuestUseCase: IsGuestUseCase,
     private val enterGuestModeUseCase: EnterGuestModeUseCase,
+    private val permissionManager: PermissionManager,
 ) : ViewModel() {
+    private val _showPermissionModal = MutableStateFlow(false)
+    val showPermissionModal: StateFlow<Boolean> = _showPermissionModal.asStateFlow()
+
+    private val _permissionRequestRoute = Channel<PermissionRequestRoute>()
+    val permissionRequestRoute: Flow<PermissionRequestRoute> = _permissionRequestRoute.receiveAsFlow()
+
     fun isGuest(): Boolean = isGuestUseCase()
 
     private val authState = observeAuthStateUseCase()
@@ -49,6 +65,32 @@ class MainViewModel @Inject constructor(
     internal fun getDeepLinkEntryMode(): DeepLinkEntryMode = authState.value.toDeepLinkEntryMode()
 
     internal fun enterGuestMode() = enterGuestModeUseCase()
+
+    fun checkNotificationPermission() {
+        viewModelScope.launch {
+            _showPermissionModal.value = permissionManager.shouldShowPermissionModal()
+        }
+    }
+
+    fun allowNotificationPermission(shouldShowRationale: Boolean) {
+        _showPermissionModal.value = false
+
+        viewModelScope.launch {
+            _permissionRequestRoute.send(
+                permissionManager.requestNotificationPermission(shouldShowRationale),
+            )
+        }
+    }
+
+    fun dismissPermissionModal() {
+        _showPermissionModal.value = false
+    }
+
+    fun syncSystemNotificationPermission() {
+        viewModelScope.launch {
+            permissionManager.syncSystemPermissionToServer()
+        }
+    }
 }
 
 internal enum class DeepLinkEntryMode {

--- a/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
@@ -86,6 +86,12 @@ class MainViewModel @Inject constructor(
         _showPermissionModal.value = false
     }
 
+    fun applySystemPermissionDialogResult(isGranted: Boolean) {
+        viewModelScope.launch {
+            permissionManager.applySystemPermissionDialogResult(isGranted)
+        }
+    }
+
     fun syncSystemNotificationPermission() {
         viewModelScope.launch {
             permissionManager.syncSystemPermissionToServer()

--- a/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/main/MainViewModel.kt
@@ -87,9 +87,7 @@ class MainViewModel @Inject constructor(
     }
 
     fun applySystemPermissionDialogResult(isGranted: Boolean) {
-        viewModelScope.launch {
-            permissionManager.applySystemPermissionDialogResult(isGranted)
-        }
+        permissionManager.applySystemPermissionDialogResult(isGranted)
     }
 
     fun syncSystemNotificationPermission() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,12 +322,13 @@
     <string name="alarm_setting_trade_description">분철 모집/참여 거래 알림</string>
     <string name="alarm_setting_event_title">이벤트 및 혜택 알림</string>
     <string name="alarm_setting_event_description">광고성 정보 수신 및 마케팅 알림</string>
-    <string name="alarm_setting_permission_modal_title">푸시 알림을 허용해주세요</string>
-    <string name="alarm_setting_permission_modal_text">분철 진행 상황을 실시간으로 확인할 수 있도록 알림을 보내드려요.</string>
-    <string name="alarm_setting_permission_modal_button">푸시 알림 허용</string>
-    <string name="alarm_setting_permission_modal_sub_button">나중에</string>
     <string name="alarm_setting_load_failed">알림 설정을 불러오지 못했어요</string>
     <string name="alarm_setting_update_failed">알림 설정 변경에 실패했어요</string>
+
+    <string name="alarm_permission_modal_title">푸시 알림을 허용해주세요</string>
+    <string name="alarm_permission_modal_text">분철 진행 상황을 실시간으로 확인할 수 있도록 알림을 보내드려요.</string>
+    <string name="alarm_permission_modal_button">푸시 알림 허용</string>
+    <string name="alarm_permission_modal_sub_button">나중에</string>
 
     <!-- Relative Time -->
     <string name="time_just_now">방금 전</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #204 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->

다음 정책대로 구현했습니다.

- [로그인]
    - 온보딩 미완료 유저라면, 로그인 직후 바로 온보딩을 한다.
    - 로그인 또는 온보딩 완료 후 진입한 화면에서 시스템 알림 권한 또는 서버 알림 권한 둘 중 하나라도 비허용한 경우 모달을 노출한다.

- [모달 내에서 허용 버튼 클릭]
    - `시스템X 서버X` 시스템 팝업 노출
        - 팝업 내에서 허용 시 API 호출
    - `시스템X 서버O` 시스템 팝업 노출
    - `시스템O 서버X` API 호출

특정 화면에만 적용되는 정책이 아니기 때문에 `MainScreen`에서 모달을 띄우고 관련 로직을 처리하게 했습니다.
설정 앱 또는 시스템 권한 팝업을 띄우기 위해 SideEffect 패턴 적용했습니다.

## Screenshot 📸

| 온보딩 완료 유저 | 온보딩 미완료 유저 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a7f21bb0-c149-4008-966d-5044c4663e12" width="250" /> | <video src="https://github.com/user-attachments/assets/b413a755-9f4f-4a95-b57a-910142b0e75d" width="250" /> |

## Uncompleted Tasks 😅
- [x] N/A 

## To Reviewers 📢
시스템 권한 팝업 내에서 권한 미허용 시 API 호출 안 되도록 수정했지만
서버 기본값 자체가 ON/ON이라서 알림 설정은 켜진 상태로 보일 수 있습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 알림 권한 안내 모달을 추가했습니다.
  * 알림 권한 허용, 취소 및 시스템 설정 이동을 지원합니다.
  * 알림 권한 상태를 확인하고 서버 알림 설정과 동기화합니다.
  * 상황에 따라 시스템 권한 창 또는 알림 설정 화면으로 안내합니다.

* **개선**
  * 알림 권한 요청을 인증 완료 후 처리하도록 변경했습니다.
  * 이미 안내한 권한 요청의 중복 표시를 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->