### PR TITLE
[Fix/#215] 분철팟 상세 화면 & 회원 탈퇴 모달 QA 반영

### DIFF
--- a/app/src/main/java/com/poti/android/data/mapper/party/PartyDetailMapper.kt
+++ b/app/src/main/java/com/poti/android/data/mapper/party/PartyDetailMapper.kt
@@ -15,6 +15,7 @@ import com.poti.android.domain.type.PartyStatusType
 fun PartyDetailResponseDto.toDomain(): PartyDetail = PartyDetail(
     postId = postId,
     isMyPost = isMyPost,
+    isParticipated = isParticipated,
     status = mapToPartyStatus(status),
     artist = artist,
     artistId = artistId,

--- a/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
+++ b/app/src/main/java/com/poti/android/data/mock/UiMockData.kt
@@ -172,6 +172,7 @@ object UiMockData {
     val partyDetail = PartyDetail(
         postId = 1,
         isMyPost = false,
+        isParticipated = false,
         status = PartyStatusType.RECRUITING,
         artist = "IVE",
         artistId = 1,

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/party/PartyDetailResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/party/PartyDetailResponseDto.kt
@@ -10,7 +10,7 @@ data class PartyDetailResponseDto(
     @SerialName("isMyPost")
     val isMyPost: Boolean,
     @SerialName("isParticipated")
-    val isParticipated: Boolean = false,
+    val isParticipated: Boolean,
     @SerialName("status")
     val status: String,
     @SerialName("artist")

--- a/app/src/main/java/com/poti/android/data/remote/dto/response/party/PartyDetailResponseDto.kt
+++ b/app/src/main/java/com/poti/android/data/remote/dto/response/party/PartyDetailResponseDto.kt
@@ -9,6 +9,8 @@ data class PartyDetailResponseDto(
     val postId: Long,
     @SerialName("isMyPost")
     val isMyPost: Boolean,
+    @SerialName("isParticipated")
+    val isParticipated: Boolean = false,
     @SerialName("status")
     val status: String,
     @SerialName("artist")

--- a/app/src/main/java/com/poti/android/domain/model/party/PartyDetail.kt
+++ b/app/src/main/java/com/poti/android/domain/model/party/PartyDetail.kt
@@ -7,6 +7,7 @@ import com.poti.android.domain.type.PartyStatusType
 data class PartyDetail(
     val postId: Long, // 분철글 고유 ID
     val isMyPost: Boolean, // 본인 작성 글 여부
+    val isParticipated: Boolean, // 본인 참여 여부
     val status: PartyStatusType, // 모집 상태
     val artist: String, // 아티스트 그룹명
     val artistId: Long, // 아티스트 아이디

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
@@ -1,9 +1,11 @@
 package com.poti.android.presentation.party.detail
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -36,7 +38,6 @@ import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.core.share.KakaoShareManager
 import com.poti.android.data.mock.UiMockData
 import com.poti.android.domain.model.party.PartyDetail
-import com.poti.android.presentation.party.detail.component.ParticipantGuidelines
 import com.poti.android.presentation.party.detail.component.PartyDetailContent
 import com.poti.android.presentation.party.detail.component.PartyDetailHeaderInfo
 import com.poti.android.presentation.party.detail.component.PartyJoinBottomSheet
@@ -214,7 +215,7 @@ private fun PartyDetailScreen(
 
             PartyShareButton(onClick = onShareClick)
 
-            ParticipantGuidelines()
+            Spacer(modifier = Modifier.height(40.dp))
         }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailScreen.kt
@@ -46,6 +46,7 @@ import com.poti.android.presentation.party.detail.component.PartyShareButton
 import com.poti.android.presentation.party.detail.component.PartyUploaderInfo
 import com.poti.android.presentation.party.detail.model.PartyDetailEffect
 import com.poti.android.presentation.party.detail.model.PartyDetailIntent
+import com.poti.android.presentation.party.detail.model.PartyDetailJoinButtonState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -112,7 +113,7 @@ fun PartyDetailRoute(
     uiState.partyDetail.onSuccess { partyDetail ->
         PartyDetailScreen(
             partyDetail = partyDetail,
-            isJoinEnable = uiState.isDetailJoinEnable,
+            joinButtonState = uiState.detailJoinButtonState,
             onBackClick = { viewModel.processIntent(PartyDetailIntent.OnBackClick) },
             onJoinClick = { viewModel.processIntent(PartyDetailIntent.OnDetailJoinClick) },
             onUploaderClick = { viewModel.processIntent(PartyDetailIntent.OnUploaderClick(it)) },
@@ -125,7 +126,7 @@ fun PartyDetailRoute(
 @Composable
 private fun PartyDetailScreen(
     partyDetail: PartyDetail,
-    isJoinEnable: Boolean,
+    joinButtonState: PartyDetailJoinButtonState,
     onBackClick: () -> Unit,
     onJoinClick: () -> Unit,
     onUploaderClick: (Long) -> Unit,
@@ -142,9 +143,16 @@ private fun PartyDetailScreen(
         },
         bottomBar = {
             PotiBottomButton(
-                text = if (isJoinEnable) stringResource(R.string.party_detail_join_party) else stringResource(R.string.party_detail_join_party_closed),
+                text = when (joinButtonState) {
+                    PartyDetailJoinButtonState.MY_POST -> stringResource(R.string.party_detail_join_party_my_post)
+                    PartyDetailJoinButtonState.ALREADY_JOINED -> stringResource(R.string.party_detail_join_party_already_joined)
+                    PartyDetailJoinButtonState.CLOSED -> stringResource(R.string.party_detail_join_party_closed)
+                    PartyDetailJoinButtonState.JOIN,
+                    PartyDetailJoinButtonState.DISABLED,
+                    -> stringResource(R.string.party_detail_join_party)
+                },
                 onClick = onJoinClick,
-                enabled = isJoinEnable,
+                enabled = joinButtonState == PartyDetailJoinButtonState.JOIN,
             )
         },
     ) { innerPadding ->
@@ -217,7 +225,7 @@ private fun PartyDetailScreenPreview() {
     PotiTheme {
         PartyDetailScreen(
             partyDetail = UiMockData.partyDetail,
-            isJoinEnable = true,
+            joinButtonState = PartyDetailJoinButtonState.JOIN,
             onBackClick = {},
             onJoinClick = {},
             onUploaderClick = {},

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyDetailViewModel.kt
@@ -234,6 +234,8 @@ class PartyDetailViewModel @Inject constructor(
     }
 
     private fun handleDetailJoin() {
+        if (!uiState.value.isDetailJoinEnable) return
+
         if (isGuestUseCase()) {
             updateState { copy(showLoginRequiredDialog = true) }
             return

--- a/app/src/main/java/com/poti/android/presentation/party/detail/PartyJoinScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/PartyJoinScreen.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -46,7 +47,6 @@ import com.poti.android.core.designsystem.component.modal.PotiNoticeModal
 import com.poti.android.core.designsystem.component.navigation.PotiBottomButton
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
-import com.poti.android.presentation.party.detail.component.ParticipantGuidelines
 import com.poti.android.presentation.party.detail.component.TotalPrice
 import com.poti.android.presentation.party.detail.model.PartyDetailEffect
 import com.poti.android.presentation.party.detail.model.PartyDetailIntent
@@ -288,9 +288,7 @@ private fun PartyJoinScreen(
                 }
             }
 
-            PotiDivider(styleType = PotiDividerStyle.LARGE)
-
-            ParticipantGuidelines()
+            Spacer(modifier = Modifier.height(40.dp))
         }
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyDetailContent.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyDetailContent.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -53,6 +52,7 @@ fun PartyDetailContent(
         Spacer(modifier = Modifier.height(60.dp))
 
         Row(
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Column(
@@ -72,6 +72,7 @@ fun PartyDetailContent(
             }
 
             Column(
+                modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Text(
@@ -81,22 +82,27 @@ fun PartyDetailContent(
                 )
 
                 FlowRow(
-                    modifier = Modifier.height(IntrinsicSize.Min),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     partyDetail.deliveryOptions.forEachIndexed { index, option ->
-                        Text(
-                            text = stringResource(R.string.party_detail_shipping_price_format, option.name, option.price.toMoneyString()),
-                            style = PotiTheme.typography.body14m,
-                            color = PotiTheme.colors.black,
-                        )
-
-                        if (index < partyDetail.deliveryOptions.lastIndex) {
-                            VerticalDivider(
-                                thickness = 1.dp,
-                                color = PotiTheme.colors.gray800,
-                                modifier = Modifier.height(textHeightDp),
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.party_detail_shipping_price_format, option.name, option.price.toMoneyString()),
+                                style = PotiTheme.typography.body14m,
+                                color = PotiTheme.colors.black,
                             )
+
+                            if (index < partyDetail.deliveryOptions.lastIndex) {
+                                VerticalDivider(
+                                    thickness = 1.dp,
+                                    color = PotiTheme.colors.gray800,
+                                    modifier = Modifier.height(textHeightDp),
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyDetailContent.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/component/PartyDetailContent.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.widthIn
@@ -13,7 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,17 +30,6 @@ fun PartyDetailContent(
     partyDetail: PartyDetail,
     modifier: Modifier = Modifier,
 ) {
-    val density = LocalDensity.current
-    val textStyle = PotiTheme.typography.body14m
-
-    val textHeightDp = with(density) {
-        if (textStyle.lineHeight.isSp) {
-            textStyle.lineHeight.toDp()
-        } else {
-            textStyle.fontSize.toDp()
-        }
-    }
-
     Column(
         modifier = modifier.fillMaxWidth(),
     ) {
@@ -88,6 +78,7 @@ fun PartyDetailContent(
                 ) {
                     partyDetail.deliveryOptions.forEachIndexed { index, option ->
                         Row(
+                            modifier = Modifier.height(IntrinsicSize.Min),
                             horizontalArrangement = Arrangement.spacedBy(10.dp),
                         ) {
                             Text(
@@ -100,7 +91,7 @@ fun PartyDetailContent(
                                 VerticalDivider(
                                     thickness = 1.dp,
                                     color = PotiTheme.colors.gray800,
-                                    modifier = Modifier.height(textHeightDp),
+                                    modifier = Modifier.fillMaxHeight(),
                                 )
                             }
                         }

--- a/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/party/detail/model/Contracts.kt
@@ -42,8 +42,20 @@ data class PartyDetailUiState(
     val artistMembers: ImmutableList<Member> = persistentListOf(),
     val showLoginRequiredDialog: Boolean = false,
 ) : UiState {
+    val detailJoinButtonState: PartyDetailJoinButtonState
+        get() {
+            val detail = partyDetail.getSuccessDataOrNull() ?: return PartyDetailJoinButtonState.DISABLED
+
+            return when {
+                detail.isMyPost -> PartyDetailJoinButtonState.MY_POST
+                detail.isParticipated -> PartyDetailJoinButtonState.ALREADY_JOINED
+                detail.status != PartyStatusType.RECRUITING -> PartyDetailJoinButtonState.CLOSED
+                else -> PartyDetailJoinButtonState.JOIN
+            }
+        }
+
     val isDetailJoinEnable: Boolean
-        get() = partyDetail.getSuccessDataOrNull()?.status == PartyStatusType.RECRUITING
+        get() = detailJoinButtonState == PartyDetailJoinButtonState.JOIN
 
     val isRequiredAddressFilled: Boolean
         get() = orderName.isNotBlank() &&
@@ -87,6 +99,14 @@ data class PartyDetailUiState(
 
     val isBottomSheetButtonEnable: Boolean
         get() = selectedMemberIds.isNotEmpty() && selectedDeliveryIds.isNotEmpty()
+}
+
+enum class PartyDetailJoinButtonState {
+    JOIN,
+    MY_POST,
+    ALREADY_JOINED,
+    CLOSED,
+    DISABLED,
 }
 
 sealed interface PartyDetailIntent : UiIntent {

--- a/app/src/main/java/com/poti/android/presentation/user/withdrawal/component/WithdrawalUnavailableModal.kt
+++ b/app/src/main/java/com/poti/android/presentation/user/withdrawal/component/WithdrawalUnavailableModal.kt
@@ -39,7 +39,7 @@ fun WithdrawalUnavailableModal(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_notice),
+                imageVector = ImageVector.vectorResource(R.drawable.ic_notice_lg),
                 contentDescription = null,
                 modifier = Modifier
                     .padding(bottom = 12.dp)

--- a/app/src/main/res/drawable/ic_notice_lg.xml
+++ b/app/src/main/res/drawable/ic_notice_lg.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,12m-9.25,0a9.25,9.25 0,1 1,18.5 0a9.25,9.25 0,1 1,-18.5 0"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#303030"/>
+  <path
+      android:pathData="M12,7V13"
+      android:strokeWidth="1.8"
+      android:fillColor="#00000000"
+      android:strokeColor="#303030"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12,16.75m-1.25,0a1.25,1.25 0,1 1,2.5 0a1.25,1.25 0,1 1,-2.5 0"
+      android:fillColor="#303030"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,8 @@
         <item>마감 기한까지 모집 인원이 과반수 이상 충족되지 않을 경우, 해당 분철팟은 자동으로 종료되며 분철은 진행되지 않습니다.</item>
     </string-array>
     <string name="party_detail_join_party">분철팟 참여하기</string>
+    <string name="party_detail_join_party_my_post">내가 등록한 분철팟이에요</string>
+    <string name="party_detail_join_party_already_joined">이미 참여한 분철팟이에요</string>
     <string name="party_detail_join_party_closed">마감된 분철팟이에요</string>
     <string name="party_detail_upload_date_label">"%s 등록"</string>
     <string name="party_detail_share_button">이 분철팟 공유하기</string>

--- a/app/src/test/java/com/poti/android/presentation/party/detail/model/PartyDetailUiStateTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/party/detail/model/PartyDetailUiStateTest.kt
@@ -46,13 +46,4 @@ class PartyDetailUiStateTest {
 
         assertFalse(state.isDetailJoinEnable)
     }
-
-    @Test
-    fun `비로그인 사용자는 모집 중인 분철팟에 참여 버튼이 활성화된다`() {
-        val state = PartyDetailUiState(
-            partyDetail = ApiState.Success(UiMockData.partyDetail),
-        )
-
-        assertTrue(state.isDetailJoinEnable)
-    }
 }

--- a/app/src/test/java/com/poti/android/presentation/party/detail/model/PartyDetailUiStateTest.kt
+++ b/app/src/test/java/com/poti/android/presentation/party/detail/model/PartyDetailUiStateTest.kt
@@ -1,0 +1,58 @@
+package com.poti.android.presentation.party.detail.model
+
+import com.poti.android.core.common.state.ApiState
+import com.poti.android.data.mock.UiMockData
+import com.poti.android.domain.type.PartyStatusType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PartyDetailUiStateTest {
+    @Test
+    fun `내가 등록한 분철팟은 모집 중이어도 참여할 수 없다`() {
+        val state = PartyDetailUiState(
+            partyDetail = ApiState.Success(UiMockData.partyDetail.copy(isMyPost = true)),
+        )
+
+        assertFalse(state.isDetailJoinEnable)
+        assertEquals(PartyDetailJoinButtonState.MY_POST, state.detailJoinButtonState)
+    }
+
+    @Test
+    fun `이미 참여한 분철팟은 모집 중이어도 참여할 수 없다`() {
+        val state = PartyDetailUiState(
+            partyDetail = ApiState.Success(UiMockData.partyDetail.copy(isParticipated = true)),
+        )
+
+        assertFalse(state.isDetailJoinEnable)
+        assertEquals(PartyDetailJoinButtonState.ALREADY_JOINED, state.detailJoinButtonState)
+    }
+
+    @Test
+    fun `모집 중이고 작성자나 참여자가 아니면 참여할 수 있다`() {
+        val state = PartyDetailUiState(
+            partyDetail = ApiState.Success(UiMockData.partyDetail),
+        )
+
+        assertTrue(state.isDetailJoinEnable)
+    }
+
+    @Test
+    fun `모집이 끝났으면 작성자나 참여자가 아니어도 참여할 수 없다`() {
+        val state = PartyDetailUiState(
+            partyDetail = ApiState.Success(UiMockData.partyDetail.copy(status = PartyStatusType.CLOSED)),
+        )
+
+        assertFalse(state.isDetailJoinEnable)
+    }
+
+    @Test
+    fun `비로그인 사용자는 모집 중인 분철팟에 참여 버튼이 활성화된다`() {
+        val state = PartyDetailUiState(
+            partyDetail = ApiState.Success(UiMockData.partyDetail),
+        )
+
+        assertTrue(state.isDetailJoinEnable)
+    }
+}


### PR DESCRIPTION
## Related issue 🛠️
- closed #215 

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 본인이 등록한 분철팟의 분철팟 참여하기 버튼 비활성화
- 이미 참여한 분철팟의 분철팟 참여하기 버튼 비활성화
- 등록된 배송방법 잘림 문제 해결
- 배송비 | 위치 수정
- 상세/참여 화면 하단에 안내사항 영역 삭제
- 회원 탈퇴 모달 아이콘 수정 (같이 해버렸어요)

## Screenshot 📸

| 분철팟 상세 화면 1 |분철팟 상세 화면 2 |
| --- | --- |
| <img width="318" height="714" alt="image" src="https://github.com/user-attachments/assets/969e00c1-9c22-4d72-b734-ade1a24b414a" /> | <img width="324" height="719" alt="image" src="https://github.com/user-attachments/assets/50b9ef1d-b3ae-49d4-8e01-210925a5481a" /> |

| 분철팟 안내사항 삭제 | 참여자 안내사항 삭제 |
|---|---|
| <img width="320" height="717" alt="image" src="https://github.com/user-attachments/assets/07215d57-5922-443c-9e29-e72d598aabfb" /> | <img width="322" height="720" alt="image" src="https://github.com/user-attachments/assets/d73c798f-d24d-43d8-b143-0dcf9423d2b8" /> |

| 탈퇴 불가 모달 |
|---|
| <img width="317" height="717" alt="image" src="https://github.com/user-attachments/assets/e72df92c-e5d4-4b4b-b6b5-6db706776b41" /> |


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 파티 상세 화면에서 내가 등록한 파티, 이미 참여한 파티, 모집 중·종료·비활성 상태를 구분해 버튼 문구와 활성화 상태를 표시합니다.
  * 이미 참여한 파티 여부를 상세 정보에 반영합니다.

* **개선**
  * 참여가 불가능한 상태에서는 참여 절차가 시작되지 않도록 개선했습니다.
  * 파티 상세 및 참여 화면의 정보 배치와 구분선 표시를 개선했습니다.
  * 회원 탈퇴 불가 안내 아이콘을 확대했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->