### PR TITLE
[Fix/#224] 등록뷰 배송옵션 초기상태 변경 및 에러 케이스 추가

### DIFF
--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -243,7 +243,7 @@ class PartyCreateViewModel @Inject constructor(
                             deliveryId = it.deliveryId,
                             name = it.name,
                             priceInput = it.price.toString(),
-                            isSelected = true,
+                            isSelected = false,
                         )
                     }.toPersistentList()
 

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -428,7 +428,7 @@ class PartyCreateViewModel @Inject constructor(
         updateState {
             copy(
                 deliveryOptions = newOptions,
-                deliveryError = if (this.deliveryError == FieldError.DELIVERY_EMPTY_ERROR) null else this.deliveryError,
+                deliveryError = this.deliveryError?.takeIf { it == deliveryErrorOf(newOptions) },
             )
         }
     }
@@ -454,6 +454,12 @@ class PartyCreateViewModel @Inject constructor(
 
     private fun hasInvalidDeliveryPrice(deliveries: ImmutableList<DeliveryOptionUiModel>): Boolean =
         deliveries.filter { it.isSelected }.any { it.priceInput.toIntOrNull() == null }
+
+    private fun deliveryErrorOf(deliveries: ImmutableList<DeliveryOptionUiModel>): FieldError? = when {
+        !hasSelectedDeliveryOption(deliveries) -> FieldError.DELIVERY_EMPTY_ERROR
+        hasInvalidDeliveryPrice(deliveries) -> FieldError.DELIVERY_PRICE_ERROR
+        else -> null
+    }
 
     private fun DeliveryOptionUiModel.toDeliveryOption(): DeliveryOption =
         DeliveryOption(deliveryId = deliveryId, name = name, price = requireNotNull(priceInput.toIntOrNull()))
@@ -481,11 +487,7 @@ class PartyCreateViewModel @Inject constructor(
             hasInvalidPrice(uiState.value.selectedMembers) -> FieldError.MEMBER_PRICE_ERROR
             else -> null
         }
-        val deliveryError = when {
-            !hasSelectedDeliveryOption(uiState.value.deliveryOptions) -> FieldError.DELIVERY_EMPTY_ERROR
-            hasInvalidDeliveryPrice(uiState.value.deliveryOptions) -> FieldError.DELIVERY_PRICE_ERROR
-            else -> null
-        }
+        val deliveryError = deliveryErrorOf(uiState.value.deliveryOptions)
 
         val hasError = imageError != null || artistError != null || productError != null ||
             deadlineError != null || descriptionError != null ||

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -54,8 +54,8 @@ class PartyCreateViewModel @Inject constructor(
     private val createPartyUseCase: CreatePartyUseCase,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<CreateUiState, CreateUiIntent, CreateUiEffect>(
-        initialState = CreateUiState(),
-    ) {
+    initialState = CreateUiState(),
+) {
     private val params = savedStateHandle.toRoute<PartyCreateGraph>()
     private val paramArtistId = params.artistId
     private val paramArtistName = params.artistName
@@ -428,6 +428,7 @@ class PartyCreateViewModel @Inject constructor(
         updateState {
             copy(
                 deliveryOptions = newOptions,
+                deliveryError = if (this.deliveryError == FieldError.DELIVERY_EMPTY_ERROR) null else this.deliveryError,
             )
         }
     }
@@ -447,6 +448,9 @@ class PartyCreateViewModel @Inject constructor(
 
     private fun hasInvalidPrice(members: ImmutableList<MemberPriceOption>): Boolean =
         members.any { it.price == "0" || it.price.isBlank() }
+
+    private fun hasSelectedDeliveryOption(deliveries: ImmutableList<DeliveryOptionUiModel>): Boolean =
+        deliveries.any { it.isSelected }
 
     private fun hasInvalidDeliveryPrice(deliveries: ImmutableList<DeliveryOptionUiModel>): Boolean =
         deliveries.filter { it.isSelected }.any { it.priceInput.toIntOrNull() == null }
@@ -477,10 +481,10 @@ class PartyCreateViewModel @Inject constructor(
             hasInvalidPrice(uiState.value.selectedMembers) -> FieldError.MEMBER_PRICE_ERROR
             else -> null
         }
-        val deliveryError = if (hasInvalidDeliveryPrice(uiState.value.deliveryOptions)) {
-            FieldError.DELIVERY_PRICE_ERROR
-        } else {
-            null
+        val deliveryError = when {
+            !hasSelectedDeliveryOption(uiState.value.deliveryOptions) -> FieldError.DELIVERY_EMPTY_ERROR
+            hasInvalidDeliveryPrice(uiState.value.deliveryOptions) -> FieldError.DELIVERY_PRICE_ERROR
+            else -> null
         }
 
         val hasError = imageError != null || artistError != null || productError != null ||

--- a/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/PartyCreateViewModel.kt
@@ -54,8 +54,8 @@ class PartyCreateViewModel @Inject constructor(
     private val createPartyUseCase: CreatePartyUseCase,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<CreateUiState, CreateUiIntent, CreateUiEffect>(
-    initialState = CreateUiState(),
-) {
+        initialState = CreateUiState(),
+    ) {
     private val params = savedStateHandle.toRoute<PartyCreateGraph>()
     private val paramArtistId = params.artistId
     private val paramArtistName = params.artistName

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -39,6 +39,7 @@ enum class FieldError(
     MEMBER_EMPTY_ERROR(R.string.create_error_need_member),
     MEMBER_PRICE_ERROR(R.string.create_error_need_price),
     DELIVERY_PRICE_ERROR(R.string.create_error_need_delivery_price),
+    DELIVERY_EMPTY_ERROR(R.string.create_error_need_delivery_option)
 }
 
 data class CreateUiState(

--- a/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/create/model/Contracts.kt
@@ -39,7 +39,7 @@ enum class FieldError(
     MEMBER_EMPTY_ERROR(R.string.create_error_need_member),
     MEMBER_PRICE_ERROR(R.string.create_error_need_price),
     DELIVERY_PRICE_ERROR(R.string.create_error_need_delivery_price),
-    DELIVERY_EMPTY_ERROR(R.string.create_error_need_delivery_option)
+    DELIVERY_EMPTY_ERROR(R.string.create_error_need_delivery_option),
 }
 
 data class CreateUiState(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,6 +165,7 @@
     <string name="create_error_need_member">멤버를 1명 이상 추가해주세요</string>
     <string name="create_error_need_price">모든 멤버에 가격을 설정해주세요</string>
     <string name="create_error_need_delivery_price">선택한 배송 방법의 가격을 설정해주세요</string>
+    <string name="create_error_need_delivery_option">배송 방법을 1개 이상 선택해주세요</string>
     <string name="create_title_bottomsheet">멤버 편집</string>
     <string name="create_header_artist_search">아티스트 검색</string>
     <string name="create_message_artist_search_empty_result">검색 결과가 없어요\n다른 키워드로 다시 검색해보세요</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #224 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 등록뷰 배송옵션 초기상태를 전체 미선택으로 변경했습니다.
- 배송옵션 미선택 상태로 등록 시도할 경우 에러 상태를 추가했습니다.
    `배송 방법을 1개 이상 선택해주세요` [디코 논의](https://discord.com/channels/1452247391804850237/1544633613352443904)

## Screenshot 📸

| 스크린샷 |
| --- |
| <video src="https://github.com/user-attachments/assets/d3fe21bc-8127-47d6-9c5c-fef6d8c234bf" width="250" /> |

## Uncompleted Tasks 😅
- [x] N/A

## To Reviewers 📢
아자자

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 파티 생성 시 배송 방법이 기본으로 선택되지 않도록 변경했습니다.
  * 배송 방법을 하나도 선택하지 않으면 안내 오류가 표시됩니다.
  * 배송 옵션 변경 후에도 입력 검증 결과가 올바르게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->