### PR TITLE
[Fix/#228] 탈퇴한 유저에 대한 기본이미지 처리

### DIFF
--- a/app/src/main/java/com/poti/android/data/remote/dto/response/user/ProfileResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/user/ProfileResponseDto.kt
@@ -10,7 +10,7 @@ data class ProfileResponseDto(
     @SerialName("nickname")
     val nickname: String,
     @SerialName("profileImageUrl")
-    val profileImageUrl: String,
+    val profileImageUrl: String?,
     @SerialName("ratingAvg")
     val ratingAvg: Double,
     @SerialName("activityMessage")

--- a/app/src/main/java/com/poti/android/domain/model/user/UserProfile.kt
+++ b/app/src/main/java/com/poti/android/domain/model/user/UserProfile.kt
@@ -3,7 +3,7 @@ package com.poti.android.domain.model.user
 data class UserProfile(
     val userId: Long,
     val nickname: String,
-    val profileImageUrl: String,
+    val profileImageUrl: String?,
     val ratingAvg: Double,
     val activityMessage: String,
     val joinedAt: String,

--- a/app/src/main/java/com/poti/android/presentation/history/participant/model/ParticipantDetailOverlayState.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/participant/model/ParticipantDetailOverlayState.kt
@@ -9,7 +9,7 @@ sealed interface ParticipantDetailOverlayState {
 
     data class DeliveryReviewModal(
         val recruiterName: String,
-        val recruiterProfileUrl: String,
+        val recruiterProfileUrl: String?,
         val partnerRating: String,
     ) : ParticipantDetailOverlayState
 }


### PR DESCRIPTION
## Related issue 🛠️
- closed #228

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 탈퇴한 유저의 경우, img URL 이 Null 로 처리되기 때문에 DTO 를 Nullable 로 수정하고, 컴포넌트 단에서 기본값 이미지 처리했습니다.

## Screenshot 📸

| 탈퇴한 유저 프로필 조회 |
| --- |
| <video src="https://github.com/user-attachments/assets/51cf98cf-a442-4fe7-8686-430aaca964c8" /> |


## Uncompleted Tasks 😅
- [ ]

## To Reviewers 📢
변경된 DTO 에 영향을 받는 `DeliveryReviewModal` 은
분철 모집이 끝나고, 사용자가 모집자에게 별점을 주는 모달에서
모집이 끝나서 모집자가 탈퇴하는 경우가 발생할 수 있으므로, 같이 Nullable 처리해주었습니다.