### PR TITLE
[Fix/#220] 모집 중이며 참여자 0명일 경우, 모집 상세에 삭제 버튼 추가

### DIFF
--- a/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
+++ b/app/src/main/java/com/poti/android/core/designsystem/component/navigation/PotiHeaderPage.kt
@@ -36,6 +36,7 @@ enum class PotiHeaderPageType(
 
 /**
  * @param containerColor 헤더 배경색입니다. 화면 배경이 흰색이 아닌 경우 맞춰서 전달합니다.
+ * @param trailingContent 헤더 우측에 배치할 커스텀 콘텐츠입니다. 전달 시 [onTrailingIconClick]보다 우선하며, 둘은 함께 노출되지 않습니다.
  */
 @Composable
 fun PotiHeaderPage(
@@ -47,6 +48,7 @@ fun PotiHeaderPage(
     onTrailingIconClick: (() -> Unit)? = null,
     @DrawableRes trailingIconRes: Int = R.drawable.ic_switch,
     containerColor: Color = PotiTheme.colors.white,
+    trailingContent: (@Composable RowScope.() -> Unit)? = null,
 ) {
     PotiHeaderPageBase(
         onNavigationClick = onNavigationClick,
@@ -82,7 +84,9 @@ fun PotiHeaderPage(
             }
         }
 
-        onTrailingIconClick?.let {
+        if (trailingContent != null) {
+            trailingContent()
+        } else if (onTrailingIconClick != null) {
             PotiIconButton(
                 iconRes = trailingIconRes,
                 onClick = onTrailingIconClick,

--- a/app/src/main/java/com/poti/android/data/remote/datasource/PartyRemoteDataSource.kt
+++ b/app/src/main/java/com/poti/android/data/remote/datasource/PartyRemoteDataSource.kt
@@ -53,6 +53,9 @@ class PartyRemoteDataSource @Inject constructor(
     suspend fun getRecruitPostParticipant(postId: Long): BaseResponse<GroupBuyPostParticipantDetailDto> =
         partyService.getRecruitPostParticipant(postId)
 
+    suspend fun deleteParty(postId: Long): BaseResponse<Unit> =
+        partyService.deleteParty(postId)
+
     suspend fun getProductPartyList(
         page: Int?,
         size: Int?,

--- a/app/src/main/java/com/poti/android/data/remote/service/PartyService.kt
+++ b/app/src/main/java/com/poti/android/data/remote/service/PartyService.kt
@@ -15,6 +15,7 @@ import com.poti.android.data.remote.dto.response.party.ProductPartyListResponseD
 import com.poti.android.data.remote.dto.response.party.ProductSearchResponseDto
 import com.poti.android.data.remote.dto.response.party.ShippingOptionResponseDto
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -69,6 +70,11 @@ interface PartyService {
     suspend fun getRecruitPostParticipant(
         @Path("postId") postId: Long,
     ): BaseResponse<GroupBuyPostParticipantDetailDto>
+
+    @DELETE("/api/v1/posts/{postId}")
+    suspend fun deleteParty(
+        @Path("postId") postId: Long,
+    ): BaseResponse<Unit>
 
     @GET("/api/v1/posts/pots")
     suspend fun getProductPartyList(

--- a/app/src/main/java/com/poti/android/data/repository/PartyRepositoryImpl.kt
+++ b/app/src/main/java/com/poti/android/data/repository/PartyRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.poti.android.data.repository
 
 import com.poti.android.core.network.model.handleApiResponse
+import com.poti.android.core.network.model.handleNullableApiResponse
 import com.poti.android.core.network.util.HttpResponseHandler
 import com.poti.android.data.mapper.artist.toDomain
 import com.poti.android.data.mapper.artist.toDto
@@ -184,6 +185,19 @@ class PartyRepositoryImpl @Inject constructor(
                         .handleApiResponse()
                         .getOrThrow()
                         .toDomain()
+                }
+            },
+        )
+
+    override suspend fun deleteRecruitPost(postId: Long): Result<Unit> =
+        executeWithUiMock(
+            mock = { Unit },
+            real = {
+                httpResponseHandler.safeApiCall {
+                    partyRemoteDataSource.deleteParty(postId)
+                        .handleNullableApiResponse()
+                        .getOrThrow()
+                    Unit
                 }
             },
         )

--- a/app/src/main/java/com/poti/android/domain/repository/PartyRepository.kt
+++ b/app/src/main/java/com/poti/android/domain/repository/PartyRepository.kt
@@ -47,6 +47,8 @@ interface PartyRepository {
 
     suspend fun getRecruitPostParticipant(postId: Long): Result<ParticipantManageDetail>
 
+    suspend fun deleteRecruitPost(postId: Long): Result<Unit>
+
     suspend fun getProductPartyList(
         page: Int?,
         size: Int?,

--- a/app/src/main/java/com/poti/android/domain/usecase/history/DeleteRecruitPostUseCase.kt
+++ b/app/src/main/java/com/poti/android/domain/usecase/history/DeleteRecruitPostUseCase.kt
@@ -1,0 +1,11 @@
+package com.poti.android.domain.usecase.history
+
+import com.poti.android.domain.repository.PartyRepository
+import javax.inject.Inject
+
+class DeleteRecruitPostUseCase @Inject constructor(
+    private val partyRepository: PartyRepository,
+) {
+    suspend operator fun invoke(postId: Long): Result<Unit> =
+        partyRepository.deleteRecruitPost(postId)
+}

--- a/app/src/main/java/com/poti/android/presentation/history/recruiter/RecruiterDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/recruiter/RecruiterDetailScreen.kt
@@ -21,12 +21,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poti.android.R
 import com.poti.android.core.common.extension.onSuccess
 import com.poti.android.core.common.util.HandleSideEffects
+import com.poti.android.core.designsystem.component.button.PotiTextButton
 import com.poti.android.core.designsystem.component.display.PotiDivider
 import com.poti.android.core.designsystem.component.display.PotiDividerStyle
 import com.poti.android.core.designsystem.component.display.PotiEmptyStateInline
 import com.poti.android.core.designsystem.component.navigation.PotiHeaderPage
 import com.poti.android.core.designsystem.theme.PotiTheme
 import com.poti.android.data.mock.UiMockData
+import com.poti.android.domain.type.PartyStatusType
 import com.poti.android.presentation.history.component.HistoryDetailContentHeader
 import com.poti.android.presentation.history.component.PartyInfoSection
 import com.poti.android.presentation.history.component.ProgressStatusSection
@@ -65,6 +67,7 @@ fun RecruiterDetailRoute(
                 onBackClick = { viewModel.processIntent(RecruiterDetailUiIntent.BackButtonClicked) },
                 onDetailClick = { viewModel.processIntent(RecruiterDetailUiIntent.PartyCardClicked) },
                 onParticipantManageDetailClick = { viewModel.processIntent(RecruiterDetailUiIntent.ParticipantSectionClicked) },
+                onDeleteClick = {},
             )
         }
     }
@@ -76,14 +79,28 @@ private fun RecruiterDetailScreen(
     onBackClick: () -> Unit,
     onDetailClick: () -> Unit,
     onParticipantManageDetailClick: () -> Unit,
+    onDeleteClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isDeletable = recruiterDetail.partySummary.partyStatus == PartyStatusType.RECRUITING &&
+        recruiterDetail.participantCount == 0
+
     Column(
         modifier = modifier.fillMaxSize(),
     ) {
         PotiHeaderPage(
             onNavigationClick = onBackClick,
             title = stringResource(id = R.string.history_ongoing_title),
+            trailingContent = if (isDeletable) {
+                {
+                    PotiTextButton(
+                        text = stringResource(id = R.string.history_recruiter_delete),
+                        onClick = onDeleteClick,
+                    )
+                }
+            } else {
+                null
+            },
         )
 
         LazyColumn(
@@ -158,6 +175,7 @@ private fun RecruiterDetailScreenRecruitPreview() {
             onBackClick = {},
             onDetailClick = {},
             onParticipantManageDetailClick = {},
+            onDeleteClick = {},
         )
     }
 }
@@ -171,6 +189,7 @@ private fun RecruiterDetailScreenDepositPreview() {
             onBackClick = {},
             onDetailClick = {},
             onParticipantManageDetailClick = {},
+            onDeleteClick = {},
         )
     }
 }
@@ -184,6 +203,7 @@ private fun RecruiterDetailScreenDeliveryDonePreview() {
             onBackClick = {},
             onDetailClick = {},
             onParticipantManageDetailClick = {},
+            onDeleteClick = {},
         )
     }
 }

--- a/app/src/main/java/com/poti/android/presentation/history/recruiter/RecruiterDetailScreen.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/recruiter/RecruiterDetailScreen.kt
@@ -67,7 +67,7 @@ fun RecruiterDetailRoute(
                 onBackClick = { viewModel.processIntent(RecruiterDetailUiIntent.BackButtonClicked) },
                 onDetailClick = { viewModel.processIntent(RecruiterDetailUiIntent.PartyCardClicked) },
                 onParticipantManageDetailClick = { viewModel.processIntent(RecruiterDetailUiIntent.ParticipantSectionClicked) },
-                onDeleteClick = {},
+                onDeleteClick = { viewModel.processIntent(RecruiterDetailUiIntent.DeleteButtonClicked) },
             )
         }
     }

--- a/app/src/main/java/com/poti/android/presentation/history/recruiter/RecruiterViewModel.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/recruiter/RecruiterViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.poti.android.core.base.BaseViewModel
 import com.poti.android.core.common.state.ApiState
+import com.poti.android.domain.usecase.history.DeleteRecruitPostUseCase
 import com.poti.android.domain.usecase.history.GetRecruitDetailUseCase
 import com.poti.android.presentation.history.navigation.HistoryRoute
 import com.poti.android.presentation.history.recruiter.model.RecruiterDetailUiEffect
@@ -12,12 +13,14 @@ import com.poti.android.presentation.history.recruiter.model.RecruiterDetailUiIn
 import com.poti.android.presentation.history.recruiter.model.RecruiterDetailUiState
 import com.poti.android.presentation.history.recruiter.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class RecruiterViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getRecruitDetailUseCase: GetRecruitDetailUseCase,
+    private val deleteRecruitPostUseCase: DeleteRecruitPostUseCase,
 ) : BaseViewModel<RecruiterDetailUiState, RecruiterDetailUiIntent, RecruiterDetailUiEffect>(
         initialState = RecruiterDetailUiState(),
     ) {
@@ -32,7 +35,24 @@ class RecruiterViewModel @Inject constructor(
             is RecruiterDetailUiIntent.BackButtonClicked -> sendEffect(RecruiterDetailUiEffect.NavigateBack)
             is RecruiterDetailUiIntent.PartyCardClicked -> sendEffect(NavigateToPartyDetail(recruitId))
             is RecruiterDetailUiIntent.ParticipantSectionClicked -> sendEffect(NavigateToParticipantList(recruitId))
+            RecruiterDetailUiIntent.DeleteButtonClicked -> deleteRecruitPost()
             RecruiterDetailUiIntent.OnResume -> getRecruiterDetail()
+        }
+    }
+
+    private fun deleteRecruitPost() {
+        if (uiState.value.isDeleting) return
+
+        launchScope {
+            updateState { copy(isDeleting = true) }
+            deleteRecruitPostUseCase(recruitId)
+                .onSuccess {
+                    sendEffect(NavigateBack)
+                }
+                .onFailure { error ->
+                    Timber.d("deleteRecruitPost 실패: $error")
+                    updateState { copy(isDeleting = false) }
+                }
         }
     }
 

--- a/app/src/main/java/com/poti/android/presentation/history/recruiter/model/Contracts.kt
+++ b/app/src/main/java/com/poti/android/presentation/history/recruiter/model/Contracts.kt
@@ -7,6 +7,7 @@ import com.poti.android.core.common.state.ApiState
 
 data class RecruiterDetailUiState(
     val recruiterDetailState: ApiState<RecruiterDetailUiModel> = ApiState.Loading,
+    val isDeleting: Boolean = false,
 ) : UiState
 
 sealed interface RecruiterDetailUiIntent : UiIntent {
@@ -15,6 +16,8 @@ sealed interface RecruiterDetailUiIntent : UiIntent {
     data object PartyCardClicked : RecruiterDetailUiIntent
 
     data object ParticipantSectionClicked : RecruiterDetailUiIntent
+
+    data object DeleteButtonClicked : RecruiterDetailUiIntent
 
     data object OnResume : RecruiterDetailUiIntent
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,7 @@
     <string name="history_participant_detail_total_deposit_label">총 입금 금액</string>
     <string name="history_participant_detail_won_unit_format">%s원</string>
     <string name="history_ongoing_title">진행 중인 분철</string>
+    <string name="history_recruiter_delete">삭제</string>
     <string name="history_recruit_number">모집번호 %s</string>
     <string name="history_progress_status_title">진행 상황</string>
     <string name="history_state_guide_waiting">참여자들을 기다리고 있어요</string>


### PR DESCRIPTION
## Related issue 🛠️
- closed #220

## Work Description ✏️
<!--작업 내용을 작성해주세요-->
- 모집 중이고 참여자가 0명일 때만 모집 상세 우측 상단에 `삭제` 버튼을 노출합니다.
- 삭제 성공 시 직전 화면(모집 내역 목록)으로 복귀합니다.

## Screenshot 📸

| 삭제 플로우 |
| --- |
| <video src="https://github.com/user-attachments/assets/c3a8032b-1b63-4400-901c-8b27c90eb3f4" /> |

## Uncompleted Tasks 😅
- [ ]

## To Reviewers 📢
- 헤더에 삭제 버튼 추가를 위해서,`PotiHeaderPage`에 `trailingContent` 슬롯을 추가했고, 기존 `onTrailingIconClick`과는 배타적으로 노출됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모집자가 참여자가 없는 모집 중 게시글을 삭제할 수 있습니다.
  * 삭제 성공 시 이전 화면으로 자동 이동합니다.
  * 헤더에 상황에 맞는 사용자 지정 콘텐츠와 삭제 버튼을 표시할 수 있습니다.

* **개선**
  * 게시글 삭제 중 중복 요청을 방지하고 처리 상태를 관리합니다.
  * 삭제 버튼 문구가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->